### PR TITLE
Replace architecture diagrams with Spring Apps versions

### DIFF
--- a/images/architecture-private.svg
+++ b/images/architecture-private.svg
@@ -1,1426 +1,5582 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 1124.73 498">
-  <defs>
-    <linearGradient id="linear-gradient" x1="134.04" y1="1440.27" x2="138.78" y2="1435.53" gradientTransform="matrix(1, 0, 0, -1, 3.69, 1582.17)" gradientUnits="userSpaceOnUse">
-      <stop offset="0" stop-color="#86d633"/>
-      <stop offset="1" stop-color="#5e9624"/>
-    </linearGradient>
-    <linearGradient id="linear-gradient-2" x1="144.34" y1="1426.17" x2="149.07" y2="1421.42" gradientTransform="matrix(1, 0, 0, -1, 0, 1583.71)" xlink:href="#linear-gradient"/>
-    <linearGradient id="linear-gradient-3" x1="125.99" y1="1426.18" x2="130.72" y2="1421.45" gradientTransform="matrix(1, 0, 0, -1, 0, 1583.71)" xlink:href="#linear-gradient"/>
-    <linearGradient id="linear-gradient-4" x1="199.55" y1="1160.47" x2="199.55" y2="1140.3" gradientTransform="matrix(1, 0, 0, -1, 0, 1583.71)" gradientUnits="userSpaceOnUse">
-      <stop offset="0" stop-color="#5ea0ef"/>
-      <stop offset="0.18" stop-color="#559cec"/>
-      <stop offset="0.47" stop-color="#3c91e5"/>
-      <stop offset="0.84" stop-color="#1380da"/>
-      <stop offset="1" stop-color="#0078d4"/>
-    </linearGradient>
-    <linearGradient id="linear-gradient-5" x1="199.98" y1="1117.74" x2="202.35" y2="1115.37" gradientTransform="matrix(1, 0, 0, -1, 3.69, 1583.14)" gradientUnits="userSpaceOnUse">
-      <stop offset="0" stop-color="#86d633"/>
-      <stop offset="0.24" stop-color="#83d232"/>
-      <stop offset="0.5" stop-color="#7cc52f"/>
-      <stop offset="0.76" stop-color="#6fb02a"/>
-      <stop offset="1" stop-color="#5e9624"/>
-    </linearGradient>
-    <linearGradient id="linear-gradient-6" x1="194.64" y1="1117.74" x2="196.99" y2="1115.37" xlink:href="#linear-gradient-5"/>
-    <linearGradient id="linear-gradient-7" x1="189.3" y1="1117.74" x2="191.65" y2="1115.38" xlink:href="#linear-gradient-5"/>
-    <linearGradient id="linear-gradient-8" x1="517.04" y1="1175.5" x2="519.41" y2="1173.13" xlink:href="#linear-gradient-5"/>
-    <linearGradient id="linear-gradient-9" x1="511.7" y1="1175.5" x2="514.05" y2="1173.13" xlink:href="#linear-gradient-5"/>
-    <linearGradient id="linear-gradient-10" x1="506.36" y1="1175.5" x2="508.71" y2="1173.13" xlink:href="#linear-gradient-5"/>
-    <linearGradient id="linear-gradient-11" x1="580.34" y1="1117.21" x2="582.71" y2="1114.84" xlink:href="#linear-gradient-5"/>
-    <linearGradient id="linear-gradient-12" x1="575" y1="1117.21" x2="577.35" y2="1114.84" xlink:href="#linear-gradient-5"/>
-    <linearGradient id="linear-gradient-13" x1="569.66" y1="1117.21" x2="572.01" y2="1114.84" xlink:href="#linear-gradient-5"/>
-    <linearGradient id="Teal_Gradient" data-name="Teal Gradient" x1="253.7" y1="1223.21" x2="253.7" y2="1251.4" gradientTransform="matrix(0.71, 0.71, 0.71, -0.71, -801.61, 1041.51)" gradientUnits="userSpaceOnUse">
-      <stop offset="0" stop-color="#258378"/>
-      <stop offset="0.42" stop-color="#49a498"/>
-      <stop offset="0.78" stop-color="#60bbad"/>
-      <stop offset="1" stop-color="#68c2b5"/>
-    </linearGradient>
-    <radialGradient id="radial-gradient" cx="-5919.65" cy="-5634.92" r="30.05" gradientTransform="translate(3353.24 3175.98) scale(0.5)" gradientUnits="userSpaceOnUse">
-      <stop offset="0.18" stop-color="#699cd3"/>
-      <stop offset="1" stop-color="#2e76bc"/>
-    </radialGradient>
-    <radialGradient id="radial-gradient-2" cx="658.77" cy="1519.64" r="11.32" gradientTransform="matrix(1, 0, 0, -1, 0, 1583.71)" gradientUnits="userSpaceOnUse">
-      <stop offset="0" stop-color="#9f7db8"/>
-      <stop offset="0.21" stop-color="#9b7bb7"/>
-      <stop offset="0.43" stop-color="#9074b4"/>
-      <stop offset="0.65" stop-color="#8068ae"/>
-      <stop offset="0.88" stop-color="#6c5faa"/>
-      <stop offset="1" stop-color="#6059a7"/>
-    </radialGradient>
-    <linearGradient id="linear-gradient-14" x1="658.79" y1="1525.72" x2="658.9" y2="1512.34" gradientTransform="matrix(1, 0, 0, -1, 0, 1583.71)" gradientUnits="userSpaceOnUse">
-      <stop offset="0" stop-color="#f2f2f3"/>
-      <stop offset="0.23" stop-color="#f2f1f2" stop-opacity="0.99"/>
-      <stop offset="0.37" stop-color="#ededf0" stop-opacity="0.95"/>
-      <stop offset="0.48" stop-color="#e7e5ef" stop-opacity="0.89"/>
-      <stop offset="0.58" stop-color="#dedbee" stop-opacity="0.81"/>
-      <stop offset="0.67" stop-color="#d4cee7" stop-opacity="0.7"/>
-      <stop offset="0.76" stop-color="#c4bdde" stop-opacity="0.57"/>
-      <stop offset="0.84" stop-color="#b5abd4" stop-opacity="0.41"/>
-      <stop offset="0.92" stop-color="#a094c7" stop-opacity="0.22"/>
-      <stop offset="0.99" stop-color="#877cba" stop-opacity="0.02"/>
-      <stop offset="1" stop-color="#847ab9" stop-opacity="0"/>
-    </linearGradient>
-    <radialGradient id="radial-gradient-3" cx="805.04" cy="1516.73" r="15" gradientTransform="matrix(1, 0, 0, -1, 0, 1583.71)" gradientUnits="userSpaceOnUse">
-      <stop offset="0.18" stop-color="#699cd3"/>
-      <stop offset="0.56" stop-color="#669cd3"/>
-      <stop offset="0.69" stop-color="#6198d1"/>
-      <stop offset="0.78" stop-color="#5793ce"/>
-      <stop offset="0.86" stop-color="#4a8cca"/>
-      <stop offset="0.93" stop-color="#3b83c5"/>
-      <stop offset="0.99" stop-color="#3078be"/>
-      <stop offset="1" stop-color="#2e76bc"/>
-    </radialGradient>
-    <radialGradient id="radial-gradient-4" cx="892.79" cy="1366.12" r="17.44" gradientTransform="matrix(0.94, 0, 0, -0.94, -36.11, 1349.2)" gradientUnits="userSpaceOnUse">
-      <stop offset="0.27" stop-color="#fed70a"/>
-      <stop offset="0.49" stop-color="#ffcc12"/>
-      <stop offset="0.88" stop-color="#fbac1d"/>
-      <stop offset="1" stop-color="#f9a120"/>
-    </radialGradient>
-    <radialGradient id="radial-gradient-5" cx="713.08" cy="1515.41" r="14.91" gradientTransform="matrix(1.01, 0, 0, -1.01, 4.46, 1597.1)" xlink:href="#radial-gradient-3"/>
-    <radialGradient id="radial-gradient-6" cx="788.01" cy="1343.24" r="4.78" gradientTransform="matrix(0.95, 0, 0, -0.95, -23.94, 1339.31)" gradientUnits="userSpaceOnUse">
-      <stop offset="0.19" stop-color="#8c8e90"/>
-      <stop offset="0.35" stop-color="#848688"/>
-      <stop offset="0.6" stop-color="#6e7071"/>
-      <stop offset="0.91" stop-color="#4a4b4d"/>
-      <stop offset="1" stop-color="#3e403f"/>
-    </radialGradient>
-    <linearGradient id="linear-gradient-15" x1="869.44" y1="1503" x2="869.44" y2="1530.48" gradientTransform="matrix(1, 0, 0, -1, 0, 1583.71)" gradientUnits="userSpaceOnUse">
-      <stop offset="0" stop-color="#2e76bc"/>
-      <stop offset="0.06" stop-color="#3179be"/>
-      <stop offset="0.34" stop-color="#4288c8"/>
-      <stop offset="0.59" stop-color="#5693ce"/>
-      <stop offset="0.82" stop-color="#639bd2"/>
-      <stop offset="1" stop-color="#699cd3"/>
-    </linearGradient>
-    <radialGradient id="radial-gradient-7" cx="-5672.1" cy="-6205.34" r="34.06" xlink:href="#radial-gradient"/>
-    <linearGradient id="Green_Gradient_" data-name="Green Gradient " x1="623.61" y1="1361.9" x2="623.61" y2="1396.68" gradientTransform="matrix(1, 0, 0, -1, 0, 1583.71)" gradientUnits="userSpaceOnUse">
-      <stop offset="0" stop-color="#5e9741"/>
-      <stop offset="0.02" stop-color="#5f9841"/>
-      <stop offset="1" stop-color="#76bc43"/>
-    </linearGradient>
-    <linearGradient id="linear-gradient-16" x1="841.36" y1="1233.49" x2="841.36" y2="1219.45" gradientTransform="matrix(1, 0, 0, -1, 0, 1583.71)" gradientUnits="userSpaceOnUse">
-      <stop offset="0.22" stop-color="#50c8e9"/>
-      <stop offset="0.47" stop-color="#4ac7e9"/>
-      <stop offset="0.63" stop-color="#3bc4e7"/>
-      <stop offset="0.77" stop-color="#2abade"/>
-      <stop offset="0.89" stop-color="#21a5cb"/>
-      <stop offset="1" stop-color="#1b8ab3"/>
-    </linearGradient>
-    <linearGradient id="linear-gradient-17" x1="840.96" y1="1241" x2="841.99" y2="1228.26" xlink:href="#linear-gradient-16"/>
-    <linearGradient id="linear-gradient-18" x1="839.47" y1="1267.55" x2="839.47" y2="1249.21" xlink:href="#linear-gradient-4"/>
-    <linearGradient id="linear-gradient-19" x1="841.36" y1="1388.49" x2="841.36" y2="1374.45" xlink:href="#linear-gradient-16"/>
-    <linearGradient id="linear-gradient-20" x1="840.96" y1="1396" x2="841.99" y2="1383.26" xlink:href="#linear-gradient-16"/>
-    <linearGradient id="linear-gradient-21" x1="839.47" y1="1422.55" x2="839.47" y2="1404.21" xlink:href="#linear-gradient-4"/>
-    <linearGradient id="linear-gradient-22" x1="912.99" y1="1216.46" x2="935.61" y2="1216.46" gradientTransform="matrix(1, 0, 0, -1, 0, 1583.71)" gradientUnits="userSpaceOnUse">
-      <stop offset="0" stop-color="#005ca1"/>
-      <stop offset="0.07" stop-color="#0161aa"/>
-      <stop offset="0.36" stop-color="#2571b8"/>
-      <stop offset="0.52" stop-color="#2e76bc"/>
-      <stop offset="0.64" stop-color="#2973ba"/>
-      <stop offset="0.82" stop-color="#166bb5"/>
-      <stop offset="1" stop-color="#005ca1"/>
-    </linearGradient>
-    <linearGradient id="linear-gradient-23" x1="795.47" y1="1308.78" x2="795.47" y2="1268.78" gradientTransform="matrix(1, 0, 0, -1, 0, 1583.71)" gradientUnits="userSpaceOnUse">
-      <stop offset="0" stop-color="#008bf1"/>
-      <stop offset="0.22" stop-color="#0086ec"/>
-      <stop offset="0.49" stop-color="#0078dd"/>
-      <stop offset="0.79" stop-color="#0061c4"/>
-      <stop offset="1" stop-color="#004dae"/>
-    </linearGradient>
-    <linearGradient id="linear-gradient-24" x1="798.65" y1="1291" x2="811.47" y2="1291" gradientTransform="matrix(1, 0, 0, -1, 0, 1583.71)" gradientUnits="userSpaceOnUse">
-      <stop offset="0" stop-opacity="0.64"/>
-      <stop offset="0.57" stop-opacity="0.22"/>
-      <stop offset="1" stop-color="#fff" stop-opacity="0"/>
-    </linearGradient>
-    <linearGradient id="linear-gradient-25" x1="799.95" y1="1291.66" x2="815.47" y2="1291.66" gradientTransform="matrix(1, 0, 0, -1, 0, 1583.71)" gradientUnits="userSpaceOnUse">
-      <stop offset="0" stop-color="#00315c"/>
-      <stop offset="0.79" stop-color="#0080e5"/>
-    </linearGradient>
-    <linearGradient id="linear-gradient-26" x1="790.99" y1="1291.66" x2="775.47" y2="1291.66" xlink:href="#linear-gradient-25"/>
-    <linearGradient id="linear-gradient-27" x1="799.95" y1="1285.89" x2="815.47" y2="1285.89" gradientTransform="matrix(1, 0, 0, -1, 0, 1583.71)" gradientUnits="userSpaceOnUse">
-      <stop offset="0" stop-color="#00315c"/>
-      <stop offset="0.58" stop-color="#0e71c7"/>
-      <stop offset="1" stop-color="#0a75d5"/>
-    </linearGradient>
-    <linearGradient id="linear-gradient-28" x1="790.99" y1="1285.89" x2="775.47" y2="1285.89" xlink:href="#linear-gradient-27"/>
-    <linearGradient id="linear-gradient-29" x1="792.58" y1="1293.22" x2="792.58" y2="1306.8" gradientTransform="matrix(1, 0, 0, -1, 0, 1583.71)" gradientUnits="userSpaceOnUse">
-      <stop offset="0" stop-color="#00315c"/>
-      <stop offset="0.79" stop-color="#008af0"/>
-    </linearGradient>
-    <linearGradient id="linear-gradient-30" x1="798.36" y1="1293.22" x2="798.36" y2="1306.8" xlink:href="#linear-gradient-29"/>
-    <linearGradient id="linear-gradient-31" x1="798.36" y1="1283.88" x2="798.36" y2="1268.58" gradientTransform="matrix(1, 0, 0, -1, 0, 1583.71)" gradientUnits="userSpaceOnUse">
-      <stop offset="0" stop-color="#00294f"/>
-      <stop offset="0.7" stop-color="#005ba6"/>
-      <stop offset="0.83" stop-color="#0457ac"/>
-      <stop offset="1" stop-color="#0050b2"/>
-    </linearGradient>
-    <linearGradient id="linear-gradient-32" x1="792.58" y1="1283.88" x2="792.58" y2="1268.58" xlink:href="#linear-gradient-31"/>
-    <linearGradient id="linear-gradient-33" x1="394.04" y1="1735.83" x2="394.04" y2="1765.68" gradientTransform="matrix(1, 0, 0, -1, 564, 1817.71)" gradientUnits="userSpaceOnUse">
-      <stop offset="0" stop-color="#0078d4"/>
-      <stop offset="0.16" stop-color="#1380da"/>
-      <stop offset="0.53" stop-color="#3c91e5"/>
-      <stop offset="0.82" stop-color="#559cec"/>
-      <stop offset="1" stop-color="#5ea0ef"/>
-    </linearGradient>
-    <linearGradient id="linear-gradient-34" x1="52.83" y1="1346.61" x2="52.83" y2="1374.81" gradientTransform="matrix(0.71, 0.71, 0.71, -0.71, -947.7, 1147.4)" gradientUnits="userSpaceOnUse">
-      <stop offset="0" stop-color="#258277"/>
-      <stop offset="0.42" stop-color="#49a498"/>
-      <stop offset="0.78" stop-color="#60baad"/>
-      <stop offset="1" stop-color="#68c2b5"/>
-    </linearGradient>
-    <linearGradient id="linear-gradient-35" x1="13.29" y1="1135.98" x2="13.29" y2="1110.98" xlink:href="#linear-gradient-4"/>
-    <linearGradient id="linear-gradient-36" x1="77.1" y1="1252.92" x2="69.19" y2="1267.91" gradientTransform="matrix(1, 0, 0, -1, 0, 1583.71)" gradientUnits="userSpaceOnUse">
-      <stop offset="0" stop-color="#3085c7"/>
-      <stop offset="0.9" stop-color="#5fabdf"/>
-    </linearGradient>
-    <linearGradient id="linear-gradient-37" x1="73.69" y1="1257.27" x2="79.16" y2="1247.84" gradientTransform="matrix(1, 0, 0, -1, 0, 1583.71)" gradientUnits="userSpaceOnUse">
-      <stop offset="0.1" stop-color="#5fabdf"/>
-      <stop offset="0.29" stop-color="#5aa8dd"/>
-      <stop offset="0.51" stop-color="#4da0d8"/>
-      <stop offset="0.74" stop-color="#3b90ce"/>
-      <stop offset="0.88" stop-color="#3085c7"/>
-    </linearGradient>
-    <linearGradient id="linear-gradient-38" x1="36.12" y1="1304.91" x2="36.12" y2="1281.67" gradientTransform="matrix(1, 0, 0, -1, 0, 1583.71)" gradientUnits="userSpaceOnUse">
-      <stop offset="0" stop-color="#b3b2b4"/>
-      <stop offset="0.38" stop-color="#b0aeaf"/>
-      <stop offset="0.76" stop-color="#a2a1a1"/>
-      <stop offset="1" stop-color="#979797"/>
-    </linearGradient>
-    <linearGradient id="linear-gradient-39" x1="38.26" y1="1283.05" x2="48.99" y2="1283.05" xlink:href="#linear-gradient-22"/>
-    <linearGradient id="linear-gradient-40" x1="43.92" y1="1206.96" x2="43.92" y2="1233.41" gradientTransform="matrix(1, 0, 0, -1, 0, 1583.71)" gradientUnits="userSpaceOnUse">
-      <stop offset="0.05" stop-color="#949494"/>
-      <stop offset="0.36" stop-color="#979797"/>
-      <stop offset="0.54" stop-color="#9f9e9e"/>
-      <stop offset="0.69" stop-color="#aeadae"/>
-      <stop offset="0.73" stop-color="#b3b4b4"/>
-    </linearGradient>
-    <linearGradient id="linear-gradient-41" x1="51.67" y1="1224.82" x2="51.67" y2="1203.52" gradientTransform="matrix(1, 0, 0, -1, 0, 1583.71)" xlink:href="#radial-gradient"/>
-    <radialGradient id="radial-gradient-8" cx="826.11" cy="1236.82" r="10.55" gradientTransform="matrix(1.04, 0, 0, -1.03, 122.67, 1638.99)" xlink:href="#radial-gradient"/>
-    <clipPath id="clip-path">
-      <path d="M993.3,362.6a10.89,10.89,0,1,1-13.17-8,10.88,10.88,0,0,1,13.17,8Z" fill="none"/>
-    </clipPath>
-    <linearGradient id="Teal_Gradient-2" x1="393.6" y1="1350.17" x2="393.6" y2="1378.36" gradientTransform="matrix(0.71, 0.71, 0.71, -0.71, -850.41, 905.39)" xlink:href="#Teal_Gradient"/>
-    <linearGradient id="linear-gradient-42" x1="253.7" y1="1356.2" x2="253.7" y2="1379.69" gradientTransform="matrix(1, 0, 0, -1, 0, 1583.71)" gradientUnits="userSpaceOnUse">
-      <stop offset="0" stop-color="#2e76bc"/>
-      <stop offset="0.82" stop-color="#699cd3"/>
-    </linearGradient>
-    <linearGradient id="Green_Gradient_2" x1="623.61" y1="1198.96" x2="623.61" y2="1233.74" xlink:href="#Green_Gradient_"/>
-  </defs>
-  <g id="Shapes">
-    <rect x="0.25" y="0.25" width="1124.23" height="497.5" fill="#fff" stroke="#fff" stroke-width="0.5"/>
-    <g>
-      <g>
-        <rect x="555.54" y="140.33" width="563.2" height="326.26" rx="4" fill="#fff"/>
-        <rect x="555.54" y="140.33" width="563.2" height="326.26" rx="4" fill="#505150" opacity="0.07"/>
-        <rect x="555.54" y="140.33" width="563.2" height="326.26" rx="4" fill="none" stroke="#505150" opacity="0.15"/>
-      </g>
-      <path d="M1114.75,467.09h-.12v-1h.11a3.81,3.81,0,0,0,.6-.06l.17,1A6.31,6.31,0,0,1,1114.75,467.09Zm-2.12,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.79v-1h.79Zm-2.79,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.79v-1h.79Zm-2.79,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.79,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.79,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.79,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.79,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.79,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.79v-1h.79Zm-2.79,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.79,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.79v-1h.79Zm-2.79,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.79v-1h.79Zm-2.79,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.79,0H594v-1h.8Zm-30.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.93-.2a4.93,4.93,0,0,1-.82-.35l.48-.88a3.61,3.61,0,0,0,.64.27Zm559.32-.78-.62-.79a3.78,3.78,0,0,0,.5-.48l.76.64A4.76,4.76,0,0,1,1117.54,466.11ZM555.77,465a3.71,3.71,0,0,1-.41-.79l.93-.37a3.32,3.32,0,0,0,.32.62Zm563.39-1.54-1-.2a3.23,3.23,0,0,0,.07-.69l1,0v0A5.45,5.45,0,0,1,1119.16,463.48ZM556,462.08h-1v-.8h1Zm563.2-1.54h-1v-.8h1ZM556,459.28h-1v-.8h1Zm563.2-1.54h-1v-.8h1ZM556,456.48h-1v-.8h1Zm563.2-1.54h-1v-.8h1ZM556,453.68h-1v-.8h1Zm563.2-1.54h-1v-.8h1ZM556,450.88h-1v-.8h1Zm563.2-1.54h-1v-.8h1ZM556,448.08h-1v-.8h1Zm563.2-1.54h-1v-.8h1ZM556,445.28h-1v-.8h1Zm563.2-1.54h-1v-.8h1ZM556,442.48h-1v-.8h1Zm563.2-1.54h-1v-.8h1ZM556,439.68h-1v-.8h1Zm563.2-1.54h-1v-.8h1ZM556,436.88h-1v-.8h1Zm563.2-1.53h-1v-.8h1ZM556,434.09h-1v-.8h1Zm563.2-1.54h-1v-.8h1ZM556,431.29h-1v-.8h1Zm563.2-1.54h-1V429h1ZM556,428.49h-1v-.8h1Zm563.2-1.54h-1v-.8h1ZM556,425.69h-1v-.8h1Zm563.2-1.54h-1v-.8h1ZM556,422.89h-1v-.8h1Zm563.2-1.54h-1v-.8h1ZM556,420.09h-1v-.8h1Zm563.2-1.54h-1v-.8h1ZM556,417.29h-1v-.8h1Zm563.2-1.54h-1V415h1ZM556,414.49h-1v-.8h1Zm563.2-1.54h-1v-.8h1ZM556,411.69h-1v-.8h1Zm563.2-1.54h-1v-.8h1ZM556,408.89h-1v-.8h1Zm563.2-1.54h-1v-.8h1ZM556,406.09h-1v-.8h1Zm563.2-1.54h-1v-.8h1ZM556,403.29h-1v-.8h1Zm563.2-1.54h-1V401h1ZM556,400.49h-1v-.8h1Zm563.2-1.54h-1v-.8h1ZM556,397.69h-1v-.8h1Zm563.2-1.54h-1v-.8h1ZM556,394.89h-1v-.8h1Zm563.2-1.53h-1v-.81h1ZM556,392.09h-1v-.8h1Zm563.2-1.53h-1v-.8h1ZM556,389.3h-1v-.8h1Zm563.2-1.54h-1V387h1ZM556,386.5h-1v-.8h1Zm563.2-1.54h-1v-.8h1ZM556,383.7h-1v-.8h1Zm563.2-1.54h-1v-.8h1ZM556,380.9h-1v-.8h1Zm563.2-1.54h-1v-.8h1ZM556,378.1h-1v-.8h1Zm563.2-1.54h-1v-.8h1ZM556,375.3h-1v-.8h1Zm563.2-1.54h-1V373h1ZM556,372.5h-1v-.8h1Zm563.2-1.54h-1v-.8h1ZM556,369.7h-1v-.8h1Zm563.2-1.54h-1v-.8h1ZM556,366.9h-1v-.8h1Zm563.2-1.54h-1v-.8h1ZM556,364.1h-1v-.8h1Zm563.2-1.54h-1v-.8h1ZM556,361.3h-1v-.8h1Zm563.2-1.54h-1V359h1ZM556,358.5h-1v-.8h1Zm563.2-1.54h-1v-.8h1ZM556,355.7h-1v-.8h1Zm563.2-1.54h-1v-.8h1ZM556,352.9h-1v-.8h1Zm563.2-1.54h-1v-.8h1ZM556,350.1h-1v-.8h1Zm563.2-1.53h-1v-.8h1ZM556,347.3h-1v-.79h1Zm563.2-1.53h-1V345h1ZM556,344.51h-1v-.8h1Zm563.2-1.54h-1v-.8h1ZM556,341.71h-1v-.8h1Zm563.2-1.54h-1v-.8h1ZM556,338.91h-1v-.8h1Zm563.2-1.54h-1v-.8h1ZM556,336.11h-1v-.8h1Zm563.2-1.54h-1v-.8h1ZM556,333.31h-1v-.8h1Zm563.2-1.54h-1V331h1ZM556,330.51h-1v-.8h1Zm563.2-1.54h-1v-.8h1ZM556,327.71h-1v-.8h1Zm563.2-1.54h-1v-.8h1ZM556,324.91h-1v-.8h1Zm563.2-1.54h-1v-.8h1ZM556,322.11h-1v-.8h1Zm563.2-1.54h-1v-.8h1ZM556,319.31h-1v-.8h1Zm563.2-1.54h-1V317h1ZM556,316.51h-1v-.8h1Zm563.2-1.54h-1v-.8h1ZM556,313.71h-1v-.8h1Zm563.2-1.54h-1v-.8h1ZM556,310.91h-1v-.8h1Zm563.2-1.54h-1v-.8h1ZM556,308.11h-1v-.8h1Zm563.2-1.54h-1v-.8h1ZM556,305.31h-1v-.8h1Zm563.2-1.53h-1V303h1ZM556,302.51h-1v-.8h1Zm563.2-1.53h-1v-.8h1ZM556,299.71h-1v-.79h1Zm563.2-1.53h-1v-.8h1ZM556,296.92h-1v-.8h1Zm563.2-1.54h-1v-.8h1ZM556,294.12h-1v-.8h1Zm563.2-1.54h-1v-.8h1ZM556,291.32h-1v-.8h1Zm563.2-1.54h-1V289h1ZM556,288.52h-1v-.8h1Zm563.2-1.54h-1v-.8h1ZM556,285.72h-1v-.8h1Zm563.2-1.54h-1v-.8h1ZM556,282.92h-1v-.8h1Zm563.2-1.54h-1v-.8h1ZM556,280.12h-1v-.8h1Zm563.2-1.54h-1v-.8h1ZM556,277.32h-1v-.8h1Zm563.2-1.54h-1V275h1ZM556,274.52h-1v-.8h1Zm563.2-1.54h-1v-.8h1ZM556,271.72h-1v-.8h1Zm563.2-1.54h-1v-.8h1ZM556,268.92h-1v-.8h1Zm563.2-1.54h-1v-.8h1ZM556,266.12h-1v-.8h1Zm563.2-1.54h-1v-.8h1ZM556,263.32h-1v-.8h1Zm563.2-1.53h-1V261h1ZM556,260.52h-1v-.8h1Zm563.2-1.53h-1v-.8h1ZM556,257.72h-1v-.8h1Zm563.2-1.53h-1v-.8h1ZM556,254.92h-1v-.79h1Zm563.2-1.53h-1v-.8h1ZM556,252.13h-1v-.8h1Zm563.2-1.54h-1v-.8h1ZM556,249.33h-1v-.8h1Zm563.2-1.54h-1V247h1ZM556,246.53h-1v-.8h1Zm563.2-1.54h-1v-.8h1ZM556,243.73h-1v-.8h1Zm563.2-1.54h-1v-.8h1ZM556,240.93h-1v-.8h1Zm563.2-1.54h-1v-.8h1ZM556,238.13h-1v-.8h1Zm563.2-1.54h-1v-.8h1ZM556,235.33h-1v-.8h1Zm563.2-1.54h-1V233h1ZM556,232.53h-1v-.8h1Zm563.2-1.54h-1v-.8h1ZM556,229.73h-1v-.8h1Zm563.2-1.54h-1v-.8h1ZM556,226.93h-1v-.8h1Zm563.2-1.54h-1v-.8h1ZM556,224.13h-1v-.8h1Zm563.2-1.54h-1v-.8h1ZM556,221.33h-1v-.8h1Zm563.2-1.54h-1V219h1ZM556,218.53h-1v-.8h1Zm563.2-1.53h-1v-.8h1ZM556,215.73h-1v-.8h1Zm563.2-1.53h-1v-.8h1ZM556,212.93h-1v-.8h1Zm563.2-1.53h-1v-.8h1ZM556,210.14h-1v-.8h1Zm563.2-1.54h-1v-.8h1ZM556,207.34h-1v-.8h1Zm563.2-1.54h-1V205h1ZM556,204.54h-1v-.8h1Zm563.2-1.54h-1v-.8h1ZM556,201.74h-1v-.8h1Zm563.2-1.54h-1v-.8h1ZM556,198.94h-1v-.8h1Zm563.2-1.54h-1v-.8h1ZM556,196.14h-1v-.8h1Zm563.2-1.54h-1v-.8h1ZM556,193.34h-1v-.8h1Zm563.2-1.54h-1V191h1ZM556,190.54h-1v-.8h1Zm563.2-1.54h-1v-.8h1ZM556,187.74h-1v-.8h1Zm563.2-1.54h-1v-.8h1ZM556,184.94h-1v-.8h1Zm563.2-1.54h-1v-.8h1ZM556,182.14h-1v-.8h1Zm563.2-1.54h-1v-.8h1ZM556,179.34h-1v-.8h1Zm563.2-1.54h-1V177h1ZM556,176.54h-1v-.8h1Zm563.2-1.53h-1v-.8h1ZM556,173.74h-1v-.8h1Zm563.2-1.53h-1v-.8h1ZM556,170.94h-1v-.8h1Zm563.2-1.53h-1v-.8h1ZM556,168.14h-1v-.8h1Zm563.2-1.53h-1v-.8h1ZM556,165.35h-1v-.8h1Zm563.2-1.54h-1V163h1ZM556,162.55h-1v-.8h1Zm563.2-1.54h-1v-.8h1ZM556,159.75h-1V159h1Zm563.2-1.54h-1v-.8h1ZM556,157h-1v-.8h1Zm563.2-1.54h-1v-.8h1ZM556,154.15h-1v-.8h1Zm563.2-1.54h-1v-.8h1ZM556,151.35h-1v-.8h1Zm563.2-1.54h-1V149h1ZM556,148.55h-1v-.8h1Zm563.2-1.54h-1v-.8h1ZM556,145.75h-1V145h1Zm562.2-1.52a3.27,3.27,0,0,0-.09-.7l1-.22a5.28,5.28,0,0,1,.11.89Zm-562-1.08-.94-.34a4.31,4.31,0,0,1,.39-.81l.85.52A3.64,3.64,0,0,0,556.25,143.15Zm561.1-1.15a3.35,3.35,0,0,0-.52-.47l.6-.8a4.78,4.78,0,0,1,.67.6Zm-559.56-.7-.51-.86a4.3,4.3,0,0,1,.82-.37l.32.94A3.6,3.6,0,0,0,557.79,141.3Zm557.45-.44a4.07,4.07,0,0,0-.5,0h-.23v-1h.23a4.49,4.49,0,0,1,.64,0Zm-2.73,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.79,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.79,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.79,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.79,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0H955v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0H941v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0H927v-1h.8Zm-2.8,0h-.79v-1H925Zm-2.79,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0H913v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0H899v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0H885v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.79v-1h.79Zm-2.79,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0H871v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0H857v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0H843v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.79,0h-.8v-1h.8Zm-2.8,0H829v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0H815v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0H801v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.79,0H787v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0H773v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0H759v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.79,0H745v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0H731v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0H717v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.79,0H703v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0H689v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0H675v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0H661v-1h.8Zm-2.79,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0H647v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0H633v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0H619v-1h.8Zm-2.79,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0H605v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0H591v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0H577v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.79,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0H563v-1h.8Zm-2.8,0h-.8v-1h.8Z" fill="#505150" opacity="0.65"/>
-    </g>
-    <g>
-      <g>
-        <rect x="175.79" y="140.23" width="297" height="326" rx="4" fill="#fff"/>
-        <rect x="175.79" y="140.23" width="297" height="326" rx="4" fill="#505150" opacity="0.07"/>
-        <rect x="175.79" y="140.23" width="297" height="326" rx="4" fill="none" stroke="#505150" stroke-width="0.8" opacity="0.15"/>
-      </g>
-      <path d="M468.79,466.63h-.11v-.8h.11a3.08,3.08,0,0,0,.61-.06l.14.79A3.81,3.81,0,0,1,468.79,466.63Zm-2.11,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.79,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.79,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.79v-.8h.79Zm-2.79,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.79,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.79,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.79v-.8h.79Zm-2.79,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.79,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0H396v-.8h.8Zm-2.79,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.79,0H382v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.79,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0H368v-.8h.8Zm-2.79,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.79,0H354v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.79,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0H340v-.8h.8Zm-2.8,0h-.79v-.8H338Zm-2.79,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.79v-.8h.79Zm-2.79,0H326v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.79,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0H312v-.8h.8Zm-2.8,0h-.79v-.8H310Zm-2.79,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.79,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.79,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.79v-.8h.79Zm-2.79,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.79,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.79,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.79,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.79,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.79,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.79,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.79,0h-.8v-.8h.8Zm-33.57,0h-.8v-.8h.8Zm-2.9-.2a4.69,4.69,0,0,1-.8-.34l.38-.71a4.27,4.27,0,0,0,.66.29Zm293-.76L471,465a3.5,3.5,0,0,0,.52-.5l.61.52A4.54,4.54,0,0,1,471.52,465.67ZM176.09,464.6a3.83,3.83,0,0,1-.4-.78l.74-.29a3.87,3.87,0,0,0,.33.64Zm297-1.5-.78-.16a4.17,4.17,0,0,0,.07-.71l.8-.05v.05A4.28,4.28,0,0,1,473.1,463.1Zm-296.91-1.39h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.26h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8V451h.8Zm-297-1.27h-.8v-.79h.8Zm297-1.52h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.52h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8V437h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.79h.8Zm297-1.52h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8V423h.8Zm-297-1.27h-.8v-.79h.8Zm297-1.52h-.8v-.8h.8Zm-297-1.27h-.8V419h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.79h.8Zm-297-1.26h-.8v-.8h.8Zm297-1.53h-.8V409h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8V405h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.79h.8Zm297-1.52h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.52h-.8v-.8h.8Zm-297-1.27h-.8V391h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.79h.8Zm-297-1.26h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8V377h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.79h.8Zm297-1.52h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.52h-.8v-.8h.8Zm-297-1.27h-.8V363h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.79h.8Zm-297-1.26h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8V349h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.79h.8Zm297-1.52h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.79h.8Zm-297-1.26h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.26h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.52h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.79h.8Zm-297-1.26h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8V300h.8Zm-297-1.26h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.52h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8V286h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.79h.8Zm-297-1.26h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8V272h.8Zm-297-1.27h-.8v-.79h.8Zm297-1.52h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.52h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8V258h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.79h.8Zm-297-1.26h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8V244h.8Zm-297-1.27h-.8v-.79h.8Zm297-1.52h-.8v-.8h.8Zm-297-1.27h-.8V240h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.52h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8V230h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8V226h.8Zm297-1.53h-.8v-.79h.8Zm-297-1.27h-.8v-.79h.8Zm297-1.52h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8V216h.8Zm-297-1.27h-.8v-.79h.8Zm297-1.52h-.8v-.8h.8Zm-297-1.27h-.8V212h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.79h.8Zm-297-1.26h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8V198h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.79h.8Zm297-1.52h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.52h-.8v-.8h.8Zm-297-1.27h-.8V184h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.79h.8Zm-297-1.26h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8V170h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.79h.8Zm297-1.52h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.52h-.8v-.8h.8Zm-297-1.27h-.8V156h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.79h.8Zm-297-1.26h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm296.2-1.52a4.18,4.18,0,0,0-.09-.71l.78-.18a5,5,0,0,1,.11.87ZM176.4,143l-.75-.27A4.09,4.09,0,0,1,176,142l.68.42A3.15,3.15,0,0,0,176.4,143Zm295.08-1.17a4.1,4.1,0,0,0-.53-.49l.48-.64a4.55,4.55,0,0,1,.64.6ZM178,141.12l-.41-.69a5.23,5.23,0,0,1,.8-.37l.26.76A4.22,4.22,0,0,0,178,141.12Zm291.33-.46a4.53,4.53,0,0,0-.52,0h-.22v-.8h.22a4.35,4.35,0,0,1,.63,0Zm-2.74,0h-.8v-.8h.8Zm-2.8,0H463v-.8h.8Zm-2.79,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.79,0h-.8v-.8h.8Zm-2.8,0H449v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.79v-.8h.79Zm-2.79,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0H435v-.8h.8Zm-2.79,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.79,0h-.8v-.8h.8Zm-2.8,0H421v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.79v-.8h.79Zm-2.79,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0H407v-.8h.8Zm-2.79,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.79,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.79v-.8h.79Zm-2.79,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.79,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.79v-.8h.79Zm-2.79,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.79,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.79,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.79,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.79,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.79,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.79v-.8h.79Zm-2.79,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.79,0h-.8v-.8h.8Zm-2.8,0H298v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.79,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0H284v-.8h.8Zm-2.79,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.79,0h-.8v-.8h.8Zm-2.8,0H270v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.79,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0H256v-.8h.79Zm-2.79,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.79,0h-.8v-.8h.8Zm-2.8,0H242v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.79v-.8h.79Zm-2.79,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0H228v-.8h.8Zm-2.79,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.79,0h-.8v-.8h.8Zm-2.8,0H214v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.79,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.79,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.79,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.79v-.8h.79Z" fill="#505150" opacity="0.65"/>
-    </g>
-    <g>
-      <rect x="437.77" y="6.46" width="157.75" height="52.96" fill="#fff"/>
-      <rect x="437.77" y="6.46" width="157.75" height="52.96" fill="#83b9f9" opacity="0.15"/>
-      <path d="M595.39,6.58V59.29H437.89V6.58h157.5m.25-.25h-158V59.54h158V6.33Z" fill="#83b9f9"/>
-    </g>
-    <g>
-      <rect x="921.37" y="6.46" width="197.75" height="114.15" fill="#fff"/>
-      <rect x="921.37" y="6.46" width="197.75" height="114.15" fill="#83b9f9" opacity="0.15"/>
-      <path d="M1119,6.58v113.9H921.49V6.58H1119m.25-.25h-198v114.4h198V6.33Z" fill="#83b9f9"/>
-    </g>
-    <g>
-      <rect x="771.77" y="6.46" width="136.15" height="114.35" fill="#fff"/>
-      <rect x="771.77" y="6.46" width="136.15" height="114.35" fill="#83b9f9" opacity="0.15"/>
-      <path d="M907.79,6.58v114.1H771.89V6.58h135.9m.25-.25H771.64v114.6H908V6.33Z" fill="#83b9f9"/>
-    </g>
-    <g>
-      <rect x="622.17" y="6.46" width="136.15" height="114.35" fill="#fff"/>
-      <rect x="622.17" y="6.46" width="136.15" height="114.35" fill="#83b9f9" opacity="0.15"/>
-      <path d="M758.19,6.58v114.1H622.29V6.58h135.9m.25-.25H622v114.6h136.4V6.33Z" fill="#83b9f9"/>
-    </g>
-    <g>
-      <line x1="124.31" y1="152.23" x2="106.67" y2="152.23" fill="none" stroke="#3c3c41" stroke-miterlimit="10"/>
-      <polygon points="107.76 148.49 101.29 152.23 107.76 155.97 107.76 148.49" fill="#3c3c41"/>
-    </g>
-    <g>
-      <line x1="166.3" y1="152.23" x2="149.31" y2="152.23" fill="none" stroke="#3c3c41" stroke-miterlimit="10"/>
-      <polygon points="165.21 148.49 171.69 152.23 165.21 155.97 165.21 148.49" fill="#3c3c41"/>
-    </g>
-    <g>
-      <rect x="126.84" y="150.8" width="13.21" height="2.75" transform="translate(-65.07 191.66) rotate(-60)" fill="#a67af4"/>
-      <rect x="141.07" y="145.79" width="2.75" height="13.21" transform="translate(-57.11 91.64) rotate(-30)" fill="#a67af4"/>
-      <rect x="131.24" y="158.79" width="13.21" height="2.75" fill="#773adc"/>
-      <circle cx="138.09" cy="144.08" r="3.35" fill="url(#linear-gradient)"/>
-      <circle cx="147.16" cy="160.38" r="3.35" fill="url(#linear-gradient-2)"/>
-      <circle cx="128.83" cy="160.38" r="3.35" fill="url(#linear-gradient-3)"/>
-    </g>
-    <g>
-      <line x1="496.59" y1="406.51" x2="478.47" y2="406.51" fill="none" stroke="#3c3c41" stroke-miterlimit="10"/>
-      <polygon points="479.56 402.77 473.09 406.51 479.56 410.25 479.56 402.77" fill="#3c3c41"/>
-    </g>
-    <g>
-      <line x1="551.3" y1="406.51" x2="534.69" y2="406.51" fill="none" stroke="#3c3c41" stroke-miterlimit="10"/>
-      <polygon points="550.21 402.77 556.69 406.51 550.21 410.25 550.21 402.77" fill="#3c3c41"/>
-    </g>
-    <g>
-      <line x1="871.86" y1="371.17" x2="855.24" y2="371.17" fill="none" stroke="#3c3c41" stroke-miterlimit="10"/>
-      <polygon points="870.77 367.43 877.24 371.17 870.77 374.91 870.77 367.43" fill="#3c3c41"/>
-    </g>
-    <g>
-      <path d="M208.52,432.6c0,5.91-7.15,10.68-8.7,11.64a.57.57,0,0,1-.59,0c-1.55-1-8.7-5.73-8.7-11.64v-7.12a.56.56,0,0,1,.55-.56c5.56-.15,4.28-2.59,8.45-2.59s2.88,2.44,8.44,2.59a.56.56,0,0,1,.55.56Z" fill="#0078d4"/>
-      <path d="M207.78,432.66c0,5.42-6.55,9.78-8,10.68a.52.52,0,0,1-.54,0c-1.43-.88-8-5.26-8-10.68v-6.53a.5.5,0,0,1,.5-.51c5.09-.14,3.92-2.38,7.75-2.38s2.65,2.24,7.75,2.38a.51.51,0,0,1,.5.51Z" fill="#6bb9f2"/>
-      <path d="M199.53,433.33V423.24c3.82,0,2.65,2.24,7.75,2.38a.52.52,0,0,1,.5.52v6.53q0,.33,0,.66Zm0,0h-8.22c.49,5.11,6.58,9.17,7.95,10a.41.41,0,0,0,.22.07h.05Z" fill="url(#linear-gradient-4)"/>
-      <path d="M191.78,425.62c5.09-.14,3.92-2.38,7.75-2.38v10.09h-8.22q0-.33,0-.66v-6.53A.52.52,0,0,1,191.78,425.62Z" fill="#50e6ff"/>
-      <path d="M207.74,433.33h-8.21v10.08h0a.47.47,0,0,0,.22-.07C201.16,442.5,207.25,438.44,207.74,433.33Z" fill="#50e6ff"/>
-    </g>
-    <g>
-      <circle cx="203.29" cy="466.3" r="1.67" fill="url(#linear-gradient-5)"/>
-      <circle cx="197.95" cy="466.31" r="1.67" fill="url(#linear-gradient-6)"/>
-      <circle cx="192.6" cy="466.31" r="1.67" fill="url(#linear-gradient-7)"/>
-      <path d="M193.82,473l-1,1a.43.43,0,0,1-.61,0h0l-7.1-7.07a.87.87,0,0,1,0-1.23h0l1-1h0l7.71,7.69a.43.43,0,0,1,0,.61Z" fill="#50e6ff"/>
-      <path d="M192.72,458.67l1,1a.43.43,0,0,1,0,.61l-7.58,7.6h0l-1-1a.86.86,0,0,1,0-1.22h0l7-7A.44.44,0,0,1,192.72,458.67Z" fill="#1490df"/>
-      <path d="M209.67,464.7l1,1a.87.87,0,0,1,0,1.22h0L203.53,474a.43.43,0,0,1-.61,0h0l-1-1a.43.43,0,0,1,0-.61h0l7.71-7.69Z" fill="#50e6ff"/>
-      <path d="M210.62,466.87l-1,1h0l-7.57-7.6a.43.43,0,0,1,0-.61h0l1-1a.44.44,0,0,1,.61,0h0l7,7a.86.86,0,0,1,0,1.22h0Z" fill="#1490df"/>
-    </g>
-    <g>
-      <circle cx="520.27" cy="408.1" r="1.67" fill="url(#linear-gradient-8)"/>
-      <circle cx="514.92" cy="408.11" r="1.67" fill="url(#linear-gradient-9)"/>
-      <circle cx="509.58" cy="408.11" r="1.67" fill="url(#linear-gradient-10)"/>
-      <path d="M510.8,414.81l-1,1a.43.43,0,0,1-.61,0h0l-7.1-7.07a.87.87,0,0,1,0-1.23h0l1-1h0l7.71,7.69a.43.43,0,0,1,0,.61Z" fill="#50e6ff"/>
-      <path d="M509.69,400.47l1,1a.44.44,0,0,1,0,.61l-7.58,7.6h0l-1-1a.86.86,0,0,1,0-1.22h0l7-7A.43.43,0,0,1,509.69,400.47Z" fill="#1490df"/>
-      <path d="M526.64,406.5l1,1a.86.86,0,0,1,0,1.22h0l-7.1,7.08a.43.43,0,0,1-.61,0h0l-1-1a.43.43,0,0,1,0-.61h0l7.71-7.69Z" fill="#50e6ff"/>
-      <path d="M527.6,408.67l-1,1h0l-7.58-7.6a.43.43,0,0,1,0-.61h0l1-1a.45.45,0,0,1,.62,0h0l7,7a.86.86,0,0,1,0,1.22h0Z" fill="#1490df"/>
-    </g>
-    <g>
-      <circle cx="583.65" cy="466.3" r="1.67" fill="url(#linear-gradient-11)"/>
-      <circle cx="578.3" cy="466.31" r="1.67" fill="url(#linear-gradient-12)"/>
-      <circle cx="572.96" cy="466.31" r="1.67" fill="url(#linear-gradient-13)"/>
-      <path d="M574.18,473l-1,1a.43.43,0,0,1-.61,0h0l-7.1-7.07a.87.87,0,0,1,0-1.23h0l1-1h0l7.71,7.69a.43.43,0,0,1,0,.61Z" fill="#50e6ff"/>
-      <path d="M573.07,458.67l1,1a.44.44,0,0,1,0,.61l-7.58,7.6h0l-1-1a.86.86,0,0,1,0-1.22h0l7-7A.43.43,0,0,1,573.07,458.67Z" fill="#1490df"/>
-      <path d="M590,464.7l1,1a.86.86,0,0,1,0,1.22h0l-7.1,7.08a.43.43,0,0,1-.61,0h0l-1-1a.43.43,0,0,1,0-.61h0L590,464.7Z" fill="#50e6ff"/>
-      <path d="M591,466.87l-1,1h0l-7.58-7.6a.43.43,0,0,1,0-.61h0l1-1a.45.45,0,0,1,.62,0h0l7,7a.86.86,0,0,1,0,1.22h0Z" fill="#1490df"/>
-    </g>
-    <g>
-      <rect x="570.64" y="154.33" width="285" height="124" fill="#fff"/>
-      <rect x="570.64" y="154.33" width="285" height="124" fill="#cccccb" opacity="0.7"/>
-    </g>
-    <g>
-      <rect x="194.93" y="290.39" width="117.54" height="124.1" fill="#fff"/>
-      <rect x="194.93" y="290.39" width="117.54" height="124.1" fill="#cccccb" opacity="0.7"/>
-    </g>
-    <g>
-      <rect x="334.09" y="290.39" width="117.54" height="124.1" fill="#fff"/>
-      <rect x="334.09" y="290.39" width="117.54" height="124.1" fill="#cccccb" opacity="0.7"/>
-    </g>
-    <g>
-      <rect x="242.8" y="334.09" width="21.8" height="21.8" rx="1.01" transform="translate(-169.64 280.44) rotate(-45)" fill="url(#Teal_Gradient)"/>
-      <path d="M250.27,337.36l3.32-3.32a.2.2,0,0,1,.25,0l3.4,3.32a.16.16,0,0,1,0,.23.16.16,0,0,1-.15.05h-2a.18.18,0,0,0-.18.18h0v4.29a.16.16,0,0,1-.15.16h-2.07a.16.16,0,0,1-.18-.14v-4.31a.18.18,0,0,0-.16-.18H250.4a.17.17,0,0,1-.16-.19A.16.16,0,0,1,250.27,337.36Zm7,15.26-3.4,3.31a.18.18,0,0,1-.25,0l-3.32-3.31a.18.18,0,0,1,0-.25.19.19,0,0,1,.09,0h1.95a.17.17,0,0,0,.16-.17v-4.29a.16.16,0,0,1,.16-.16h2.09a.16.16,0,0,1,.15.16h0v4.29a.18.18,0,0,0,.18.17H257a.18.18,0,0,1,.21.29Zm-10-4.38V346.3a.19.19,0,0,0-.17-.18h-4.29a.18.18,0,0,1-.18-.16v-2.07a.19.19,0,0,1,.18-.17h4.29a.17.17,0,0,0,.17-.16v-2a.15.15,0,0,1,.1-.2.16.16,0,0,1,.19.06l3.31,3.35a.16.16,0,0,1,0,.23h0l-3.31,3.32a.17.17,0,0,1-.23,0A.18.18,0,0,1,247.25,348.24Zm12.93-6.64v2a.17.17,0,0,0,.17.16h4.29a.19.19,0,0,1,.18.17V346a.18.18,0,0,1-.18.16h-4.29a.18.18,0,0,0-.17.18v1.94a.16.16,0,0,1-.29.12L256.57,345a.17.17,0,0,1,0-.23h0l3.32-3.3a.15.15,0,0,1,.22,0A.18.18,0,0,1,260.18,341.6Z" fill="#fff"/>
-    </g>
-    <g>
-      <path id="f57e105d-6d2d-4ad7-b8c3-c10684c9f9b8" d="M402.26,370a15,15,0,0,1-18.42-23.76l.16-.11A15,15,0,0,1,402.26,370" fill="url(#radial-gradient)"/>
-      <path d="M393.05,344.57a13.59,13.59,0,1,0,13.59,13.59A13.59,13.59,0,0,0,393.05,344.57Zm9.1,4.57a13,13,0,0,1-3.8,1.42,15.49,15.49,0,0,0-2.21-4.77A12.7,12.7,0,0,1,402.15,349.14Zm-9.1-3.81a12.32,12.32,0,0,1,1.92.15h0a13.22,13.22,0,0,1,2.71,5.31,26.92,26.92,0,0,1-9.64,0,13.16,13.16,0,0,1,2.67-5.2h0A12.24,12.24,0,0,1,393.05,345.33Zm-3.54.46a15.35,15.35,0,0,0-2.24,4.73,9.67,9.67,0,0,1-3.36-1.36A13,13,0,0,1,389.51,345.79ZM383.71,367a9.37,9.37,0,0,1,3.15-1.35,12.43,12.43,0,0,0,2.39,4.81A12.87,12.87,0,0,1,383.71,367ZM395,370.88a12.08,12.08,0,0,1-2,.11,12.83,12.83,0,0,1-2.55-.26h0a10.67,10.67,0,0,1-2.95-5.31,26,26,0,0,1,10.39,0,10.6,10.6,0,0,1-3,5.31Zm1.29-.28a12.49,12.49,0,0,0,2.44-5,12,12,0,0,1,3.54,1.47,12.62,12.62,0,0,1-6,3.41Zm2.62-5.69a19.89,19.89,0,0,0,.35-2l-.81.2c-.09.54-.18,1.09-.3,1.6a27.07,27.07,0,0,0-10.76,0,13.19,13.19,0,0,1-.3-1.52.43.43,0,0,1,0-.16l-.82-.23a4.17,4.17,0,0,0,0,.5,8.2,8.2,0,0,0,.3,1.61,10.52,10.52,0,0,0-3.53,1.5,12.79,12.79,0,0,1,.19-16.61,11.42,11.42,0,0,0,3.68,1.52c-.12.42-.23.88-.32,1.34s0,.44-.14.65l.83-.19v-.3c.11-.46.21-.9.34-1.33a26.27,26.27,0,0,0,5.39.43,26.94,26.94,0,0,0,4.91-.46c.12.47.25,1,.35,1.5l.82.19c-.13-.63-.27-1.22-.43-1.76a13.79,13.79,0,0,0,4.07-1.61,12.75,12.75,0,0,1,.1,16.77,13,13,0,0,0-3.92-1.71Z" fill="#699cd3"/>
-      <path d="M383.66,354.62a15.69,15.69,0,0,1,2-.14,4.27,4.27,0,0,1,3,.92,3.52,3.52,0,0,1,1,2.58,4,4,0,0,1-1.08,2.9,4.62,4.62,0,0,1-3.29,1.08,17.48,17.48,0,0,1-1.77-.09Zm1,6.6a8,8,0,0,0,1,0,2.86,2.86,0,0,0,3.16-2.53,2.51,2.51,0,0,0,0-.67,2.65,2.65,0,0,0-2.4-2.88,2.56,2.56,0,0,0-.62,0,7,7,0,0,0-1.12,0Z" fill="#fff"/>
-      <path d="M391,361.89v-7.44h1l2.39,3.71a20.38,20.38,0,0,1,1.34,2.42h0c-.08-1-.1-1.89-.1-3.06v-3.07h.88v7.44h-1l-2.33-3.73c-.52-.83-1-1.77-1.4-2.48h0v6.26Z" fill="#fff"/>
-      <path d="M398.16,360.72a3.5,3.5,0,0,0,1.76.48c1,0,1.56-.51,1.56-1.27s-.39-1.1-1.4-1.47-2-1.06-2-2.12a2.16,2.16,0,0,1,2.28-2h.14a3.61,3.61,0,0,1,1.65.36l-.29.79a2.78,2.78,0,0,0-1.41-.35c-1,0-1.41.6-1.41,1.11s.46,1,1.48,1.43a2.51,2.51,0,0,1,1.91,2.2c0,1.09-.85,2.13-2.62,2.13a3.79,3.79,0,0,1-1.89-.47Z" fill="#fff"/>
-    </g>
-    <g>
-      <path d="M660.94,81.79l1.43-1.54V76.16h-7.13v4.09l1.43,1.54A.53.53,0,0,0,657,82h3.53A.55.55,0,0,0,660.94,81.79Z" fill="#cfcfce"/>
-      <path d="M658.77,52a10.4,10.4,0,0,0-10.5,10.29,9.59,9.59,0,0,0,.07,1.31c.47,4.35,4.62,6.38,5.8,11.91a.87.87,0,0,0,.83.67h7.59a.87.87,0,0,0,.83-.67c1.18-5.53,5.29-7.56,5.81-11.91a10.4,10.4,0,0,0-9.13-11.53A11.33,11.33,0,0,0,658.77,52Z" fill="url(#radial-gradient-2)"/>
-      <path d="M663.11,57.79a2.48,2.48,0,0,0-2.39,2.54v1.36H657V60.33a2.49,2.49,0,0,0-2.43-2.54h-.06a2.56,2.56,0,0,0,0,5.1h1.13V73.48a.64.64,0,0,0,.64.63.63.63,0,0,0,.63-.63V62.89h3.81V73.48a.64.64,0,0,0,1.28,0V62.89h1.11a2.47,2.47,0,0,0,2.38-2.56h0A2.47,2.47,0,0,0,663.11,57.79Zm-7.47,3.9h-1.2a1.37,1.37,0,1,1,1.2-1.36Zm7.56,0H662V60.26a1.2,1.2,0,1,1,2.38-.29,1.4,1.4,0,0,1,0,.29,1.28,1.28,0,0,1-1.14,1.42Z" fill="url(#linear-gradient-14)"/>
-      <polygon points="655.17 78.98 662.37 77.59 662.37 76.79 655.17 78.2 655.17 78.98" fill="#999"/>
-      <polygon points="662.37 79.53 662.37 78.75 655.17 80.18 655.17 80.25 655.71 80.85 662.37 79.53" fill="#999"/>
-    </g>
-    <g>
-      <path id="aacf8311-a317-400f-b613-74bd00da5ce3" d="M805,52a15,15,0,1,0,15,15A15,15,0,0,0,805,52Zm0,28a13,13,0,1,1,13-13h0A13,13,0,0,1,805,79.93Z" fill="url(#radial-gradient-3)"/>
-      <circle cx="805.04" cy="66.98" r="12.95" fill="#fff"/>
-      <g>
-        <path id="bd983c41-db73-40ec-a4f4-da1213fc9924" d="M812.88,64a3.25,3.25,0,0,0,0-4.57h0l-5.56-5.57a3.23,3.23,0,0,0-4.55,0h0l-5.56,5.57a3.24,3.24,0,0,0,0,4.57l4.62,4.72a.87.87,0,0,1,.27.63V78a1.13,1.13,0,0,0,.31.78l2.12,2.12a.74.74,0,0,0,1,0h0l2-2h0l1.2-1.2a.43.43,0,0,0,0-.6l-.86-.86a.49.49,0,0,1,0-.66l.86-.86a.44.44,0,0,0,0-.6l-.86-.87a.48.48,0,0,1,0-.65l.86-.86a.43.43,0,0,0,0-.6l-1.2-1.22v-.44ZM805,55.25a1.83,1.83,0,1,1-1.82,1.82A1.82,1.82,0,0,1,805,55.25Z" fill="url(#radial-gradient-4)"/>
-        <path id="ad2e7e44-9bfd-4775-8bf4-8ef26a544921" d="M803.6,78.1h0a.4.4,0,0,0,.57,0,.44.44,0,0,0,.1-.26V70.74a.42.42,0,0,0-.2-.35h0a.37.37,0,0,0-.53.11.42.42,0,0,0-.07.24V77.8A.48.48,0,0,0,803.6,78.1Z" fill="#f7921e" opacity="0.75" style="isolation: isolate"/>
-        <rect id="a996fbff-3936-4b24-b407-369336c143ba" x="800.6" y="61.32" width="9.12" height="1.08" rx="0.49" fill="#f7921e" opacity="0.75" style="isolation: isolate"/>
-        <rect id="bb12d31c-3352-4a18-87dd-a169a4a8721d" x="800.6" y="63.06" width="9.12" height="1.08" rx="0.49" fill="#f7921e" opacity="0.75" style="isolation: isolate"/>
-      </g>
-    </g>
-    <g>
-      <ellipse cx="724.68" cy="66.48" rx="15.05" ry="15" fill="url(#radial-gradient-5)"/>
-      <ellipse cx="724.68" cy="66.48" rx="13.11" ry="13.05" fill="#fff"/>
-      <path d="M713.55,67.26a11,11,0,0,0,3.23,7.08l3.54-3.54a6.21,6.21,0,0,1-1.77-3.54Z" fill="#a5def3"/>
-      <path d="M732,58.11a11,11,0,0,0-6.53-2.71v4.94a5.9,5.9,0,0,1,3,1.24Z" fill="#33bedd"/>
-      <path d="M717.36,58.11l3.54,3.54a6,6,0,0,1,3-1.24v-5A11,11,0,0,0,717.36,58.11Z" fill="#33bedd"/>
-      <path d="M729.6,62.67a6.4,6.4,0,0,1,1.26,3h4.94a10.92,10.92,0,0,0-2.71-6.5Z" fill="#33bedd"/>
-      <path d="M719.75,62.67l-3.54-3.54a11,11,0,0,0-2.66,6.57h5A6.39,6.39,0,0,1,719.75,62.67Z" fill="#74cfeb"/>
-      <path d="M733.78,62.94a.8.8,0,0,0-1-.44l-7.3,2.94.57,1.43,7.3-2.89a.77.77,0,0,0,.46-1S733.79,63,733.78,62.94Z" fill="#ef404a"/>
-      <circle cx="724.68" cy="66.48" r="2.13" fill="url(#radial-gradient-6)"/>
-    </g>
-    <g>
-      <path d="M881.93,66c0,8.06-9.91,14.55-12.08,15.87a.74.74,0,0,1-.81,0C866.87,80.56,857,74.07,857,66v-9.7a.78.78,0,0,1,.76-.78c7.73-.19,5.95-3.53,11.73-3.53s4,3.34,11.73,3.53a.77.77,0,0,1,.76.78Z" fill="#2e76bc"/>
-      <path d="M880.91,66.06c0,7.41-9.1,13.35-11.1,14.55a.7.7,0,0,1-.74,0c-2-1.2-11.09-7.14-11.09-14.55V57.24a.72.72,0,0,1,.59-.84h.11c7.09-.12,5.47-3.16,10.76-3.16s3.67,3,10.76,3.16a.73.73,0,0,1,.71.71Z" fill="url(#linear-gradient-15)"/>
-      <path d="M874.47,64.61h-.7v-2.5a4.63,4.63,0,0,0-1.24-3.2,4.19,4.19,0,0,0-5.91-.23l-.23.23a4.62,4.62,0,0,0-1.23,3.2v2.5h-.71a.56.56,0,0,0-.61.51.28.28,0,0,0,0,.09V71.7a.57.57,0,0,0,.57.57h10.07a.57.57,0,0,0,.58-.55V65.21a.56.56,0,0,0-.52-.6Zm-2.73,0h-4.59V62.07a2.52,2.52,0,0,1,.72-1.76,2.1,2.1,0,0,1,3-.18l.17.18a3.17,3.17,0,0,1,.29.35h0a2.57,2.57,0,0,1,.44,1.39Z" fill="#febd11"/>
-      <path d="M864.42,64.61h10.05a.55.55,0,0,1,.37.14l-10.79,7.34a.58.58,0,0,1-.22-.42V65.21a.57.57,0,0,1,.53-.6Z" fill="#fee452"/>
-      <path d="M874.47,64.61H864.42a.55.55,0,0,0-.37.14l10.79,7.34a.51.51,0,0,0,.21-.42V65.21a.56.56,0,0,0-.52-.6Z" fill="#fed402" opacity="0.5" style="isolation: isolate"/>
-    </g>
-    <g>
-      <rect x="462.29" y="139.23" width="1" height="1.5" fill="#3c3c41"/>
-      <path d="M463.29,136.19h-1v-3h1Zm107,0h-1v-3h1Zm-107-6h-1v-3h1Zm107,0h-1v-3h1Zm-107-6h-1v-3h1Zm107,0h-1v-3h1Zm-107-6h-1v-3h1Zm107,0h-1v-3h1Zm-107-6h-1v-3h1Zm107,0h-1v-3h1Zm-107-6h-1v-3h1Zm107,0h-1v-3h1Zm-107-6h-1v-3h1Zm107,0h-1v-3h1Zm-107-6h-1v-3h1Zm107,0h-1v-3h1Zm-107-6h-1v-.39a4.44,4.44,0,0,1,.95-2.76l.79.61a3.42,3.42,0,0,0-.74,2.15Zm107,0h-1v-.37a3.41,3.41,0,0,0-.76-2.16l.79-.62a4.52,4.52,0,0,1,1,2.78Zm-104-3.83-.15-1a3.82,3.82,0,0,1,.68,0h2.43v1h-2.43A3.08,3.08,0,0,0,466.26,83.77Zm100,0a4.07,4.07,0,0,0-.5,0h-2.46v-1h2.46a4.73,4.73,0,0,1,.65,0Zm-6,0h-3v-1h3Zm-6.07,0h-3v-1h3Zm-6.07,0h-3v-1h3Zm-6.07,0h-3v-1h3Zm-6.07,0h-3v-1h3Zm-6.07,0h-3v-1h3Zm-6.07,0h-3v-1h3Zm-6.08,0h-3v-1h3Zm-6.07,0h-3v-1h3Zm-6.07,0h-3v-1h3Zm-6.07,0h-3v-1h3Zm-6.07,0h-3v-1h3Zm-6.07,0h-3v-1h3Zm-6.08,0h-3v-1h3Zm-6.07,0h-3v-1h3Z" fill="#3c3c41"/>
-      <rect x="569.29" y="139.23" width="1" height="1.5" fill="#3c3c41"/>
-    </g>
-    <g>
-      <path id="f57e105d-6d2d-4ad7-b8c3-c10684c9f9b8-2" data-name="f57e105d-6d2d-4ad7-b8c3-c10684c9f9b8" d="M527.21,86.36a17,17,0,0,1-20.88-26.92l.18-.12a17,17,0,0,1,20.7,27" fill="url(#radial-gradient-7)"/>
-      <path d="M516.77,57.49A15.41,15.41,0,1,0,532.18,72.9,15.4,15.4,0,0,0,516.77,57.49Zm10.32,5.19a14.56,14.56,0,0,1-4.31,1.6,17.77,17.77,0,0,0-2.5-5.41A14.48,14.48,0,0,1,527.09,62.68Zm-10.32-4.33a13.27,13.27,0,0,1,2.18.18h0a15,15,0,0,1,3.07,6,30.36,30.36,0,0,1-10.92,0,14.85,14.85,0,0,1,3-5.89h0A14.63,14.63,0,0,1,516.77,58.35Zm-4,.52a17.65,17.65,0,0,0-2.54,5.37,11.08,11.08,0,0,1-3.81-1.54A14.84,14.84,0,0,1,512.76,58.87Zm-6.57,24a10.65,10.65,0,0,1,3.57-1.52,14.3,14.3,0,0,0,2.7,5.45A14.6,14.6,0,0,1,506.19,82.91ZM519,87.32a14.21,14.21,0,0,1-2.26.12,13.87,13.87,0,0,1-2.88-.3h0a12,12,0,0,1-3.35-6,29.57,29.57,0,0,1,11.78,0,12,12,0,0,1-3.39,6ZM520.5,87a14.38,14.38,0,0,0,2.76-5.61,13.56,13.56,0,0,1,4,1.66,14.29,14.29,0,0,1-6.77,3.87Zm3-6.45c.16-.72.3-1.46.4-2.24l-.92.22c-.1.62-.2,1.24-.34,1.82a30.56,30.56,0,0,0-12.2,0c-.14-.54-.24-1.12-.34-1.72a.54.54,0,0,1,0-.18l-.92-.26a5.23,5.23,0,0,0,0,.56,8.88,8.88,0,0,0,.34,1.82,11.76,11.76,0,0,0-4,1.7,14.51,14.51,0,0,1,.22-18.83,12.49,12.49,0,0,0,4.17,1.72c-.14.49-.26,1-.36,1.53s0,.5-.16.74l.94-.22v-.34c.12-.52.24-1,.38-1.51a33.56,33.56,0,0,0,11.68,0c.14.55.28,1.13.4,1.71l.92.22q-.23-1.08-.48-2a15.41,15.41,0,0,0,4.61-1.82,14.47,14.47,0,0,1,.12,19,14.59,14.59,0,0,0-4.45-1.94Z" fill="#699cd3"/>
-      <path d="M506.13,68.89a16.49,16.49,0,0,1,2.33-.16,4.86,4.86,0,0,1,3.42,1,4,4,0,0,1,1.18,2.93A4.4,4.4,0,0,1,511.84,76a5.15,5.15,0,0,1-3.72,1.22,16.91,16.91,0,0,1-2-.1Zm1.1,7.47a6.86,6.86,0,0,0,1.11,0,3.22,3.22,0,0,0,3.58-3.62,3,3,0,0,0-2.72-3.27,3.28,3.28,0,0,0-.7,0,6.74,6.74,0,0,0-1.27,0Z" fill="#fff"/>
-      <path d="M514.49,77.12V68.69h1.18l2.7,4.21a23.66,23.66,0,0,1,1.53,2.74h0c-.1-1.12-.12-2.14-.12-3.46V68.69h1v8.43h-1.11L517,72.9c-.58-.94-1.14-2-1.58-2.81h0v7.09Z" fill="#fff"/>
-      <path d="M522.56,75.8a4,4,0,0,0,2,.54c1.12,0,1.77-.58,1.77-1.44s-.44-1.24-1.59-1.66-2.24-1.2-2.24-2.41a2.44,2.44,0,0,1,2.58-2.29h.16a4,4,0,0,1,1.87.4l-.32.9a3.34,3.34,0,0,0-1.61-.4c-1.16,0-1.6.68-1.6,1.26s.52,1.19,1.68,1.63a2.83,2.83,0,0,1,2.17,2.48c0,1.24-1,2.42-3,2.42a4.21,4.21,0,0,1-2.14-.54Z" fill="#fff"/>
-    </g>
-    <g>
-      <path d="M608.91,203l14-14a1,1,0,0,1,1.41,0l0,0,14,14a1,1,0,0,1,0,1.41l0,0-14,14a1,1,0,0,1-1.4,0l-14-14a1,1,0,0,1,0-1.42Z" fill="url(#Green_Gradient_)"/>
-      <path d="M627.27,195.4l-3.53-3.52a.22.22,0,0,0-.27,0l-3.53,3.52a.16.16,0,0,0-.05.23.16.16,0,0,0,.18.07h2.07a.18.18,0,0,1,.18.18v3.34a.18.18,0,0,0,.19.18h2.2a.18.18,0,0,0,.18-.18v-3.34a.18.18,0,0,1,.18-.18h2.07a.16.16,0,0,0,.2-.12A.16.16,0,0,0,627.27,195.4Z" fill="#b6d43a"/>
-      <path d="M615.27,199.75l-3.5,3.55a.2.2,0,0,0,0,.25l3.5,3.51a.18.18,0,0,0,.26,0,.18.18,0,0,0,.06-.14v-2.05a.18.18,0,0,1,.18-.18h3.34a.17.17,0,0,0,.16-.17v-2.21a.17.17,0,0,0,0-.23l-.06,0h-3.34a.17.17,0,0,1-.18-.15v-2a.2.2,0,0,0-.12-.25A.21.21,0,0,0,615.27,199.75Z" fill="#b6d43a"/>
-      <path d="M632.07,207.06l3.55-3.53a.18.18,0,0,0,0-.25l-3.55-3.53a.19.19,0,0,0-.26,0,.21.21,0,0,0,0,.11V202a.16.16,0,0,1-.16.16h-3.36a.17.17,0,0,0-.16.17v2.21a.17.17,0,0,0,.15.19h3.35a.18.18,0,0,1,.18.18V207a.19.19,0,0,0,.21.16A.2.2,0,0,0,632.07,207.06Z" fill="#b6d43a"/>
-      <path d="M628.25,203.73a4.65,4.65,0,1,0-5.89,4.45v1.58A2.85,2.85,0,1,0,626.2,211a2.92,2.92,0,0,0-1.23-1.23V208.1A4.61,4.61,0,0,0,628.25,203.73Z" fill="#fff"/>
-      <circle id="e99c3387-15c3-4f28-bd4b-cb209b430e06" cx="623.62" cy="203.72" r="2.7" fill="#699cd3"/>
-    </g>
-    <g>
-      <circle cx="660.29" cy="203.73" r="2.49"/>
-      <circle cx="667.8" cy="203.73" r="2.49"/>
-      <circle cx="675.32" cy="203.73" r="2.49"/>
-    </g>
-    <g>
-      <rect x="570.64" y="309.33" width="284.6" height="124" fill="#fff"/>
-      <rect x="570.64" y="309.33" width="284.6" height="124" fill="#cccccb" opacity="0.7"/>
-    </g>
-    <g>
-      <rect x="878.64" y="309.33" width="227.4" height="124" fill="#fff"/>
-      <rect x="878.64" y="309.33" width="227.4" height="124" fill="#cccccb" opacity="0.7"/>
-    </g>
-    <g>
-      <g>
-        <path d="M848.3,361.73a1.48,1.48,0,0,0,1.51-1.43v-.25c-.6-4.72-3.29-8.56-8.43-8.56s-7.94,3.25-8.46,8.56a1.51,1.51,0,0,0,1.34,1.67h14Z" fill="url(#linear-gradient-16)"/>
-        <path d="M841.38,352.6a4.71,4.71,0,0,1-2.58-.75l2.55,6.64,2.52-6.6A4.67,4.67,0,0,1,841.38,352.6Z" fill="#fff" opacity="0.8" style="isolation: isolate"/>
-        <circle cx="841.38" cy="347.86" r="4.74" fill="url(#linear-gradient-17)"/>
-        <path d="M835.78,347.91v-6a.19.19,0,0,0-.18-.21H834a.22.22,0,0,0-.22.2h0v5.76a.21.21,0,0,1-.21.21h-1.37a.14.14,0,0,1-.12-.14v-1.61A.14.14,0,0,0,832,346a.15.15,0,0,0-.1,0l-2.72,2.7a.19.19,0,0,0,0,.27l0,0,2.69,2.68a.14.14,0,0,0,.17.09.14.14,0,0,0,.09-.17h0V350a.12.12,0,0,1,.12-.13h3.36a.21.21,0,0,0,.19-.21Z" fill="#2e76bc"/>
-      </g>
-      <g>
-        <path d="M847.63,324.67c0,5.37-6.5,9.71-7.91,10.59a.52.52,0,0,1-.54,0c-1.41-.88-7.91-5.22-7.91-10.59V318.2a.5.5,0,0,1,.5-.51c5.06-.14,3.89-2.36,7.68-2.36s2.62,2.22,7.68,2.36a.5.5,0,0,1,.5.51Z" fill="#0078d4"/>
-        <path d="M847,324.72c0,4.94-6,8.89-7.25,9.71a.48.48,0,0,1-.49,0c-1.3-.8-7.26-4.77-7.26-9.71v-5.93a.47.47,0,0,1,.46-.47c4.63-.12,3.56-2.15,7-2.15s2.41,2,7,2.15a.47.47,0,0,1,.45.47Z" fill="#6bb9f2"/>
-        <path d="M839.45,325.33v-9.16c3.48,0,2.41,2,7,2.15a.47.47,0,0,1,.45.48v5.93q0,.3,0,.6Zm0,0H832c.45,4.65,6,8.34,7.23,9.1a.37.37,0,0,0,.2.07h0Z" fill="url(#linear-gradient-18)"/>
-        <path d="M832.41,318.32c4.63-.12,3.56-2.15,7-2.15v9.16H832q0-.3,0-.6V318.8A.49.49,0,0,1,832.41,318.32Z" fill="#50e6ff"/>
-        <path d="M846.92,325.33h-7.47v9.17h0a.37.37,0,0,0,.2-.07C840.94,333.67,846.47,330,846.92,325.33Z" fill="#50e6ff"/>
-      </g>
-    </g>
-    <g>
-      <g>
-        <path d="M848.3,206.73a1.48,1.48,0,0,0,1.51-1.43v-.25c-.6-4.72-3.29-8.56-8.43-8.56s-7.94,3.25-8.46,8.56a1.51,1.51,0,0,0,1.34,1.67h14Z" fill="url(#linear-gradient-19)"/>
-        <path d="M841.38,197.6a4.71,4.71,0,0,1-2.58-.75l2.55,6.64,2.52-6.6A4.67,4.67,0,0,1,841.38,197.6Z" fill="#fff" opacity="0.8" style="isolation: isolate"/>
-        <circle cx="841.38" cy="192.86" r="4.74" fill="url(#linear-gradient-20)"/>
-        <path d="M835.78,192.91v-6a.19.19,0,0,0-.18-.21H834a.22.22,0,0,0-.22.2h0v5.76a.21.21,0,0,1-.21.21h-1.37a.14.14,0,0,1-.12-.14v-1.61A.14.14,0,0,0,832,191a.15.15,0,0,0-.1,0l-2.72,2.7a.19.19,0,0,0,0,.27l0,0,2.69,2.68a.14.14,0,0,0,.17.09.14.14,0,0,0,.09-.17h0V195a.12.12,0,0,1,.12-.13h3.36a.21.21,0,0,0,.19-.21Z" fill="#2e76bc"/>
-      </g>
-      <g>
-        <path d="M847.63,169.67c0,5.37-6.5,9.71-7.91,10.59a.52.52,0,0,1-.54,0c-1.41-.88-7.91-5.22-7.91-10.59V163.2a.5.5,0,0,1,.5-.51c5.06-.14,3.89-2.36,7.68-2.36s2.62,2.22,7.68,2.36a.5.5,0,0,1,.5.51Z" fill="#0078d4"/>
-        <path d="M847,169.72c0,4.94-6,8.89-7.25,9.71a.48.48,0,0,1-.49,0c-1.3-.8-7.26-4.77-7.26-9.71v-5.93a.47.47,0,0,1,.46-.47c4.63-.12,3.56-2.15,7-2.15s2.41,2,7,2.15a.47.47,0,0,1,.45.47Z" fill="#6bb9f2"/>
-        <path d="M839.45,170.33v-9.16c3.48,0,2.41,2,7,2.15a.47.47,0,0,1,.45.48v5.93q0,.3,0,.6Zm0,0H832c.45,4.65,6,8.34,7.23,9.1a.37.37,0,0,0,.2.07h0Z" fill="url(#linear-gradient-21)"/>
-        <path d="M832.41,163.32c4.63-.12,3.56-2.15,7-2.15v9.16H832q0-.3,0-.6V163.8A.49.49,0,0,1,832.41,163.32Z" fill="#50e6ff"/>
-        <path d="M846.92,170.33h-7.47v9.17h0a.37.37,0,0,0,.2-.07C840.94,178.67,846.47,175,846.92,170.33Z" fill="#50e6ff"/>
-      </g>
-    </g>
-    <g>
-      <path d="M924.37,358.4c-6.2,0-11.38-1.84-11.38-4.1v21.77c0,2.25,5,4.14,11.15,4.14h.23c6.21,0,11.32-1.82,11.32-4.14V354.3C935.61,356.56,930.58,358.4,924.37,358.4Z" fill="url(#linear-gradient-22)"/>
-      <path d="M935.61,354.3c0,2.26-5.07,4.14-11.32,4.14S913,356.56,913,354.3s5.18-4.09,11.38-4.09,11.32,1.82,11.32,4.14" fill="#e8e8e8"/>
-      <path d="M933,354c0,1.43-3.87,2.59-8.67,2.59s-8.67-1.16-8.67-2.59,3.89-2.6,8.75-2.6S933,352.52,933,354" fill="#74cfeb"/>
-      <path d="M924.37,354.57a21,21,0,0,0-6.85,1,23.8,23.8,0,0,0,13.72,0A20.78,20.78,0,0,0,924.37,354.57Z" fill="#1b8ab3"/>
-    </g>
-    <g>
-      <line x1="1018.04" y1="120.73" x2="1018.04" y2="134.45" fill="none" stroke="#3c3c41" stroke-miterlimit="10"/>
-      <polygon points="1014.3 133.35 1018.04 139.83 1021.78 133.35 1014.3 133.35" fill="#3c3c41"/>
-    </g>
-    <g>
-      <line x1="839.84" y1="120.73" x2="839.84" y2="134.45" fill="none" stroke="#3c3c41" stroke-miterlimit="10"/>
-      <polygon points="836.1 133.35 839.84 139.83 843.58 133.35 836.1 133.35" fill="#3c3c41"/>
-    </g>
-    <g>
-      <line x1="690.24" y1="126.11" x2="690.24" y2="139.83" fill="none" stroke="#3c3c41" stroke-miterlimit="10"/>
-      <polygon points="686.5 127.21 690.24 120.73 693.98 127.21 686.5 127.21" fill="#3c3c41"/>
-    </g>
-    <g>
-      <rect x="6.84" y="6.07" width="131" height="55" fill="#fff" opacity="0.3"/>
-      <rect x="6.84" y="6.07" width="131" height="55" fill="none" stroke="#75767a" stroke-miterlimit="10" stroke-width="0.25"/>
-    </g>
-    <g>
-      <g>
-        <line x1="46.69" y1="43.53" x2="20.25" y2="43.53" fill="none" stroke="#207067" stroke-miterlimit="10" stroke-width="3"/>
-        <polygon points="56.22 43.53 42.79 38.04 45.98 43.53 42.79 49.02 56.22 43.53" fill="#207067"/>
-      </g>
-      <line x1="46.69" y1="43.53" x2="20.25" y2="43.53" fill="none" stroke="#42e8ca" stroke-miterlimit="10" stroke-width="1.5" stroke-dasharray="4 2"/>
-    </g>
-    <g>
-      <g>
-        <line x1="46.69" y1="23.93" x2="20.25" y2="23.93" fill="none" stroke="#59285f" stroke-miterlimit="10" stroke-width="3"/>
-        <polygon points="44.94 17.95 55.3 23.93 44.94 29.91 44.94 17.95" fill="#59285f"/>
-      </g>
-      <g>
-        <line x1="46.69" y1="23.93" x2="46.19" y2="23.93" fill="none" stroke="#ce74b6" stroke-miterlimit="10" stroke-width="2"/>
-        <line x1="44.24" y1="23.93" x2="44.23" y2="23.93" fill="none" stroke="#ce74b6" stroke-miterlimit="10" stroke-width="2" stroke-dasharray="0.01 0"/>
-        <line x1="44.23" y1="23.93" x2="20.75" y2="23.93" fill="none" stroke="#ce74b6" stroke-miterlimit="10" stroke-width="2" stroke-dasharray="0.98 1.95 0.01 0"/>
-        <line x1="20.75" y1="23.93" x2="20.25" y2="23.93" fill="none" stroke="#ce74b6" stroke-miterlimit="10" stroke-width="2"/>
-      </g>
-    </g>
-    <circle cx="795.47" cy="295.44" r="35" fill="#fff" opacity="0.6"/>
-    <g>
-      <path d="M794.14,293.61H775.47V274.94h18.67Zm-15.56-3.12H791V278.05H778.58Zm36.89,3.12H796.81V274.94h18.66Zm-15.55-3.12h12.44V278.05H799.92Zm15.55,24.45H796.81V296.27h18.66Zm-21.33,0H775.47V296.27h18.67Zm5.78-3.11h12.44V299.38H799.92Zm-21.34,0H791V299.38H778.58Z" fill="url(#linear-gradient-23)"/>
-      <path d="M811.47,291.38v2.67h-12.8v-2.67Z" fill="url(#linear-gradient-24)"/>
-      <path d="M815.47,293.61v-3.12H799.92v3.12Z" fill="url(#linear-gradient-25)"/>
-      <path d="M775.47,293.61v-3.12H791v3.12Z" fill="url(#linear-gradient-26)"/>
-      <path d="M815.47,296.27v3.11H799.92v-3.11Z" fill="url(#linear-gradient-27)"/>
-      <path d="M775.47,299.38v-3.11H791v3.11Z" fill="url(#linear-gradient-28)"/>
-      <path d="M791,274.94h3.11v15.55H791Z" fill="url(#linear-gradient-29)"/>
-      <path d="M796.81,274.94h3.11v15.55h-3.11Z" fill="url(#linear-gradient-30)"/>
-      <path d="M799.92,314.94h-3.11V299.38h3.11Z" fill="url(#linear-gradient-31)"/>
-      <path d="M794.14,314.94H791V299.38h3.11Z" fill="url(#linear-gradient-32)"/>
-      <path d="M808.81,294.72a37.75,37.75,0,0,0-2.45-11.56,11.47,11.47,0,0,1-1.33,2.33,13.75,13.75,0,0,0-9.56-3.88,13.33,13.33,0,1,0,13.34,13.33Z" fill="#5fb832"/>
-      <path d="M806.25,300.94c-3.33,4.33-10.33,2.89-14.78,3.11a12.66,12.66,0,0,0-1.55.11l.66-.22c3.12-1.11,4.67-1.33,6.56-2.33,3.67-1.89,7.22-5.89,7.89-10.12-1.33,4.12-5.56,7.56-9.33,8.89a53.86,53.86,0,0,1-7.34,1.89l-.22-.11c-3.22-1.55-3.33-8.55,2.44-10.78,2.56-1,5-.44,7.78-1.11,3-.78,6.34-2.89,7.78-5.78C807.81,289.27,809.58,296.49,806.25,300.94Z" fill="#fff"/>
-      <path d="M787.47,305.27a1.11,1.11,0,1,0-1.11-1.11A1.11,1.11,0,0,0,787.47,305.27Z" fill="#fff"/>
-    </g>
-    <g>
-      <path d="M1030.77,66.44a10.53,10.53,0,1,1-10.53-10.76,10.65,10.65,0,0,1,10.53,10.76" fill="#d33833"/>
-      <path d="M1010.15,69.1s-.76-11.22,9.58-11.54l-.72-1.2-5.61,1.88-1.61,1.84-1.4,2.69-.8,3.13.24,2.08" fill="#ef3d3a"/>
-      <path d="M1013,59.1a10.48,10.48,0,0,0-3,7.38h0a10.5,10.5,0,0,0,3,7.38h0a10,10,0,0,0,7.2,3h0a10,10,0,0,0,7.21-3h0a10.5,10.5,0,0,0,3-7.38h0a10.48,10.48,0,0,0-3-7.38h0a10,10,0,0,0-7.21-3.06h0A10,10,0,0,0,1013,59.1Zm-.47,15.22a11.19,11.19,0,0,1-3.17-7.84h0a11.19,11.19,0,0,1,3.17-7.84h0a10.67,10.67,0,0,1,7.67-3.25h0a10.69,10.69,0,0,1,7.68,3.25h0a11.19,11.19,0,0,1,3.17,7.84h0a11.19,11.19,0,0,1-3.17,7.84h0a10.77,10.77,0,0,1-7.68,3.25h0a10.75,10.75,0,0,1-7.67-3.25h0" fill="#231f20"/>
-      <path d="M1024.67,66.5l-1.6.24-2.16.24-1.41,0-1.36,0-1-.32-.92-1-.73-2-.16-.44-1-.32-.56-.92-.4-1.32.44-1.17,1-.36.85.4.4.88.48-.08.16-.2-.16-.92,0-1.16.24-1.6v-.92l.73-1.17,1.28-.92,2.25-1,2.48.36,2.17,1.56,1,1.61.64,1.16.16,2.88-.48,2.49-.88,2.2-.85,1.17" fill="#f0d6b7"/>
-      <path d="M1023.31,73.43l-5.73.24v1l.48,3.37-.24.28-4-1.36-.28-.48-.4-4.53-.92-2.73-.2-.64,3.2-2.2,1-.4.88,1.08.76.68.88.28.4.12.48,2.08.36.45.93-.32-.65,1.24,3.49,1.64-.44.24" fill="#335061"/>
-      <path d="M1013.81,59.44l1-.36.85.4.4.88.48-.08.12-.48-.24-.92.24-2.2-.2-1.21.72-.84,1.56-1.24-.44-.6-2.2,1.08-.93.72-.52,1.13-.8,1.08-.24,1.28.16,1.36" fill="#6d6b6d"/>
-      <path d="M1015.45,55.68a4.53,4.53,0,0,1,3-2.21c2.41-.72.12-.52.12-.52l-2.6,1-1,1-.44.81.92-.08" fill="#dcd9d8"/>
-      <path d="M1014.25,59.16a2.45,2.45,0,0,1,2.37-3.2l-.12-.49-2.21.53-.64,2.08.16,1.36.44-.28" fill="#dcd9d8"/>
-      <path d="M1015.53,62.89l.53-.51a.36.36,0,0,1,.28.31c0,.28.16,2.81,1.88,4.17.16.12-1.28-.2-1.28-.2l-1.29-2" fill="#f7e4cd"/>
-      <path d="M1022.91,62.13s.09-1.22.42-1.12a.45.45,0,0,1,.33.42s-.8.51-.75.7" fill="#f7e4cd"/>
-      <path d="M1026.24,57.68s-.66.14-.72.72.72.12.84.08" fill="#f7e4cd"/>
-      <path d="M1021.39,57.72s-.89.12-.89.68,1,.52,1.29.28" fill="#f7e4cd"/>
-      <path d="M1015.94,60.32s-1.53-.92-1.69,0-.52,1.53.24,2.45l-.52-.16-.48-1.24-.16-1.21.92-1,1,.08.61.48,0,.61" fill="#f7e4cd"/>
-      <path d="M1016.66,57.8a5.52,5.52,0,0,1,4.13-4.21c2.83-.56,4.32.12,4.89.76,0,0-2.53-3-4.93-2.08s-4.17,2.6-4.13,3.69a16.47,16.47,0,0,1,0,1.84" fill="#f7e4cd"/>
-      <path d="M1026,54.75s-1.17,0-1.21,1a.89.89,0,0,0,.08.32s.93-1,1.49-.48" fill="#f7e4cd"/>
-      <path d="M1020.87,56.18s-.2-1.59-1.57-.66c-.88.6-.8,1.44-.64,1.6s.12.48.24.26.08-.94.52-1.14,1.17-.43,1.45-.06" fill="#f7e4cd"/>
-      <path d="M1017.1,67l-3.77,1.68s1.56,6.22.76,8.14l-.56-.2,0-2.37-1-4.49-.44-1.24,3.93-2.64L1017.1,67" fill="#49728b"/>
-      <path d="M1017.49,70.45l.53.66v2.4h-.64s-.08-1.68-.08-1.88.08-.92.08-.92" fill="#49728b"/>
-      <path d="M1017.5,73.87l-1.81.08.53.36,1.28.2" fill="#49728b"/>
-      <path d="M1023.67,73.47l1.48,0,.37,3.69-1.53.2-.32-3.85" fill="#335061"/>
-      <path d="M1024.07,73.47l2.25-.12s.92-2.32.92-2.44.8-3.37.8-3.37l-1.8-1.88-.36-.32-1,1V70l-.84,3.44" fill="#335061"/>
-      <path d="M1025.07,73.19l-1.4.28.2,1.12c.52.25,1.4-.4,1.4-.4" fill="#49728b"/>
-      <path d="M1025.11,66.18l2.81,2.08.08-1-2.12-2-.77.84" fill="#49728b"/>
-      <path d="M1018.89,81.37l-.83-3.37-.41-2.48-.07-1.85,3.75-.2h2.34l-.21,4.21.36,3.25,0,.6-3,.24-1.84-.4" fill="#fff"/>
-      <path d="M1023.15,73.43a35.58,35.58,0,0,0,.4,7.14,7.74,7.74,0,0,1-3,1l3.37-.12.4-.24-.48-6.58-.12-1.4" fill="#dcd9d8"/>
-      <path d="M1025.58,76.8l1.57-.44,3-.16.44-1.36-.8-2.37-.92-.12-1.28.4-1.23.6-.66-.12-.51.2" fill="#fff"/>
-      <path d="M1025.56,76a5.86,5.86,0,0,1,1.2-.44l-.44-2.21.52-.2s.36,2.09.36,2.33l2.44.12a3.69,3.69,0,0,0,.36-1.89l.45,1.28,0,.73-.65,1-.72.16-1.2,0-.4-.52-1.4.2-.44.16" fill="#dcd9d8"/>
-      <path d="M1024,73.15l-.88-2.24-.92-1.33s.2-.56.48-.56h.92l.88.32-.08,1.49-.4,2.32" fill="#fff"/>
-      <path d="M1024.15,72.39A18.26,18.26,0,0,1,1023,69.9s.2-.48.48-.36.88.44.88.44v-.76l-1.36-.28-.92.12,1.56,3.69.32,0" fill="#dcd9d8"/>
-      <path d="M1019.25,67.1l-1.11-.12-1-.32V67l.51.56,1.6.72" fill="#fff"/>
-      <path d="M1017.46,67.22a4.42,4.42,0,0,0,1.64.4l0,.48-1.12-.24-.68-.48.12-.16" fill="#dcd9d8"/>
-      <path d="M1025.58,69.16a7.48,7.48,0,0,1-1.83-.25,3.74,3.74,0,0,1,0-.6,1.34,1.34,0,0,1,.63-.13,1.13,1.13,0,0,0-.7-.08,1.07,1.07,0,0,0-.12-.37c.39-.13,1.29-1,1.8-.73.24.14.34.94.36,1.34a1.34,1.34,0,0,1-.16.82" fill="#d33833"/>
-      <path d="M1025.58,69.16a7.48,7.48,0,0,1-1.83-.25,3.74,3.74,0,0,1,0-.6,1.34,1.34,0,0,1,.63-.13,1.13,1.13,0,0,0-.7-.08,1.07,1.07,0,0,0-.12-.37c.39-.13,1.29-1,1.8-.73.24.14.34.94.36,1.34A1.34,1.34,0,0,1,1025.58,69.16Z" fill="none" stroke="#d33833" stroke-width="2"/>
-      <path d="M1022.33,68.05a.76.76,0,0,0,0,.15,8.13,8.13,0,0,1-.79.26,2.05,2.05,0,0,1,.85.21c0,.13,0,.26,0,.39a13.17,13.17,0,0,1-1.21.91,3,3,0,0,1-1.21.37c-.13,0-.14-.19-.19-.34a5,5,0,0,1-.39-1.34c0-.62-.09-1.66.58-1.53a5.73,5.73,0,0,1,1.59.58,1.6,1.6,0,0,0,.79.34" fill="#d33833"/>
-      <path d="M1022.33,68.05a.76.76,0,0,0,0,.15,8.13,8.13,0,0,1-.79.26,2.05,2.05,0,0,1,.85.21c0,.13,0,.26,0,.39a13.17,13.17,0,0,1-1.21.91,3,3,0,0,1-1.21.37c-.13,0-.14-.19-.19-.34a5,5,0,0,1-.39-1.34c0-.62-.09-1.66.58-1.53a5.73,5.73,0,0,1,1.59.58A1.6,1.6,0,0,0,1022.33,68.05Z" fill="none" stroke="#d33833" stroke-width="2"/>
-      <path d="M1022.71,68.79a2.5,2.5,0,0,1-.1-.73c.9-.6,1.07,1,.1.73" fill="#d33833"/>
-      <path d="M1022.71,68.79a2.5,2.5,0,0,1-.1-.73C1023.51,67.46,1023.68,69.09,1022.71,68.79Z" fill="none" stroke="#d33833" stroke-width="2"/>
-      <path d="M1024,69.06s-.28-.4-.08-.52.4,0,.52-.2,0-.32,0-.56.24-.28.44-.32.76-.12.84.08l-.24-.72-.48-.16-1.52.88-.08.44v.88" fill="#ef3d3a"/>
-      <path d="M1019.81,70.39l-.15-1.88c-.09-.93.22-.77,1-.77a2.15,2.15,0,0,1,.8.24c.22.45-.36.35.26.69s1.44-.18,1.23-.81c-.12-.14-.62,0-.79-.14l-.94-.48c-.4-.21-1.32-.51-1.75-.22-1.07.73.07,2.56.45,3.32" fill="#ef3d3a"/>
-      <path d="M1020.87,56.18a1.65,1.65,0,0,0-2,1.2c-.3-.07-.18-.47-.1-.68a1.85,1.85,0,0,1,1.62-1.16c.28.05.66.3.45.64" fill="#231f20"/>
-      <path d="M1026.19,57.43h0a11.88,11.88,0,0,0,.77,1.51c-.21.49-1.58.92-1.56,0,.3-.13.81,0,1.08-.19a2.82,2.82,0,0,1-.34-1.36" fill="#231f20"/>
-      <path d="M1021.43,57.44a4.64,4.64,0,0,0,.64,1.21c.15.14.44.32.3.73a1,1,0,0,1-.43.35c-.52.15-1.73,0-1.32-.62.43,0,1,.28,1.33,0-.25-.4-.69-1.18-.52-1.64" fill="#231f20"/>
-      <path d="M1026,61.81a4.32,4.32,0,0,1-2.94.92.88.88,0,0,1-.11-1.12c.14.24,0,.68.44.74.73.13,1.57-.44,2.1-.64.32-.55,0-.75-.32-1.1a4.39,4.39,0,0,1-1.38-2.7c.25-.18.27.26.3.35a9.76,9.76,0,0,0,1.68,2.29c.14.16.37.3.4.41.07.29-.2.65-.17.85" fill="#231f20"/>
-      <path d="M1015.66,61.28c-.24-.14-.3-.76-.59-.78s-.34.8-.34,1.29a1.52,1.52,0,0,1-.12-1.46c-.24-.12-.35.13-.48.21.17-1.23,1.8-.57,1.53.74" fill="#231f20"/>
-      <path d="M1026.49,62.32a2.25,2.25,0,0,1-2,1.48,2.71,2.71,0,0,1,0-.7,5.7,5.7,0,0,0,2-.78" fill="#231f20"/>
-      <path d="M1021.36,62.77a6.75,6.75,0,0,0,2.87.37,3.3,3.3,0,0,1,0,.7c-1.19.06-2.6-.23-2.92-1.07" fill="#231f20"/>
-      <path d="M1021.23,63.44c.48,1.18,2.1,1,3.47,1a.76.76,0,0,1-.36.41,3.53,3.53,0,0,1-2.25,0,3.11,3.11,0,0,1-.85-.94c-.1-.14-.61-.47,0-.47" fill="#231f20"/>
-      <path d="M1025.94,70a24.86,24.86,0,0,1-1.75,2.76,13,13,0,0,0,.44-3.2,1,1,0,0,1,1.31.44" fill="#81b0c4"/>
-      <path d="M1028.92,73.39c-.62.12-1.06.73-1.66.69a2,2,0,0,1,1.66-.69" fill="#231f20"/>
-      <path d="M1029.19,74.36a9.6,9.6,0,0,1-1.61.09c.24-.37,1.18-.24,1.61-.09" fill="#231f20"/>
-      <path d="M1029.37,75.2a18.18,18.18,0,0,1-1.82,0c.32-.34,1.45-.13,1.82,0" fill="#231f20"/>
-      <path d="M1024.87,77.49a13.94,13.94,0,0,1,.33,2.22,2.5,2.5,0,0,1-.92.19c0-.66-.12-1.68-.09-2.31.21,0,.51-.15.68-.1" fill="#dcd9d8"/>
-      <path d="M1024,67c-.28.19-.53.42-.8.62a1.81,1.81,0,0,1-1.39-.39s.06,0,.06,0c.65.29,1.47-.12,2.13-.18" fill="#f0d6b7"/>
-      <path d="M1020.54,71.4c.17-.77.88-1.17,1.51-1.6a12.71,12.71,0,0,1,1.5,2.94,14.83,14.83,0,0,1-3-1.34" fill="#81b0c4"/>
-      <path d="M1024.19,77.59c0,.63.06,1.65.09,2.31a2.5,2.5,0,0,0,.92-.19,13.94,13.94,0,0,0-.33-2.22C1024.7,77.44,1024.4,77.6,1024.19,77.59Zm-6.56-3.6a33.15,33.15,0,0,0,1.42,7,9.28,9.28,0,0,0,5.06.09c-.27-1.28-.15-2.83-.31-4.19-.11-1-.06-2-.22-3.1A17.49,17.49,0,0,0,1017.63,74Zm6.37-.22c0,1.09,0,2.18.13,3.27.42-.06.71-.1,1.1-.19a24.1,24.1,0,0,0-.37-3.18,2.81,2.81,0,0,0-.86.1Zm2.13-.18a3.21,3.21,0,0,0-.62,0c.09.9.31,1.88.39,2.82a2.39,2.39,0,0,0,.7-.18,5.55,5.55,0,0,0-.47-2.64Zm3.24,3a1.4,1.4,0,0,0,.84-1.71,8.21,8.21,0,0,0-.55-1.86c-.16-.25-.61-.58-1-.35-.58.37-1.61.48-2,.93a14.54,14.54,0,0,1,.37,2.58,7.8,7.8,0,0,1,2.23.06,9.05,9.05,0,0,0-1.34.34,2.75,2.75,0,0,0,1.46,0Zm-5.82-3.81a12.71,12.71,0,0,0-1.5-2.94c-.63.43-1.33.83-1.51,1.6a14.83,14.83,0,0,0,3,1.34Zm1.08-3.2a13,13,0,0,1-.44,3.2,24.86,24.86,0,0,0,1.75-2.76A1,1,0,0,0,1024.63,69.54Zm-1.23-.44c-.25,0-.46.29-.78.15-.08.08-.14.17-.22.25a18.84,18.84,0,0,1,1.59,3.1,13.64,13.64,0,0,0,.33-3.1C1023.91,69.53,1023.69,69.13,1023.4,69.1Zm-.79-1a2.5,2.5,0,0,0,.1.73c1,.3.8-1.33-.1-.73Zm-1.07-.35a5.73,5.73,0,0,0-1.59-.58c-.67-.13-.61.91-.58,1.53a5,5,0,0,0,.39,1.34c0,.15.06.31.19.34a3,3,0,0,0,1.21-.37,13.17,13.17,0,0,0,1.21-.91v-.39a2.05,2.05,0,0,0-.85-.21,8.13,8.13,0,0,0,.79-.26s0-.1,0-.15A1.6,1.6,0,0,1,1021.54,67.71Zm-4-.73c-.34.35,1,.83,1.4.86,0-.22.12-.43.1-.59-.5-.09-1.16,0-1.5-.27Zm4.28.17s-.05,0-.06,0a1.81,1.81,0,0,0,1.39.39c.27-.2.52-.43.8-.62-.66.06-1.48.47-2.13.18Zm3.92,1.19c0-.4-.12-1.2-.36-1.34-.51-.3-1.41.6-1.8.73a1.07,1.07,0,0,1,.12.37,1.13,1.13,0,0,1,.7.08,1.47,1.47,0,0,0-.63.13,3.74,3.74,0,0,0,0,.6,7.48,7.48,0,0,0,1.83.25A1.34,1.34,0,0,0,1025.74,68.34Zm-8.78-1c-.11-.08-.85-1-1-1a16.25,16.25,0,0,0-3.7,2.3,19.89,19.89,0,0,1,1.57,7.77c1.22.57,2.29,1.39,3.94,1.47-.19-1.35-.36-2.56-.47-3.83-.42-.17-1,0-1.4,0,0-.47.59-.21.64-.52s-.33-.26-.21-.63c.31.11.46.35.79.44.29-.65,0-1.79,0-2.33,0-.1,0-.57.28-.48s0,1.22,0,1.73a2.72,2.72,0,0,0,.13,1.23,45.48,45.48,0,0,1,4.94-.41,11.44,11.44,0,0,1-1.32-.59c-.27-.15-1.12-.47-1.19-.72-.13-.41.32-.63.4-1-.81.44-1-.43-1.16-1a7.71,7.71,0,0,1-.31-1.28,13.09,13.09,0,0,1-2-1.09Zm8.08-.88c1.11-.54,1.31,2,.87,2.84.07.24.3.34.4.56-.63,1.11-1.31,2.14-2,3.24.47-.29,1.15,0,1.7-.27.2-.08.35-.54.5-.91a19.49,19.49,0,0,0,1.06-3.28,3.8,3.8,0,0,0,.14-.91c0-.35-.53-.61-.77-.83-.45-.4-.73-.76-1.2-1.14-.19.28-.6.47-.75.7Zm-10.62-9.86a3.46,3.46,0,0,0-.36,2.45,1.43,1.43,0,0,1,2.22,1.08c.45,0,.17-.57.09-.93-.27-1.18.45-2.46,0-3.53a2.87,2.87,0,0,0-2,.93Zm3.79-3.38a5.34,5.34,0,0,0-3.23,2.29,9.6,9.6,0,0,1,1-.27,2.61,2.61,0,0,0,.49,0c.33-.08.6-.81.85-1.09s.53-.37.72-.62c.13-.06.32-.05.32-.24S1018.27,53.18,1018.21,53.2Zm6.24.32c-1.25-.7-3.35-1.23-4.68-.57a6.38,6.38,0,0,0-3,2.53c.46,1.08-.14,2.07-.18,3.16,0,.58.28,1.09.3,1.72-.16.26-.64.3-1,.28-.11-.56-.31-1.19-.89-1.26a1.35,1.35,0,0,0-1.45,1.3c0,.83.64,2.2,1.61,2.11.37,0,.46-.41.87-.41.22.44-.34.58-.4.89a3.31,3.31,0,0,0,.08.55,7.43,7.43,0,0,0,1,2.22c.49.7,1.45.81,2.48.87.18-.39.86-.36,1.31-.26a4.43,4.43,0,0,1-1.44-1.17,3,3,0,0,1-1-1.75,6.39,6.39,0,0,0,3.24,2.85,4.31,4.31,0,0,0,3.59-.85,4.05,4.05,0,0,0,.9-1.1,9.4,9.4,0,0,0,1.41-5.68,6.11,6.11,0,0,0-.33-2.27c-.3-.6-1.3-1.14-1.89-.59-.11-.59.49-1,1.19-.74A6.61,6.61,0,0,0,1024.45,53.52Zm2.31,19.19c1-.48,2.79-1.3,3.4,0a10.5,10.5,0,0,1,.61,1.79c.16.7-.18,2.17-.9,2.4a4.16,4.16,0,0,1-2.14,0,1.1,1.1,0,0,1-.26-.34,2.9,2.9,0,0,0-1.49.26c0,.4-.23.46-.49.55-.19.75.38,1.73.25,2.42-.1.49-.7.56-1.14.66a3.62,3.62,0,0,0,0,.73,1.09,1.09,0,0,1-1,.63,12.35,12.35,0,0,1-4.92-.24c-.38-.93-.68-2.06-1-3.13a6.44,6.44,0,0,1-3.41-1c-.35-.16-.83-.25-1-.53a4.52,4.52,0,0,1-.11-1.27,19.35,19.35,0,0,0-.48-3.73c-.14-.58-.4-1.08-.58-1.63a11,11,0,0,1-.53-1.66c-.12-.76.6-.8,1.05-1.13.71-.5,1.26-.78,2-1.24a4.71,4.71,0,0,0,1-.64c.15-.31-.27-.75-.38-1a2.81,2.81,0,0,1-.29-1.1,2.08,2.08,0,0,1-1.42-.91,3.48,3.48,0,0,1-.4-3c0-.08.19-.23.22-.35a3.82,3.82,0,0,0-.1-.81c-.05-1.3.22-2.42,1.09-2.81.36-1.42,1.63-1.89,2.83-2.59a9.44,9.44,0,0,1,1.45-.62,7.29,7.29,0,0,1,6.15.6,8.3,8.3,0,0,1,2,2.26c1,2,.9,5.25.23,7.64a9.68,9.68,0,0,1-.41,1.18c-.13.27-.53.8-.48,1s.91.9,1.09,1.08c.34.32,1,.75,1,1.16a4.09,4.09,0,0,1-.31,1.44c-.42,1.39-.82,2.68-1.29,3.92" fill="#231f20"/>
-      <path d="M1020.28,63.07c.05-.07.34-.17.75,0,0,0-.49.08-.45.88l-.2,0s-.2-.72-.1-.86" fill="#f7e4cd"/>
-      <path d="M1023.79,70a.22.22,0,1,1-.44,0,.22.22,0,0,1,.44,0h0" fill="#1d1919"/>
-      <path d="M1024,71a.22.22,0,1,1-.22-.22.22.22,0,0,1,.22.22h0" fill="#1d1919"/>
-    </g>
-    <path id="a91f0ca4-8fb7-4019-9c09-0a52e2c05754" d="M973,57.6V75.84L965.53,82l-11.61-4.23v4.19l-6.57-8.59,19.15,1.5V58.42Zm-6.39.92L955.89,52v4.29L946,59.17l-3,3.8v8.64l4.23,1.87V62.41Z" fill="url(#linear-gradient-33)"/>
-    <path d="M730.58,200.51a45.77,45.77,0,0,0-2-7.68,10.62,10.62,0,0,1-1.3,2.32A12.25,12.25,0,0,0,708,197.4a8.14,8.14,0,0,1,5,2.1,8.45,8.45,0,0,0-4.72-1.39,8.67,8.67,0,1,0,0,17.33h20a7.65,7.65,0,0,0,2.33-14.93Zm-18.66,12.25a1.06,1.06,0,0,1-1.48.16,1,1,0,1,1,1.48-.16Zm16.62-3.66c-3,4-9.48,2.66-13.62,2.86,0,0-.73,0-1.47.16,0,0,.28-.12.64-.24,2.9-1,4.28-1.21,6-2.12,3.31-1.7,6.62-5.4,7.29-9.25-1.26,3.7-5.11,6.89-8.6,8.18a58,58,0,0,1-6.73,1.75l-.18-.1c-2.94-1.43-3-7.81,2.32-9.86,2.35-.91,4.59-.41,7.13-1,2.7-.65,5.83-2.67,7.11-5.32C729.9,198.38,731.62,205,728.54,209.1Z" fill="#68bd45"/>
-    <path d="M796.53,200.51a47.79,47.79,0,0,0-2-7.68,11.08,11.08,0,0,1-1.31,2.32,12.25,12.25,0,0,0-19.29,2.25,8.15,8.15,0,0,1,5,2.1,8.51,8.51,0,0,0-4.73-1.39,8.67,8.67,0,1,0,0,17.33h20a7.65,7.65,0,0,0,2.33-14.93Zm-18.67,12.25a1,1,0,0,1-1.63-1.31,1.06,1.06,0,0,1,1.48-.16A1,1,0,0,1,777.86,212.76Zm16.63-3.66c-3,4-9.48,2.66-13.62,2.86,0,0-.74,0-1.47.16,0,0,.27-.12.63-.24,2.91-1,4.28-1.21,6.05-2.12,3.32-1.7,6.62-5.4,7.29-9.25-1.26,3.7-5.1,6.89-8.6,8.18a58,58,0,0,1-6.73,1.75l-.17-.1c-3-1.43-3-7.81,2.32-9.86,2.34-.91,4.59-.41,7.12-1,2.71-.65,5.84-2.67,7.11-5.32C795.85,198.38,797.56,205,794.49,209.1Z" fill="#68bd45"/>
-    <g>
-      <g>
-        <circle cx="752.14" cy="364.49" r="2.49"/>
-        <circle cx="759.65" cy="364.49" r="2.49"/>
-        <circle cx="767.16" cy="364.49" r="2.49"/>
-      </g>
-      <path d="M738.59,363.05l-5.26-9.12a3.2,3.2,0,0,0-2.49-1.44H720.3a3.2,3.2,0,0,0-2.49,1.44l-5.27,9.12a3.24,3.24,0,0,0,0,2.88l5.27,9.12a3.18,3.18,0,0,0,2.49,1.44h10.54a3.18,3.18,0,0,0,2.49-1.44l5.26-9.12A3.18,3.18,0,0,0,738.59,363.05Zm-14.16-5.51a1.09,1.09,0,1,1,2.17,0V364a1.09,1.09,0,1,1-2.17,0Zm1.09,13.84a7.36,7.36,0,0,1-4.39-13.26,1,1,0,1,1,1.15,1.54,5.44,5.44,0,1,0,6.45,0,1,1,0,1,1,1.15-1.55,7.35,7.35,0,0,1-4.36,13.28Z" fill="#68bd45"/>
-      <path d="M704.65,363.05l-5.26-9.12a3.2,3.2,0,0,0-2.49-1.44H686.36a3.2,3.2,0,0,0-2.49,1.44l-5.27,9.12a3.24,3.24,0,0,0,0,2.88l5.27,9.12a3.18,3.18,0,0,0,2.49,1.44H696.9a3.18,3.18,0,0,0,2.49-1.44l5.26-9.12A3.18,3.18,0,0,0,704.65,363.05Zm-14.16-5.51a1.09,1.09,0,1,1,2.17,0V364a1.09,1.09,0,1,1-2.17,0Zm1.09,13.84a7.36,7.36,0,0,1-4.39-13.26,1,1,0,1,1,1.15,1.54,5.44,5.44,0,1,0,6.45,0,1,1,0,1,1,1.15-1.55,7.35,7.35,0,0,1-4.36,13.28Z" fill="#68bd45"/>
-      <path d="M807.85,363.05l-5.27-9.12a3.2,3.2,0,0,0-2.49-1.44H789.56a3.21,3.21,0,0,0-2.5,1.44l-5.26,9.12a3.18,3.18,0,0,0,0,2.88l5.26,9.12a3.18,3.18,0,0,0,2.5,1.44h10.53a3.18,3.18,0,0,0,2.49-1.44l5.27-9.12A3.18,3.18,0,0,0,807.85,363.05Zm-14.17-5.51a1.09,1.09,0,0,1,2.18,0V364a1.09,1.09,0,0,1-2.18,0Zm1.09,13.84a7.36,7.36,0,0,1-4.39-13.26,1,1,0,1,1,1.15,1.54A5.43,5.43,0,1,0,800.2,364a5.47,5.47,0,0,0-2.21-4.37,1,1,0,0,1-.21-1.35,1,1,0,0,1,1.35-.2,7.35,7.35,0,0,1-4.36,13.28Z" fill="#68bd45"/>
-    </g>
-    <g>
-      <g>
-        <rect x="7.4" y="140.37" width="91" height="325.71" rx="4" fill="#fff"/>
-        <rect x="7.4" y="140.37" width="91" height="325.71" rx="4" fill="#505150" opacity="0.07"/>
-        <rect x="7.4" y="140.37" width="91" height="325.71" rx="4" fill="none" stroke="#505150" stroke-width="0.8" opacity="0.15"/>
-      </g>
-      <path d="M94.4,466.63h-.11v-1.1h.11a2.56,2.56,0,0,0,.62-.07l.14,1.08A3.22,3.22,0,0,1,94.4,466.63Zm-2.1,0h-.8v-1.1h.8Zm-2.8,0h-.8v-1.1h.8Zm-2.79,0h-.8v-1.1h.8Zm-2.8,0h-.79v-1.1h.79Zm-2.79,0h-.8v-1.1h.8Zm-2.79,0h-.8v-1.1h.8Zm-2.8,0h-.8v-1.1h.8Zm-2.79,0h-.8v-1.1h.8Zm-2.8,0h-.8v-1.1h.8Zm-2.79,0h-.8v-1.1h.8Zm-2.8,0h-.8v-1.1h.8Zm-2.79,0h-.8v-1.1h.8Zm-2.8,0H58v-1.1h.79Zm-2.79,0h-.8v-1.1H56Zm-2.79,0h-.8v-1.1h.8Zm-2.8,0h-.8v-1.1h.8Zm-2.79,0h-.8v-1.1h.8Zm-2.8,0H44v-1.1h.8Zm-2.79,0h-.8v-1.1H42Zm-2.8,0h-.79v-1.1h.79Zm-2.79,0h-.8v-1.1h.8Zm-2.79,0h-.8v-1.1h.8Zm-2.8,0H30v-1.1h.8Zm-2.79,0h-.8v-1.1H28Zm-2.8,0h-.8v-1.1h.8Zm-2.79,0h-.8v-1.1h.8Zm-2.8,0h-.79v-1.1h.79Zm-2.79,0h-.8v-1.1h.8Zm-2.79,0h-.8v-1.1h.8Zm-2.81,0a2.85,2.85,0,0,1-.87-.16l.18-1.06a3,3,0,0,0,.71.13Zm85.89-1.31-.5-.85a5.13,5.13,0,0,0,.51-.69l.61.71A6.64,6.64,0,0,1,97.14,465.31Zm-88.68-.23a5.5,5.5,0,0,1-.59-.89l.64-.65a4.51,4.51,0,0,0,.48.72Zm90.25-3.28-.78-.22a7.91,7.91,0,0,0,.07-1l.8-.07v.07A7.85,7.85,0,0,1,98.71,461.8ZM7,461.44a7.56,7.56,0,0,1,0-.83v-.34h.8v.34c0,.23,0,.45,0,.68Zm91.76-3.63H98v-1.09h.8Zm-91-.27H7v-1.09h.8Zm91-3.55H98v-1.1h.8Zm-91-.27H7v-1.09h.8Zm91-3.56H98v-1.09h.8Zm-91-.27H7V448.8h.8Zm91-3.55H98v-1.09h.8Zm-91-.27H7V445h.8Zm91-3.56H98v-1.09h.8Zm-91-.26H7v-1.1h.8Zm91-3.56H98V437.6h.8Zm-91-.27H7v-1.09h.8Zm91-3.55H98v-1.1h.8Zm-91-.27H7v-1.09h.8Zm91-3.56H98V430h.8Zm-91-.27H7v-1.09h.8Zm91-3.55H98v-1.09h.8ZM7.8,427H7v-1.09h.8Zm91-3.56H98V422.3h.8Zm-91-.26H7V422h.8Zm91-3.56H98v-1.09h.8Zm-91-.27H7v-1.09h.8Zm91-3.55H98v-1.1h.8Zm-91-.27H7v-1.09h.8Zm91-3.56H98v-1.09h.8Zm-91-.27H7v-1.09h.8Zm91-3.55H98V407h.8Zm-91-.27H7v-1.09h.8Zm91-3.56H98v-1.09h.8ZM7.8,404H7v-1.1h.8Zm91-3.56H98v-1.09h.8Zm-91-.27H7v-1.09h.8Zm91-3.55H98v-1.1h.8Zm-91-.27H7v-1.1h.8Zm91-3.56H98v-1.09h.8Zm-91-.27H7v-1.09h.8Zm91-3.55H98v-1.09h.8Zm-91-.27H7v-1.09h.8Zm91-3.56H98v-1.09h.8Zm-91-.26H7v-1.1h.8Zm91-3.56H98v-1.09h.8Zm-91-.27H7V380h.8Zm91-3.56H98v-1.09h.8Zm-91-.26H7v-1.1h.8Zm91-3.56H98v-1.09h.8Zm-91-.27H7v-1.09h.8Zm91-3.55H98v-1.1h.8Zm-91-.27H7V368.5h.8Zm91-3.56H98v-1.09h.8Zm-91-.26H7v-1.1h.8Zm91-3.56H98v-1.09h.8Zm-91-.27H7v-1.09h.8Zm91-3.56H98v-1.09h.8Zm-91-.26H7V357h.8Zm91-3.56H98v-1.09h.8Zm-91-.27H7V353.2h.8Zm91-3.55H98v-1.1h.8Zm-91-.27H7v-1.09h.8Zm91-3.56H98v-1.09h.8Zm-91-.27H7v-1.09h.8Zm91-3.55H98V342h.8Zm-91-.27H7v-1.09h.8Zm91-3.56H98v-1.09h.8ZM7.8,339H7v-1.1h.8Zm91-3.56H98v-1.09h.8Zm-91-.27H7v-1.09h.8Zm91-3.55H98v-1.1h.8Zm-91-.27H7v-1.09h.8Zm91-3.56H98V326.7h.8Zm-91-.27H7v-1.09h.8Zm91-3.55H98v-1.09h.8Zm-91-.27H7v-1.09h.8Zm91-3.56H98v-1.09h.8Zm-91-.26H7v-1.1h.8Zm91-3.56H98v-1.09h.8Zm-91-.27H7V315h.8Zm91-3.55H98v-1.1h.8Zm-91-.27H7v-1.09h.8Zm91-3.56H98v-1.09h.8Zm-91-.27H7v-1.09h.8Zm91-3.55H98v-1.09h.8Zm-91-.27H7v-1.09h.8Zm91-3.56H98v-1.09h.8Zm-91-.26H7v-1.1h.8Zm91-3.56H98v-1.09h.8Zm-91-.27H7v-1.09h.8Zm91-3.55H98v-1.1h.8Zm-91-.27H7V292h.8Zm91-3.56H98v-1.09h.8Zm-91-.27H7v-1.09h.8Zm91-3.55H98v-1.1h.8Zm-91-.27H7v-1.09h.8Zm91-3.56H98v-1.09h.8Zm-91-.26H7v-1.1h.8Zm91-3.56H98V277h.8Zm-91-.27H7v-1.09h.8Zm91-3.55H98v-1.1h.8ZM7.8,274H7v-1.1h.8Zm91-3.56H98v-1.09h.8Zm-91-.27H7v-1.09h.8Zm91-3.55H98v-1.1h.8Zm-91-.27H7v-1.09h.8Zm91-3.56H98v-1.09h.8Zm-91-.27H7v-1.09h.8Zm91-3.55H98v-1.09h.8Zm-91-.27H7V257.6h.8Zm91-3.56H98V254h.8Zm-91-.26H7v-1.1h.8Zm91-3.56H98v-1.09h.8ZM7.8,251H7V250h.8Zm91-3.55H98v-1.1h.8Zm-91-.27H7v-1.09h.8Zm91-3.56H98v-1.09h.8Zm-91-.27H7V242.3h.8Zm91-3.55H98v-1.09h.8Zm-91-.27H7v-1.09h.8Zm91-3.56H98v-1.09h.8Zm-91-.26H7v-1.1h.8Zm91-3.56H98V231.1h.8Zm-91-.27H7v-1.09h.8Zm91-3.55H98v-1.1h.8Zm-91-.27H7V227h.8Zm91-3.56H98v-1.09h.8Zm-91-.27H7v-1.09h.8Zm91-3.55H98v-1.09h.8Zm-91-.27H7v-1.09h.8Zm91-3.56H98V215.8h.8Zm-91-.26H7v-1.1h.8Zm91-3.56H98V212h.8Zm-91-.27H7v-1.09h.8Zm91-3.55H98v-1.1h.8ZM7.8,209H7v-1.09h.8Zm91-3.56H98v-1.09h.8Zm-91-.27H7v-1.09h.8Zm91-3.55H98v-1.09h.8Zm-91-.27H7v-1.09h.8Zm91-3.56H98v-1.09h.8Zm-91-.26H7v-1.1h.8Zm91-3.56H98v-1.09h.8Zm-91-.27H7v-1.09h.8Zm91-3.55H98V189h.8Zm-91-.27H7v-1.1h.8Zm91-3.56H98v-1.09h.8ZM7.8,186H7v-1.09h.8Zm91-3.55H98v-1.09h.8Zm-91-.27H7v-1.09h.8Zm91-3.56H98v-1.09h.8Zm-91-.26H7v-1.1h.8Zm91-3.56H98v-1.09h.8Zm-91-.27H7v-1.09h.8Zm91-3.56H98v-1.09h.8Zm-91-.26H7v-1.1h.8Zm91-3.56H98v-1.09h.8Zm-91-.27H7v-1.09h.8Zm91-3.55H98v-1.1h.8Zm-91-.27H7V162h.8Zm91-3.56H98v-1.09h.8Zm-91-.26H7v-1.1h.8Zm91-3.56H98v-1.09h.8Zm-91-.27H7v-1.09h.8Zm91-3.56H98v-1.09h.8Zm-91-.26H7v-1.1h.8Zm91-3.56H98V147h.8Zm-91-.27H7V146.7h.8Zm90-3.37a6.28,6.28,0,0,0-.27-.9l.7-.53a8,8,0,0,1,.34,1.11ZM8,144.19l-.75-.37a7.63,7.63,0,0,1,.37-1.08l.69.57A5.09,5.09,0,0,0,8,144.19Zm88.35-2.47a3.52,3.52,0,0,0-.64-.45l.3-1a4.15,4.15,0,0,1,.78.56ZM9.59,141.6l-.41-.95a4,4,0,0,1,.8-.5l.26,1A2.63,2.63,0,0,0,9.59,141.6Zm84.32-.68h-.8v-1.09h.8Zm-2.79,0h-.8v-1.09h.8Zm-2.8,0h-.79v-1.09h.79Zm-2.79,0h-.8v-1.09h.8Zm-2.79,0h-.8v-1.09h.8Zm-2.8,0h-.8v-1.09h.8Zm-2.79,0h-.8v-1.09h.8Zm-2.8,0h-.8v-1.09h.8Zm-2.79,0h-.8v-1.09h.8Zm-2.8,0H68v-1.09h.79Zm-2.79,0h-.8v-1.09H66Zm-2.79,0h-.8v-1.09h.8Zm-2.8,0h-.8v-1.09h.8Zm-2.79,0h-.8v-1.09h.8Zm-2.8,0H54v-1.09h.8Zm-2.79,0h-.8v-1.09H52Zm-2.8,0h-.79v-1.09h.79Zm-2.79,0h-.8v-1.09h.8Zm-2.79,0h-.8v-1.09h.8Zm-2.8,0H40v-1.09h.8Zm-2.79,0h-.8v-1.09H38Zm-2.8,0h-.8v-1.09h.8Zm-2.79,0h-.8v-1.09h.8Zm-2.8,0h-.8v-1.09h.8Zm-2.79,0h-.8v-1.09h.8Zm-2.8,0h-.79v-1.09h.79Zm-2.79,0h-.8v-1.09h.8Zm-2.79,0h-.8v-1.09h.8Zm-2.8,0h-.8v-1.09h.8Zm-2.79,0h-.8v-1.09h.8Z" fill="#505150" opacity="0.65"/>
-    </g>
-    <g>
-      <rect x="41.92" y="210.68" width="21.8" height="21.8" rx="1.01" transform="translate(-141.21 102.25) rotate(-45)" fill="url(#linear-gradient-34)"/>
-      <path d="M49.4,214l3.32-3.32a.16.16,0,0,1,.24,0L56.37,214a.16.16,0,0,1,0,.22.15.15,0,0,1-.15.06h-2a.18.18,0,0,0-.18.18h0v4.29a.16.16,0,0,1-.16.16H51.82a.17.17,0,0,1-.18-.14v-4.31a.18.18,0,0,0-.16-.18h-2a.17.17,0,0,1-.16-.19A.25.25,0,0,1,49.4,214Zm7,15.25L53,232.53a.16.16,0,0,1-.24,0l-3.32-3.32a.18.18,0,0,1,0-.25.16.16,0,0,1,.09,0h2a.18.18,0,0,0,.16-.18v-4.29a.16.16,0,0,1,.16-.16h2.08a.16.16,0,0,1,.16.16h0v4.29a.18.18,0,0,0,.18.18h1.94a.19.19,0,0,1,.25,0A.18.18,0,0,1,56.37,229.21Zm-10-4.38v-1.94a.2.2,0,0,0-.18-.18H41.91a.16.16,0,0,1-.17-.15v-2.07a.19.19,0,0,1,.17-.18H46.2a.17.17,0,0,0,.18-.15v-2a.16.16,0,0,1,.09-.21.17.17,0,0,1,.19.06L50,221.41a.16.16,0,0,1,0,.22h0L46.66,225a.16.16,0,0,1-.22,0A.17.17,0,0,1,46.38,224.83ZM59.3,218.2v2a.17.17,0,0,0,.18.15h4.29a.21.21,0,0,1,.18.18v2.07a.17.17,0,0,1-.18.15H59.48a.2.2,0,0,0-.18.18v1.94a.16.16,0,0,1-.13.19A.17.17,0,0,1,59,225l-3.32-3.37a.17.17,0,0,1,0-.23h0L59,218.05a.16.16,0,0,1,.22,0A.16.16,0,0,1,59.3,218.2Z" fill="#fff"/>
-    </g>
-    <g>
-      <path d="M20.64,448.57v23.32a.82.82,0,0,1-.81.84H6.77a.81.81,0,0,1-.83-.81V448.57a.83.83,0,0,1,.81-.84H19.8a.83.83,0,0,1,.84.81Z" fill="url(#linear-gradient-35)"/>
-      <path id="a1bc77ea-5288-41a0-8f9a-2d282cf54a86" d="M7.89,450.33h2.46a.21.21,0,0,1,.2.21v3.09a.2.2,0,0,1-.2.2H7.89a.23.23,0,0,1-.22-.2v-3.09A.23.23,0,0,1,7.89,450.33Zm4.21,0h2.38a.22.22,0,0,1,.21.21h0v3.09a.21.21,0,0,1-.21.2H12.1a.2.2,0,0,1-.21-.2h0v-3.09a.21.21,0,0,1,.21-.21Zm4.2,0h2.39a.23.23,0,0,1,.22.21v3.09a.23.23,0,0,1-.22.2H16.3a.2.2,0,0,1-.2-.2h0v-3.09a.21.21,0,0,1,.2-.21Zm-8.41,5.61h2.46a.2.2,0,0,1,.2.2v3.09a.22.22,0,0,1-.2.22H7.89a.22.22,0,0,1-.22-.22v-3.09A.23.23,0,0,1,7.89,455.94Zm4.21,0h2.38a.21.21,0,0,1,.21.2h0v3.09a.22.22,0,0,1-.21.22H12.1a.22.22,0,0,1-.21-.22v-3.09a.2.2,0,0,1,.21-.2Zm4.2,0h2.39a.23.23,0,0,1,.22.2v3.09a.22.22,0,0,1-.22.22H16.3a.22.22,0,0,1-.2-.22v-3.09a.2.2,0,0,1,.2-.2Zm-8.41,5.62h2.46a.2.2,0,0,1,.2.2h0v3.09a.21.21,0,0,1-.2.21H7.89a.23.23,0,0,1-.22-.21V461.7A.21.21,0,0,1,7.89,461.56Zm4.21,0h2.38a.2.2,0,0,1,.27.11v3.12a.21.21,0,0,1-.21.21H12.1a.21.21,0,0,1-.21-.21h0V461.7A.2.2,0,0,1,12.1,461.56Zm0,5.6h2.38a.21.21,0,0,1,.21.2h0V472a.21.21,0,0,1-.21.2H12.1a.2.2,0,0,1-.21-.2v-4.64A.2.2,0,0,1,12.1,467.16Zm4.2-5.6h2.39a.22.22,0,0,1,.22.2v3.09a.23.23,0,0,1-.22.21H16.3a.21.21,0,0,1-.2-.21h0V461.7A.19.19,0,0,1,16.3,461.56Z" fill="#f2f2f2"/>
-    </g>
-    <g>
-      <g>
-        <polygon points="56.17 325.97 69.71 334.75 83.49 325.93 85.21 327.95 69.71 337.93 54.44 327.95 56.17 325.97" fill="#74cfeb"/>
-        <polygon points="57.2 324.84 69.71 309.93 82.48 324.86 69.71 332.92 57.2 324.84" fill="#fff"/>
-        <polygon points="69.71 309.93 69.71 332.92 57.2 324.84 69.71 309.93" fill="#74cfeb"/>
-        <polygon points="69.71 309.93 69.71 332.92 82.48 324.86 69.71 309.93" fill="url(#linear-gradient-36)"/>
-        <polygon points="69.71 321.81 82.48 324.86 69.71 332.92 69.71 321.81" fill="#53b0de"/>
-        <polygon points="69.71 332.92 57.2 324.84 69.71 321.81 69.71 332.92" fill="#a5def3"/>
-        <polygon points="69.71 337.93 85.21 327.95 83.49 325.93 69.71 334.75 69.71 337.93" fill="url(#linear-gradient-37)"/>
-      </g>
-      <g>
-        <g>
-          <path d="M43.67,301.25a.84.84,0,0,1-.87.79H29.45a.84.84,0,0,1-.87-.79V279.6a.84.84,0,0,1,.87-.79H42.8a.84.84,0,0,1,.87.79Z" fill="url(#linear-gradient-38)"/>
-          <path d="M30.8,288.74a1.75,1.75,0,0,1,1.61-1.82H40a1.75,1.75,0,0,1,1.61,1.82h0A1.73,1.73,0,0,1,40,290.62H32.44a1.73,1.73,0,0,1-1.61-1.81Z" fill="#1e3465"/>
-          <path d="M30.8,283.37a1.73,1.73,0,0,1,1.61-1.81H40a1.73,1.73,0,0,1,1.61,1.81h0A1.73,1.73,0,0,1,40,285.18H32.44a1.73,1.73,0,0,1-1.61-1.81Z" fill="#1e3465"/>
-          <circle cx="32.91" cy="283.37" r="1.21" fill="#74cfeb"/>
-          <circle cx="32.91" cy="288.74" r="1.21" fill="#74cfeb"/>
-        </g>
-        <g>
-          <path d="M43.66,296.46c-2.94,0-5.4-.87-5.4-1.94v10.32c0,1.07,2.37,2,5.29,2h.11c3,0,5.37-.87,5.37-2V294.52C49,295.59,46.61,296.46,43.66,296.46Z" fill="url(#linear-gradient-39)"/>
-          <path d="M49,294.52c0,1.07-2.4,2-5.37,2s-5.36-.89-5.36-2,2.46-1.94,5.4-1.94,5.37.86,5.37,2" fill="#e8e8e8"/>
-          <path d="M47.74,294.36c0,.68-1.84,1.23-4.12,1.23s-4.11-.55-4.11-1.23,1.85-1.23,4.15-1.23,4.11.55,4.11,1.23" fill="#74cfeb"/>
-          <path d="M43.66,294.65a10,10,0,0,0-3.25.46,9.46,9.46,0,0,0,3.25.48,9.48,9.48,0,0,0,3.26-.48A10,10,0,0,0,43.66,294.65Z" fill="#1b8ab3"/>
-        </g>
-      </g>
-      <g>
-        <path d="M51.67,375.87a.86.86,0,0,1-.85.88H37a.87.87,0,0,1-.87-.87h0V351.2a.87.87,0,0,1,.85-.89H50.8a.87.87,0,0,1,.89.85v0Z" fill="url(#linear-gradient-40)"/>
-        <path d="M38.36,359.58A1.67,1.67,0,0,1,40,357.9h7.86a1.68,1.68,0,0,1,1.63,1.68h0a1.68,1.68,0,0,1-1.66,1.7H40.07a1.7,1.7,0,0,1-1.71-1.68Z" fill="#1e3465"/>
-        <path d="M38.36,354.57a1.7,1.7,0,0,1,1.69-1.7h7.84a1.67,1.67,0,0,1,1.63,1.69h0a1.68,1.68,0,0,1-1.68,1.68H40.07a1.67,1.67,0,0,1-1.71-1.65Z" fill="#1e3465"/>
-        <circle cx="40.18" cy="354.57" r="1.14" fill="#74cfeb"/>
-        <circle cx="40.18" cy="359.58" r="1.14" fill="#74cfeb"/>
-        <path d="M62.34,371.9a4.85,4.85,0,0,0-4.15-4.67A6.11,6.11,0,0,0,52,361.32a6.23,6.23,0,0,0-6,4.14,5.76,5.76,0,0,0-5,5.59,5.85,5.85,0,0,0,6,5.7H57.54A4.89,4.89,0,0,0,62.34,371.9Z" fill="url(#linear-gradient-41)"/>
-        <rect x="35.24" y="349.53" width="28" height="28" fill="none"/>
-      </g>
-    </g>
-    <path d="M1076.78,69.28a.61.61,0,0,1-.44-.19l-.93-.92a.63.63,0,0,1,0-.89.62.62,0,0,1,.88,0h0l.49.49,1.48-1.48a.63.63,0,0,1,.88,0,.64.64,0,0,1,0,.89h0l-1.92,1.91A.63.63,0,0,1,1076.78,69.28Zm11.69-.19,1.92-1.91a.63.63,0,0,0-.89-.89L1088,67.77l-.49-.49a.63.63,0,0,0-.9.87l0,0,.93.92a.62.62,0,0,0,.88,0Zm-19.76-7.79,3.19-2a1.26,1.26,0,0,0,.41-1.73,1.39,1.39,0,0,0-.4-.4l-3.19-2a1.26,1.26,0,0,0-1.73.39,1.3,1.3,0,0,0-.19.67v4a1.24,1.24,0,0,0,1.25,1.25A1.28,1.28,0,0,0,1068.71,61.3Zm2.54-3-3.2,2v-4Zm21.8,9.36a4.37,4.37,0,0,1-8.7.62h-2.6a4.37,4.37,0,0,1-8.65,0h-.7a4.35,4.35,0,0,1-3.1-1.3v6.3a3.75,3.75,0,0,0,3.75,3.75h0a4.38,4.38,0,1,1,0,1.25h0a5,5,0,0,1-5-5V64.36a6.28,6.28,0,1,1,1.31.12,3.1,3.1,0,0,0,3,2.5h.7a4.37,4.37,0,0,1,8.65,0h2.6a4.37,4.37,0,0,1,8.7.63Zm-18.75,10a3.13,3.13,0,1,0,3.12-3.13A3.12,3.12,0,0,0,1074.3,77.61Zm-5-14.38a5,5,0,1,0-5-5A5,5,0,0,0,1069.3,63.23Zm11.25,4.38a3.13,3.13,0,1,0-3.13,3.12A3.13,3.13,0,0,0,1080.55,67.61Zm11.25,0a3.13,3.13,0,1,0-3.13,3.12A3.13,3.13,0,0,0,1091.8,67.61Zm-16.25,10a.63.63,0,1,0,.62-.63A.62.62,0,0,0,1075.55,77.61Zm2.5,0a.63.63,0,1,0,.62-.63A.62.62,0,0,0,1078.05,77.61Zm15,0a4.37,4.37,0,0,1-8.7.62h0l-.63,0h0a.63.63,0,0,1,0-1.25l.63,0a.09.09,0,0,1,.07,0,4.37,4.37,0,0,1,8.7.61Zm-1.25,0a3.13,3.13,0,1,0-3.13,3.12A3.13,3.13,0,0,0,1091.8,77.61Z"/>
-    <g>
-      <path d="M972,358.59a.32.32,0,0,1-.3-.32h0a3.55,3.55,0,0,0-3.55-3.54.32.32,0,0,1-.32-.3h0a.32.32,0,0,1,.32-.32h0a3.55,3.55,0,0,0,3.55-3.55.31.31,0,0,1,.28-.35h0a.32.32,0,0,1,.32.32h0a3.54,3.54,0,0,0,3.54,3.54h0a.32.32,0,0,1,.32.32h0a.32.32,0,0,1-.32.3h0a3.55,3.55,0,0,0-3.54,3.55.32.32,0,0,1-.28.35Z" fill="#74cfeb"/>
-      <path d="M994.39,380.21a.25.25,0,0,1-.25-.25h0a2.86,2.86,0,0,0-2.86-2.86.24.24,0,0,1-.24-.24h0a.25.25,0,0,1,.24-.25h0a2.86,2.86,0,0,0,2.86-2.86.25.25,0,0,1,.25-.24h0a.24.24,0,0,1,.24.24h0a2.86,2.86,0,0,0,2.86,2.86h0a.25.25,0,1,1,0,.49h0a2.86,2.86,0,0,0-2.86,2.86h0a.25.25,0,0,1-.24.25Z" fill="#74cfeb"/>
-      <path d="M993.3,362.6a10.89,10.89,0,1,1-13.17-8,10.88,10.88,0,0,1,13.17,8Z" fill="url(#radial-gradient-8)"/>
-      <g clip-path="url(#clip-path)">
-        <g>
-          <path d="M976.83,372.51a2.91,2.91,0,1,0,0-5.81h0a1,1,0,0,0,0-.25,2.92,2.92,0,0,0-2.92-2.91h-2.18a11,11,0,0,0,.3,4,11.18,11.18,0,0,0,2.62,4.93Z" fill="#f2f2f3"/>
-          <path d="M993.3,363.1h0a10.55,10.55,0,0,0-2.5-5.11,2.76,2.76,0,0,0-.51-.16,3.2,3.2,0,0,0-4,2.17,4.27,4.27,0,0,0-.12.7h-.37a3.07,3.07,0,0,0-3,3.07,3,3,0,0,0,2,2.89,2.66,2.66,0,0,0,1,.2h3.55A22.82,22.82,0,0,0,993.3,363.1Z" fill="#f2f2f3"/>
-        </g>
-      </g>
-      <path d="M997.19,356c-1.12-1.86-3.73-2.57-7.36-2a30,30,0,0,0-3.62.8,12.18,12.18,0,0,1,2.72,1.37l1.27-.27a12.82,12.82,0,0,1,1.95-.16c1.78,0,3,.44,3.55,1.29h0c.67,1.12.1,3.07-1.56,5.32a32.67,32.67,0,0,1-18.92,11.17c-2.77.43-4.75,0-5.43-1.11s-.1-3.07,1.56-5.32c.22-.27.27-.41.5-.69a11.81,11.81,0,0,1,0-3,20,20,0,0,0-2.07,2.52c-2.2,2.95-2.8,5.59-1.68,7.43a5.61,5.61,0,0,0,5.14,2.22,14.5,14.5,0,0,0,2.28-.18,34.1,34.1,0,0,0,19.93-12C997.7,360.54,998.3,357.9,997.19,356Z" fill="#74cfeb"/>
-    </g>
-    <g>
-      <path d="M1064.41,400.3c-.08,0-.17.2-.17.31,0,.68,0,2.49,0,3.72,0,0,0,.11.1.11.26,0,.87,0,1.4,0a3.52,3.52,0,0,0,1.41-.21,1.81,1.81,0,0,0,.9-1.71c0-1.65-1.16-2.29-2.89-2.29a3.26,3.26,0,0,0-.72,0Zm4.42,7.64c0-1.69-1.25-2.63-3.51-2.63-.1,0-.82,0-1,0s-.12.06-.12.11c0,1.21,0,3.14,0,3.9a1.33,1.33,0,0,0,.57.92,4,4,0,0,0,1.49.2,2.33,2.33,0,0,0,2.53-2.51Zm-7.9-8.58c.17,0,.68.05,2,.05s2.24,0,3.45,0c1.49,0,3.54.53,3.54,2.76a2.68,2.68,0,0,1-1.78,2.39c-.05,0-.05.05,0,.07,1.44.36,2.7,1.25,2.7,2.92a3.58,3.58,0,0,1-2.51,3.34,8.23,8.23,0,0,1-3.18.53c-.87,0-3.21-.1-4.51-.07-.14-.05.12-.67.23-.77a3.1,3.1,0,0,0,.88-.14c.46-.12.51-.25.58-.95s0-2.72,0-4.23c0-2.07,0-3.47,0-4.15,0-.53-.2-.7-.58-.81l-1.16-.17c-.09-.08.2-.66.31-.73ZM1051.06,410a3.39,3.39,0,0,0,1.93.46,3.8,3.8,0,0,0,2.74-1,5.22,5.22,0,0,0,1.54-4.1A4.9,4.9,0,0,0,1055,401a6.07,6.07,0,0,0-3.22-.75,2.7,2.7,0,0,0-1,.11.53.53,0,0,0-.17.28c0,.34,0,3,0,4.51s0,3.82,0,4.07a1,1,0,0,0,.38.82Zm-3.88-10.63c.32,0,1.57.05,2.17.05,1.08,0,1.85-.05,3.88-.05a6.32,6.32,0,0,1,4.17,1.33,5.55,5.55,0,0,1,1.9,4.38,5.72,5.72,0,0,1-2.36,4.92,7.86,7.86,0,0,1-4.91,1.39c-1.16,0-3.16,0-4.82-.05h0c-.09-.16.13-.76.27-.77a2.6,2.6,0,0,0,.79-.16c.35-.13.42-.32.47-.95.06-1.18,0-2.6,0-4.21,0-1.15,0-3.39,0-4.1s-.31-.76-.82-.86c-.26,0-.6-.12-1.08-.17-.07-.12.24-.65.33-.75Z" fill="#8e714e" fill-rule="evenodd"/>
-      <path d="M1026.49,410.66a3.37,3.37,0,0,1-1.11-.29.59.59,0,0,1-.14-.27c0-.6,0-2.31,0-3.46a4.05,4.05,0,0,0-.55-2.29,2.34,2.34,0,0,0-2-1,4.54,4.54,0,0,0-2.59,1.24s-.16.13-.14-.06,0-.56,0-.82a.43.43,0,0,0-.12-.36,11.14,11.14,0,0,1-2.65.69c-.41.08-.51.48-.09.61h0a3.74,3.74,0,0,1,1,.45.53.53,0,0,1,.15.48c0,1.28,0,3.25,0,4.32,0,.43-.14.58-.44.65h0a6.24,6.24,0,0,1-.72.13,1,1,0,0,0,0,.77c.19,0,1.18-.05,2-.05,1.13,0,1.71.05,2,.05a1.1,1.1,0,0,0,.09-.77,2.8,2.8,0,0,1-.79-.12c-.31-.07-.39-.22-.41-.58,0-.9,0-2.82,0-4.12a.82.82,0,0,1,.2-.63,2.62,2.62,0,0,1,1.59-.58,1.77,1.77,0,0,1,1.18.39,1.66,1.66,0,0,1,.55,1.08c.09.73.05,2.19.05,3.45,0,.69-.05.86-.31.94a3.48,3.48,0,0,1-.78.16,1,1,0,0,0,0,.77c.49,0,1.07-.06,1.93-.06,1.06,0,1.74.06,2,.06a1.24,1.24,0,0,0,0-.74Zm4.73-6.53c-.9,0-1.47.7-1.47,1.79s.5,2.4,1.9,2.4a1.36,1.36,0,0,0,.89-.34,2.26,2.26,0,0,0,.55-1.58c0-1.42-.7-2.27-1.87-2.27Zm-.12,7.56a1.51,1.51,0,0,0-.73.18c-.72.47-1,.91-1,1.44a1.48,1.48,0,0,0,.6,1.23,3,3,0,0,0,2,.63c1.74,0,2.51-.94,2.51-1.86a1.31,1.31,0,0,0-1-1.32,7.09,7.09,0,0,0-2.4-.3Zm.12,4.44a3.75,3.75,0,0,1-2.44-.72,2.26,2.26,0,0,1-.91-1.69,1.3,1.3,0,0,1,.35-.85,8.31,8.31,0,0,1,1.57-1.27s0,0,0-.07a.09.09,0,0,0-.07-.08,1.65,1.65,0,0,1-1.11-1.08v0a.23.23,0,0,1,.1-.3c.12-.09.29-.19.48-.31a7.84,7.84,0,0,0,.79-.51.15.15,0,0,0,0-.11s0-.06-.07-.08a2.49,2.49,0,0,1-1.79-2.62,2.58,2.58,0,0,1,1.09-2.15,5,5,0,0,1,2.46-.84h.06a5.41,5.41,0,0,1,1.88.41,3.12,3.12,0,0,0,1.11.17,1.48,1.48,0,0,0,1.2-.44,1,1,0,0,1,.06.34,1.29,1.29,0,0,1-.22.79,1,1,0,0,1-.75.32H1035a2.81,2.81,0,0,1-.44-.07l-.07,0s0,.06,0,.12v0a5.31,5.31,0,0,1,.11.74,2.75,2.75,0,0,1-1.17,2.47,3.81,3.81,0,0,1-2,.77l-.24,0-.22,0h0c-.14,0-.48.2-.48.49s.15.57.89.62c.15,0,.3,0,.47,0a15,15,0,0,1,2.76.35,1.92,1.92,0,0,1,1.28,1.83,3.77,3.77,0,0,1-2.41,3.18,5.6,5.6,0,0,1-2.28.49Zm9.75-11.92a1.59,1.59,0,0,0-.92.26,2.64,2.64,0,0,0-1,2.43c0,2.24,1.13,3.81,2.73,3.81a1.75,1.75,0,0,0,1.18-.41,3,3,0,0,0,.76-2.38c0-2.22-1.11-3.71-2.74-3.71Zm.31,7.32c-2.91,0-4-2.14-4-4.14a3.7,3.7,0,0,1,1.69-3.25,5.21,5.21,0,0,1,2.62-.76,3.67,3.67,0,0,1,3.78,3.88,4,4,0,0,1-1.8,3.54,4.79,4.79,0,0,1-2.34.73Zm-30.47-7.32a1.62,1.62,0,0,0-.93.26,2.66,2.66,0,0,0-1,2.43c0,2.24,1.12,3.81,2.73,3.81a1.75,1.75,0,0,0,1.18-.41,3,3,0,0,0,.75-2.38c0-2.22-1.09-3.71-2.73-3.71Zm.31,7.32c-2.91,0-4-2.14-4-4.14a3.7,3.7,0,0,1,1.69-3.25,5.17,5.17,0,0,1,2.61-.76,3.66,3.66,0,0,1,3.78,3.88,4,4,0,0,1-1.79,3.54,4.69,4.69,0,0,1-2.34.73Zm-19.55-.17a.73.73,0,0,1-.05-.39.57.57,0,0,1,.05-.26,6.07,6.07,0,0,0,.75-.15c.35-.09.48-.28.5-.7,0-1,0-3,0-4.33v0a.52.52,0,0,0-.18-.48,4,4,0,0,0-1-.45c-.15-.05-.26-.13-.24-.24s.1-.22.32-.25a12.16,12.16,0,0,0,2.62-.67.38.38,0,0,1,.09.27l0,.19a6.19,6.19,0,0,0,0,.63.12.12,0,0,0,.13.12.17.17,0,0,0,.1,0,4.8,4.8,0,0,1,2.6-1.16,2.22,2.22,0,0,1,2,1.21.13.13,0,0,0,.12.07.14.14,0,0,0,.1,0,5.2,5.2,0,0,1,2.68-1.23c1.59,0,2.53,1.18,2.53,3.18,0,.56,0,1.3,0,2s0,1.15,0,1.54a.53.53,0,0,0,.31.41,3.66,3.66,0,0,0,1,.24h0a1.39,1.39,0,0,1-.11.65h-.42c-.33,0-.79,0-1.3,0-1.06,0-1.61,0-2.14.05a1.77,1.77,0,0,1,0-.65,5.41,5.41,0,0,0,.65-.15c.34-.1.43-.26.44-.7s.07-3.1,0-3.76a1.68,1.68,0,0,0-1.74-1.49,3.07,3.07,0,0,0-1.75.66.36.36,0,0,0-.07.18h0a7.77,7.77,0,0,1,.07,1.41V408c0,.77,0,1.48,0,2a.5.5,0,0,0,.41.53l.26.05.55.12a1,1,0,0,1,0,.48.3.3,0,0,1-.07.17c-.58,0-1.18,0-2,0l-1.08,0h-.77a.82.82,0,0,1,0-.34.52.52,0,0,1,.07-.31,1.75,1.75,0,0,1,.24,0l.55-.1c.29-.09.39-.24.41-.62a29.9,29.9,0,0,0,0-3.92,1.61,1.61,0,0,0-1.68-1.48,3.13,3.13,0,0,0-1.74.66.54.54,0,0,0-.15.4v1c0,1.23,0,2.77,0,3.43a.53.53,0,0,0,.48.53,3.62,3.62,0,0,0,.39.07l.31.05a1.33,1.33,0,0,1-.05.65h-.61c-.36,0-.83,0-1.34,0s-1,0-1.37,0a3.5,3.5,0,0,0-.63,0Z" fill="#442d22" fill-rule="evenodd"/>
-      <g>
-        <path d="M982.58,415.46l-.7-.23s.08-3.58-1.2-3.83c-.86-1,.14-42.07,3.21-.14a2.47,2.47,0,0,0-1.24,1.43,12.89,12.89,0,0,0-.07,2.77Z" fill="#fff" fill-rule="evenodd"/>
-        <path d="M982.58,415.46l-.7-.23s.08-3.58-1.2-3.83c-.86-1,.14-42.07,3.21-.14a2.47,2.47,0,0,0-1.24,1.43,12.89,12.89,0,0,0-.07,2.77Z" fill="#a6a385" fill-rule="evenodd"/>
-        <path d="M983,412a12.42,12.42,0,0,0,4.71-12.43c-1.39-6.11-4.66-8.11-5-8.88a7.94,7.94,0,0,1-.77-1.5l.25,17s-.53,5.2.82,5.83" fill="#fff" fill-rule="evenodd"/>
-        <path d="M983,412a12.42,12.42,0,0,0,4.71-12.43c-1.39-6.11-4.66-8.11-5-8.88a7.94,7.94,0,0,1-.77-1.5l.25,17s-.53,5.2.82,5.83" fill="#499d4a" fill-rule="evenodd"/>
-        <path d="M981.52,412.23s-5.77-3.93-5.42-10.86a14.57,14.57,0,0,1,5.18-10.94,1.58,1.58,0,0,0,.56-1.3c.36.77.29,11.51.34,12.77.16,4.88-.27,9.41-.66,10.33Z" fill="#fff" fill-rule="evenodd"/>
-        <path d="M981.52,412.23s-5.77-3.93-5.42-10.86a14.57,14.57,0,0,1,5.18-10.94,1.58,1.58,0,0,0,.56-1.3c.36.77.29,11.51.34,12.77.16,4.88-.27,9.41-.66,10.33Z" fill="#58aa50" fill-rule="evenodd"/>
-      </g>
-    </g>
-    <g>
-      <rect x="243.17" y="6.46" width="153.75" height="69.75" fill="#fff"/>
-      <rect x="243.17" y="6.46" width="153.75" height="69.75" fill="#83b9f9" opacity="0.15"/>
-      <path d="M396.79,6.58v69.5H243.29V6.58h153.5m.25-.25H243v70H397v-70Z" fill="#83b9f9"/>
-    </g>
-    <g>
-      <g>
-        <line x1="319.79" y1="140.16" x2="319.79" y2="86.02" fill="none" stroke="#207067" stroke-miterlimit="10" stroke-width="3"/>
-        <polygon points="319.79 76.49 325.27 89.92 319.79 86.73 314.3 89.92 319.79 76.49" fill="#207067"/>
-      </g>
-      <line x1="319.79" y1="140.16" x2="319.79" y2="86.02" fill="none" stroke="#42e8ca" stroke-miterlimit="10" stroke-width="1.5" stroke-dasharray="4 2"/>
-    </g>
-    <g>
-      <g>
-        <line x1="546.17" y1="218.81" x2="106.17" y2="218.81" fill="none" stroke="#59285f" stroke-miterlimit="10" stroke-width="3"/>
-        <polygon points="544.42 212.83 554.79 218.81 544.42 224.79 544.42 212.83" fill="#59285f"/>
-        <polygon points="107.92 212.83 97.56 218.81 107.92 224.79 107.92 212.83" fill="#59285f"/>
-      </g>
-      <g>
-        <line x1="546.17" y1="218.81" x2="545.67" y2="218.81" fill="none" stroke="#ce74b6" stroke-miterlimit="10" stroke-width="2"/>
-        <line x1="543.69" y1="218.81" x2="543.68" y2="218.81" fill="none" stroke="#ce74b6" stroke-miterlimit="10" stroke-width="2"/>
-        <line x1="543.68" y1="218.81" x2="106.67" y2="218.81" fill="none" stroke="#ce74b6" stroke-miterlimit="10" stroke-width="2" stroke-dasharray="1 1.99 0 0"/>
-        <line x1="106.67" y1="218.81" x2="106.17" y2="218.81" fill="none" stroke="#ce74b6" stroke-miterlimit="10" stroke-width="2"/>
-      </g>
-    </g>
-    <g>
-      <g>
-        <line x1="554.83" y1="240.81" x2="482.25" y2="240.81" fill="none" stroke="#207067" stroke-miterlimit="10" stroke-width="3"/>
-        <polygon points="472.72 240.81 486.15 235.32 482.96 240.81 486.15 246.3 472.72 240.81" fill="#207067"/>
-      </g>
-      <line x1="554.83" y1="240.81" x2="482.25" y2="240.81" fill="none" stroke="#42e8ca" stroke-miterlimit="10" stroke-width="1.5" stroke-dasharray="4 2"/>
-    </g>
-    <g opacity="0.7">
-      <rect x="334.83" y="153.93" width="117.54" height="124.1" fill="#fff"/>
-      <rect x="334.83" y="153.93" width="117.54" height="124.1" fill="#cccccb" opacity="0.9"/>
-    </g>
-    <g>
-      <rect x="382.7" y="207.13" width="21.8" height="21.8" rx="1.01" transform="translate(-38.89 342.18) rotate(-45)" fill="url(#Teal_Gradient-2)"/>
-      <path d="M390.17,210.4l3.32-3.32a.18.18,0,0,1,.25,0l3.41,3.32a.16.16,0,0,1,0,.22.17.17,0,0,1-.16.06h-2a.18.18,0,0,0-.17.18h0v4.29a.16.16,0,0,1-.16.16h-2.07a.16.16,0,0,1-.17-.14v-4.31a.18.18,0,0,0-.16-.18h-2a.17.17,0,0,1-.16-.19A.16.16,0,0,1,390.17,210.4Zm7,15.25L393.74,229a.18.18,0,0,1-.25,0l-3.32-3.32a.18.18,0,0,1,0-.24.15.15,0,0,1,.09,0h2a.18.18,0,0,0,.16-.18V220.9a.17.17,0,0,1,.15-.16h2.09a.16.16,0,0,1,.16.15h0v4.29a.18.18,0,0,0,.17.18h1.95a.17.17,0,0,1,.24,0A.16.16,0,0,1,397.15,225.65Zm-10-4.37v-1.95a.2.2,0,0,0-.18-.17h-4.29a.18.18,0,0,1-.18-.16v-2.07a.19.19,0,0,1,.18-.17H387a.18.18,0,0,0,.18-.16v-2a.17.17,0,0,1,.09-.21.16.16,0,0,1,.19.07l3.32,3.35a.17.17,0,0,1,0,.23h0l-3.32,3.32a.16.16,0,0,1-.22,0A.16.16,0,0,1,387.16,221.28Zm12.92-6.64v2a.17.17,0,0,0,.17.16h4.29a.18.18,0,0,1,.18.17V219a.18.18,0,0,1-.18.16h-4.29a.19.19,0,0,0-.17.17v1.95a.17.17,0,0,1-.13.18.14.14,0,0,1-.15-.06L396.48,218a.16.16,0,0,1,0-.23h0l3.32-3.3a.15.15,0,0,1,.22-.05A.17.17,0,0,1,400.08,214.64Z" fill="#fff"/>
-    </g>
-    <g opacity="0.7">
-      <rect x="194.93" y="153.93" width="117.54" height="124.1" fill="#fff"/>
-      <rect x="194.93" y="153.93" width="117.54" height="124.1" fill="#cccccb" opacity="0.9"/>
-    </g>
-    <g>
-      <path d="M270.25,220.14A7.46,7.46,0,0,0,263.8,213a9.39,9.39,0,0,0-9.66-9,9.63,9.63,0,0,0-9.2,6.27,8.89,8.89,0,0,0-7.8,8.54,9,9,0,0,0,9.33,8.66h16.31A7.54,7.54,0,0,0,270.25,220.14Z" fill="url(#linear-gradient-42)"/>
-      <path d="M263.43,222.08a.77.77,0,0,0-.77-.76H244.74a.77.77,0,0,0-.77.76v9.19a.77.77,0,0,0,.77.76h17.92a.77.77,0,0,0,.77-.76Z" fill="#821618"/>
-      <rect x="245.05" y="222.39" width="5.28" height="2.34" fill="#e52526"/>
-      <rect x="251.12" y="222.39" width="5.28" height="2.34" fill="#f27281"/>
-      <rect x="257.19" y="222.39" width="5.28" height="2.34" fill="#e52526"/>
-      <rect x="245.05" y="225.52" width="2.19" height="2.34" fill="#e52526"/>
-      <rect x="260.28" y="225.52" width="2.19" height="2.34" fill="#f27281"/>
-      <rect x="248.03" y="225.52" width="5.28" height="2.34" fill="#f27281"/>
-      <rect x="254.12" y="225.52" width="5.28" height="2.34" fill="#e52526"/>
-      <rect x="245.05" y="228.64" width="5.28" height="2.34" fill="#e52526"/>
-      <rect x="251.12" y="228.64" width="5.28" height="2.34" fill="#f27281"/>
-      <rect x="257.19" y="228.64" width="5.28" height="2.34" fill="#e52526"/>
-    </g>
-    <g>
-      <path d="M608.91,366l14-14a1,1,0,0,1,1.41,0l0,0,14,14a1,1,0,0,1,0,1.41l0,0-14,14a1,1,0,0,1-1.4,0l-14-14a1,1,0,0,1,0-1.41Z" fill="url(#Green_Gradient_2)"/>
-      <path d="M627.27,358.34l-3.53-3.51a.2.2,0,0,0-.27,0l-3.53,3.51a.17.17,0,0,0-.05.23.16.16,0,0,0,.18.07h2.07a.18.18,0,0,1,.18.19v3.33a.18.18,0,0,0,.19.18h2.2a.18.18,0,0,0,.18-.18v-3.33a.18.18,0,0,1,.18-.19h2.07a.16.16,0,0,0,.2-.12A.16.16,0,0,0,627.27,358.34Z" fill="#b6d43a"/>
-      <path d="M615.27,362.69l-3.5,3.55a.2.2,0,0,0,0,.25l3.5,3.52a.19.19,0,0,0,.26,0,.17.17,0,0,0,.06-.14v-2.05a.18.18,0,0,1,.18-.18h3.34a.16.16,0,0,0,.16-.17h0v-2.2a.17.17,0,0,0,0-.23l-.06,0h-3.34a.17.17,0,0,1-.18-.15v-2a.2.2,0,0,0-.12-.25A.21.21,0,0,0,615.27,362.69Z" fill="#b6d43a"/>
-      <path d="M632.07,370l3.55-3.54a.18.18,0,0,0,0-.25l-3.55-3.53a.19.19,0,0,0-.26,0,.18.18,0,0,0,0,.1v2.09a.16.16,0,0,1-.16.16h-3.36a.17.17,0,0,0-.16.17v2.22a.17.17,0,0,0,.15.18h3.35a.18.18,0,0,1,.18.18v2.07a.19.19,0,0,0,.21.16Z" fill="#b6d43a"/>
-      <path d="M628.25,366.67a4.65,4.65,0,1,0-5.89,4.45v1.59a2.86,2.86,0,1,0,2.61,0V371A4.61,4.61,0,0,0,628.25,366.67Z" fill="#fff"/>
-      <circle id="e99c3387-15c3-4f28-bd4b-cb209b430e06-2" data-name="e99c3387-15c3-4f28-bd4b-cb209b430e06" cx="623.62" cy="366.66" r="2.7" fill="#699cd3"/>
-    </g>
-  </g>
-  <g id="Text">
-    <g>
-      <path d="M191.83,489.89h-1.12v-4c0-1.46-.54-2.19-1.63-2.19a1.79,1.79,0,0,0-1.38.63,2.37,2.37,0,0,0-.56,1.63v4H186V479.53h1.12v4.52h0a2.55,2.55,0,0,1,2.3-1.32c1.57,0,2.36.95,2.36,2.85Z" fill="#2f2f2f"/>
-      <path d="M199.55,489.89h-1.13v-1.11h0a2.31,2.31,0,0,1-2.16,1.27c-1.67,0-2.5-1-2.5-3v-4.18h1.11v4c0,1.47.56,2.21,1.69,2.21a1.71,1.71,0,0,0,1.35-.6,2.3,2.3,0,0,0,.53-1.59v-4h1.13Z" fill="#2f2f2f"/>
-      <path d="M202.8,488.88h0v1h-1.12V479.53h1.12v4.59h0a2.65,2.65,0,0,1,2.42-1.39,2.56,2.56,0,0,1,2.11.94,3.85,3.85,0,0,1,.76,2.52,4.34,4.34,0,0,1-.85,2.81,2.86,2.86,0,0,1-2.34,1.05A2.31,2.31,0,0,1,202.8,488.88Zm0-2.82v1a2.09,2.09,0,0,0,.57,1.48,1.86,1.86,0,0,0,1.43.6,1.89,1.89,0,0,0,1.6-.78,3.61,3.61,0,0,0,.57-2.17,2.83,2.83,0,0,0-.54-1.83,1.78,1.78,0,0,0-1.46-.66,2,2,0,0,0-1.57.68A2.48,2.48,0,0,0,202.77,486.06Z" fill="#2f2f2f"/>
-      <path d="M213.49,486.43h-3.73v-.88h3.73Z" fill="#2f2f2f"/>
-      <path d="M220.86,482.89l-2.79,7H217l-2.66-7h1.23l1.78,5.09a4.63,4.63,0,0,1,.25,1h0a4.42,4.42,0,0,1,.21-.95l1.86-5.11Z" fill="#2f2f2f"/>
-      <path d="M222.67,481.11a.73.73,0,0,1-.51-.2.7.7,0,0,1-.21-.52.69.69,0,0,1,.21-.52.74.74,0,0,1,1,0,.66.66,0,0,1,.22.52.67.67,0,0,1-.22.51A.7.7,0,0,1,222.67,481.11Zm.55,8.78H222.1v-7h1.12Z" fill="#2f2f2f"/>
-      <path d="M229,484a1.39,1.39,0,0,0-.85-.22,1.41,1.41,0,0,0-1.2.68,3.12,3.12,0,0,0-.48,1.84v3.57h-1.12v-7h1.12v1.44h0a2.47,2.47,0,0,1,.74-1.15,1.62,1.62,0,0,1,1.1-.41,2,2,0,0,1,.67.09Z" fill="#2f2f2f"/>
-      <path d="M233.91,489.82a2.15,2.15,0,0,1-1,.22c-1.23,0-1.84-.68-1.84-2.05v-4.14h-1.2v-1H231v-1.71l1.12-.36v2.07h1.77v1h-1.77v3.94a1.65,1.65,0,0,0,.24,1,1,1,0,0,0,.79.3,1.17,1.17,0,0,0,.74-.24Z" fill="#2f2f2f"/>
-      <path d="M241,489.89H239.9v-1.11h0a2.31,2.31,0,0,1-2.17,1.27c-1.66,0-2.5-1-2.5-3v-4.18h1.12v4c0,1.47.56,2.21,1.69,2.21a1.71,1.71,0,0,0,1.35-.6,2.3,2.3,0,0,0,.53-1.59v-4H241Z" fill="#2f2f2f"/>
-      <path d="M248.18,489.89h-1.12V488.8h0a2.35,2.35,0,0,1-2.15,1.25,2.29,2.29,0,0,1-1.64-.55,1.94,1.94,0,0,1-.59-1.47q0-2,2.31-2.28l2.1-.3c0-1.19-.48-1.78-1.44-1.78a3.47,3.47,0,0,0-2.29.86v-1.15a4.32,4.32,0,0,1,2.38-.65c1.65,0,2.47.87,2.47,2.61Zm-1.12-3.54-1.69.23a2.67,2.67,0,0,0-1.18.39,1.11,1.11,0,0,0-.39,1,1.09,1.09,0,0,0,.36.84,1.46,1.46,0,0,0,1,.32,1.78,1.78,0,0,0,1.37-.58,2.07,2.07,0,0,0,.55-1.48Z" fill="#2f2f2f"/>
-      <path d="M251.32,489.89H250.2V479.53h1.12Z" fill="#2f2f2f"/>
-      <path d="M257,486.43h-3.74v-.88H257Z" fill="#2f2f2f"/>
-      <path d="M264.75,489.89h-1.12v-4c0-1.49-.55-2.23-1.63-2.23a1.76,1.76,0,0,0-1.39.63,2.34,2.34,0,0,0-.55,1.6v4h-1.12v-7h1.12v1.16h0a2.54,2.54,0,0,1,2.3-1.32,2.13,2.13,0,0,1,1.76.74,3.33,3.33,0,0,1,.61,2.14Z" fill="#2f2f2f"/>
-      <path d="M272.45,486.67h-4.94a2.56,2.56,0,0,0,.63,1.81,2.17,2.17,0,0,0,1.65.63,3.42,3.42,0,0,0,2.17-.78v1.05a4,4,0,0,1-2.44.67,3,3,0,0,1-2.33-.95,3.93,3.93,0,0,1-.85-2.68,3.84,3.84,0,0,1,.93-2.67,3,3,0,0,1,2.3-1,2.63,2.63,0,0,1,2.13.88,3.74,3.74,0,0,1,.75,2.47Zm-1.15-.95a2.24,2.24,0,0,0-.47-1.51,1.59,1.59,0,0,0-1.28-.54,1.81,1.81,0,0,0-1.35.57,2.58,2.58,0,0,0-.68,1.48Z" fill="#2f2f2f"/>
-      <path d="M277.37,489.82a2.09,2.09,0,0,1-1,.22c-1.23,0-1.84-.68-1.84-2.05v-4.14h-1.2v-1h1.2v-1.71l1.12-.36v2.07h1.76v1h-1.76v3.94a1.65,1.65,0,0,0,.24,1,1,1,0,0,0,.79.3,1.14,1.14,0,0,0,.73-.24Z" fill="#2f2f2f"/>
-      <path d="M288.06,482.89l-2.1,7H284.8l-1.44-5a3.82,3.82,0,0,1-.11-.65h0a3,3,0,0,1-.14.64l-1.57,5h-1.12l-2.12-7h1.18l1.45,5.26a3,3,0,0,1,.1.63h.05a2.65,2.65,0,0,1,.12-.64l1.62-5.25h1l1.45,5.28a3.2,3.2,0,0,1,.1.63h.06a3.49,3.49,0,0,1,.11-.63l1.43-5.28Z" fill="#2f2f2f"/>
-      <path d="M292.14,490.05a3.22,3.22,0,0,1-2.48-1,3.62,3.62,0,0,1-.93-2.6,3.79,3.79,0,0,1,1-2.75,3.46,3.46,0,0,1,2.6-1,3.16,3.16,0,0,1,2.45,1,3.84,3.84,0,0,1,.88,2.67,3.79,3.79,0,0,1-.95,2.69A3.32,3.32,0,0,1,292.14,490.05Zm.08-6.38a2.13,2.13,0,0,0-1.71.73,3,3,0,0,0-.63,2,2.82,2.82,0,0,0,.64,2,2.15,2.15,0,0,0,1.7.72,2,2,0,0,0,1.67-.7,3.74,3.74,0,0,0,0-4A2,2,0,0,0,292.22,483.67Z" fill="#2f2f2f"/>
-      <path d="M301,484a1.39,1.39,0,0,0-.85-.22,1.42,1.42,0,0,0-1.2.68,3.12,3.12,0,0,0-.48,1.84v3.57h-1.12v-7h1.12v1.44h0a2.46,2.46,0,0,1,.73-1.15,1.65,1.65,0,0,1,1.1-.41,1.92,1.92,0,0,1,.67.09Z" fill="#2f2f2f"/>
-      <path d="M308,489.89h-1.57l-3.09-3.36h0v3.36h-1.13V479.53h1.13v6.57h0l2.94-3.21h1.47l-3.25,3.38Z" fill="#2f2f2f"/>
-    </g>
-    <g>
-      <path d="M566,489.64v-1.21a3.25,3.25,0,0,0,2,.68c1,0,1.48-.33,1.48-1a.82.82,0,0,0-.13-.48,1.22,1.22,0,0,0-.34-.34,2.43,2.43,0,0,0-.51-.27l-.62-.25c-.31-.13-.58-.25-.82-.38a2.4,2.4,0,0,1-.59-.42,1.73,1.73,0,0,1-.35-.54,1.86,1.86,0,0,1-.12-.7,1.66,1.66,0,0,1,.22-.87,2,2,0,0,1,.61-.64,2.63,2.63,0,0,1,.85-.38,3.71,3.71,0,0,1,1-.13,4.05,4.05,0,0,1,1.63.31v1.14a3.17,3.17,0,0,0-1.78-.51,2,2,0,0,0-.57.07,1.56,1.56,0,0,0-.43.2.91.91,0,0,0-.28.31.79.79,0,0,0-.1.4.9.9,0,0,0,.1.46,1,1,0,0,0,.29.33,2,2,0,0,0,.46.26l.62.25a8.42,8.42,0,0,1,.84.37,2.88,2.88,0,0,1,.63.42,1.81,1.81,0,0,1,.4.55,1.92,1.92,0,0,1-.09,1.63,2.19,2.19,0,0,1-.61.64,3,3,0,0,1-.89.37,4.42,4.42,0,0,1-1,.12A3.91,3.91,0,0,1,566,489.64Z" fill="#2f2f2f"/>
-      <path d="M573.33,488.88h0v4.23h-1.12V482.89h1.12v1.23h0a2.65,2.65,0,0,1,2.42-1.39,2.54,2.54,0,0,1,2.11.94,3.85,3.85,0,0,1,.76,2.52,4.4,4.4,0,0,1-.85,2.81,2.86,2.86,0,0,1-2.34,1.05A2.34,2.34,0,0,1,573.33,488.88Zm0-2.82v1a2.09,2.09,0,0,0,.57,1.48,2,2,0,0,0,3-.18,3.54,3.54,0,0,0,.58-2.17,2.83,2.83,0,0,0-.54-1.83,1.79,1.79,0,0,0-1.46-.66,2,2,0,0,0-1.57.68A2.48,2.48,0,0,0,573.3,486.06Z" fill="#2f2f2f"/>
-      <path d="M583.33,490.05a3.21,3.21,0,0,1-2.48-1,3.62,3.62,0,0,1-.93-2.6,3.79,3.79,0,0,1,1-2.75,3.5,3.5,0,0,1,2.61-1,3.13,3.13,0,0,1,2.44,1,4.4,4.4,0,0,1-.06,5.36A3.34,3.34,0,0,1,583.33,490.05Zm.08-6.38a2.13,2.13,0,0,0-1.71.73,3,3,0,0,0-.63,2,2.82,2.82,0,0,0,.64,2,2.15,2.15,0,0,0,1.7.72,2,2,0,0,0,1.67-.7,3.79,3.79,0,0,0,0-4A2.06,2.06,0,0,0,583.41,483.67Z" fill="#2f2f2f"/>
-      <path d="M594.34,489.89h-1.57l-3.09-3.36h0v3.36h-1.12V479.53h1.12v6.57h0l2.94-3.21h1.46l-3.24,3.38Z" fill="#2f2f2f"/>
-      <path d="M600.76,486.67h-4.94a2.66,2.66,0,0,0,.63,1.81,2.17,2.17,0,0,0,1.65.63,3.45,3.45,0,0,0,2.18-.78v1.05a4.05,4.05,0,0,1-2.44.67,2.93,2.93,0,0,1-2.33-.95,4.49,4.49,0,0,1,.07-5.35,3,3,0,0,1,2.3-1,2.63,2.63,0,0,1,2.13.88,3.74,3.74,0,0,1,.75,2.47Zm-1.15-.95a2.29,2.29,0,0,0-.46-1.51,1.61,1.61,0,0,0-1.29-.54,1.79,1.79,0,0,0-1.34.57,2.59,2.59,0,0,0-.69,1.48Z" fill="#2f2f2f"/>
-      <path d="M606.11,486.43h-3.73v-.88h3.73Z" fill="#2f2f2f"/>
-      <path d="M613.47,482.89l-2.79,7h-1.1l-2.65-7h1.23l1.78,5.09a4.53,4.53,0,0,1,.24,1h0a5.1,5.1,0,0,1,.22-.95l1.86-5.11Z" fill="#2f2f2f"/>
-      <path d="M615.29,481.11a.77.77,0,0,1-.52-.2.7.7,0,0,1-.21-.52.69.69,0,0,1,.21-.52.73.73,0,0,1,.52-.21.72.72,0,0,1,.52.21.69.69,0,0,1,.22.52.7.7,0,0,1-.22.51A.72.72,0,0,1,615.29,481.11Zm.54,8.78h-1.12v-7h1.12Z" fill="#2f2f2f"/>
-      <path d="M621.6,484a1.34,1.34,0,0,0-.84-.22,1.41,1.41,0,0,0-1.2.68,3,3,0,0,0-.49,1.84v3.57H618v-7h1.12v1.44h0a2.46,2.46,0,0,1,.73-1.15,1.65,1.65,0,0,1,1.1-.41,1.92,1.92,0,0,1,.67.09Z" fill="#2f2f2f"/>
-      <path d="M626.52,489.82a2.09,2.09,0,0,1-1,.22c-1.23,0-1.84-.68-1.84-2.05v-4.14h-1.21v-1h1.21v-1.71l1.12-.36v2.07h1.76v1h-1.76v3.94a1.65,1.65,0,0,0,.24,1,1,1,0,0,0,.79.3,1.14,1.14,0,0,0,.73-.24Z" fill="#2f2f2f"/>
-      <path d="M633.64,489.89h-1.12v-1.11h0a2.29,2.29,0,0,1-2.16,1.27c-1.67,0-2.5-1-2.5-3v-4.18h1.11v4c0,1.47.57,2.21,1.7,2.21a1.71,1.71,0,0,0,1.35-.6,2.35,2.35,0,0,0,.53-1.59v-4h1.12Z" fill="#2f2f2f"/>
-      <path d="M640.8,489.89h-1.13V488.8h0a2.37,2.37,0,0,1-2.16,1.25,2.28,2.28,0,0,1-1.63-.55,1.9,1.9,0,0,1-.59-1.47q0-2,2.31-2.28l2.09-.3c0-1.19-.48-1.78-1.44-1.78a3.47,3.47,0,0,0-2.28.86v-1.15a4.32,4.32,0,0,1,2.38-.65c1.64,0,2.47.87,2.47,2.61Zm-1.13-3.54-1.68.23a2.63,2.63,0,0,0-1.18.39,1.12,1.12,0,0,0-.4,1,1.1,1.1,0,0,0,.37.84,1.44,1.44,0,0,0,1,.32,1.79,1.79,0,0,0,1.38-.58,2.11,2.11,0,0,0,.54-1.48Z" fill="#2f2f2f"/>
-      <path d="M643.94,489.89h-1.12V479.53h1.12Z" fill="#2f2f2f"/>
-      <path d="M649.64,486.43h-3.73v-.88h3.73Z" fill="#2f2f2f"/>
-      <path d="M657.36,489.89h-1.12v-4c0-1.49-.54-2.23-1.63-2.23a1.77,1.77,0,0,0-1.39.63,2.39,2.39,0,0,0-.55,1.6v4h-1.12v-7h1.12v1.16h0a2.53,2.53,0,0,1,2.3-1.32,2.11,2.11,0,0,1,1.75.74,3.27,3.27,0,0,1,.61,2.14Z" fill="#2f2f2f"/>
-      <path d="M665.07,486.67h-5a2.66,2.66,0,0,0,.63,1.81,2.18,2.18,0,0,0,1.66.63,3.44,3.44,0,0,0,2.17-.78v1.05a4.05,4.05,0,0,1-2.44.67,2.93,2.93,0,0,1-2.33-.95,3.88,3.88,0,0,1-.85-2.68,3.84,3.84,0,0,1,.93-2.67,3,3,0,0,1,2.3-1,2.63,2.63,0,0,1,2.12.88,3.74,3.74,0,0,1,.76,2.47Zm-1.15-.95a2.29,2.29,0,0,0-.47-1.51,1.6,1.6,0,0,0-1.28-.54,1.81,1.81,0,0,0-1.35.57,2.52,2.52,0,0,0-.68,1.48Z" fill="#2f2f2f"/>
-      <path d="M670,489.82a2.1,2.1,0,0,1-1,.22c-1.22,0-1.84-.68-1.84-2.05v-4.14h-1.2v-1h1.2v-1.71l1.13-.36v2.07H670v1h-1.76v3.94a1.73,1.73,0,0,0,.23,1,1,1,0,0,0,.8.3,1.16,1.16,0,0,0,.73-.24Z" fill="#2f2f2f"/>
-      <path d="M680.68,482.89l-2.1,7h-1.16l-1.44-5a3,3,0,0,1-.11-.65h0a3,3,0,0,1-.14.64l-1.57,5H673l-2.12-7h1.18l1.45,5.26a3.93,3.93,0,0,1,.09.63h.06a2.65,2.65,0,0,1,.12-.64l1.61-5.25h1l1.45,5.28a4.17,4.17,0,0,1,.1.63H678a2.32,2.32,0,0,1,.11-.63l1.42-5.28Z" fill="#2f2f2f"/>
-      <path d="M684.75,490.05a3.2,3.2,0,0,1-2.47-1,3.62,3.62,0,0,1-.93-2.6,3.79,3.79,0,0,1,1-2.75,3.5,3.5,0,0,1,2.61-1,3.13,3.13,0,0,1,2.44,1,3.79,3.79,0,0,1,.88,2.67,3.75,3.75,0,0,1-1,2.69A3.31,3.31,0,0,1,684.75,490.05Zm.09-6.38a2.13,2.13,0,0,0-1.71.73,3,3,0,0,0-.63,2,2.87,2.87,0,0,0,.63,2,2.18,2.18,0,0,0,1.71.72,2,2,0,0,0,1.67-.7,3.79,3.79,0,0,0,0-4A2.06,2.06,0,0,0,684.84,483.67Z" fill="#2f2f2f"/>
-      <path d="M693.61,484a1.39,1.39,0,0,0-.85-.22,1.41,1.41,0,0,0-1.2.68,3.12,3.12,0,0,0-.48,1.84v3.57H690v-7h1.12v1.44h0a2.38,2.38,0,0,1,.73-1.15,1.64,1.64,0,0,1,1.1-.41,2,2,0,0,1,.67.09Z" fill="#2f2f2f"/>
-      <path d="M700.66,489.89h-1.57L696,486.53h0v3.36h-1.12V479.53H696v6.57h0l2.94-3.21h1.47l-3.25,3.38Z" fill="#2f2f2f"/>
-    </g>
-    <g>
-      <path d="M433,101.69l-3.63,9.8h-1.27l-3.55-9.8h1.28l2.71,7.77a4.66,4.66,0,0,1,.2.87h0a4,4,0,0,1,.22-.88l2.77-7.76Z" fill="#2f2f2f"/>
-      <path d="M442.22,111.49h-1.41l-5-7.81a3,3,0,0,1-.31-.62h0a9.25,9.25,0,0,1,.06,1.35v7.08h-1.15v-9.8h1.49l4.91,7.69c.2.32.34.54.4.65h0a11.18,11.18,0,0,1-.07-1.44v-6.9h1.15Z" fill="#2f2f2f"/>
-      <path d="M450.2,108.27h-4.94a2.66,2.66,0,0,0,.63,1.81,2.17,2.17,0,0,0,1.65.63,3.45,3.45,0,0,0,2.18-.78v1a4.05,4.05,0,0,1-2.44.67,3,3,0,0,1-2.34-1,3.91,3.91,0,0,1-.84-2.68,3.84,3.84,0,0,1,.92-2.66,3,3,0,0,1,2.3-1,2.61,2.61,0,0,1,2.13.89,3.69,3.69,0,0,1,.75,2.46Zm-1.15-1a2.24,2.24,0,0,0-.47-1.51,1.58,1.58,0,0,0-1.28-.54,1.79,1.79,0,0,0-1.34.57,2.59,2.59,0,0,0-.69,1.48Z" fill="#2f2f2f"/>
-      <path d="M455.13,111.42a2.15,2.15,0,0,1-1.05.22c-1.23,0-1.84-.68-1.84-2v-4.14H451v-1h1.2v-1.71l1.12-.36v2.07h1.77v1h-1.77v3.94a1.65,1.65,0,0,0,.24,1,1,1,0,0,0,.79.3,1.23,1.23,0,0,0,.74-.23Z" fill="#2f2f2f"/>
-      <path d="M436.48,128.29h-1.12V117.93h1.12Z" fill="#2f2f2f"/>
-      <path d="M439.17,119.51a.73.73,0,0,1-.52-.2.7.7,0,0,1-.21-.52.69.69,0,0,1,.21-.52.7.7,0,0,1,.52-.21.73.73,0,0,1,.52.21.69.69,0,0,1,.21.52.69.69,0,0,1-.21.51A.73.73,0,0,1,439.17,119.51Zm.54,8.78h-1.12v-7h1.12Z" fill="#2f2f2f"/>
-      <path d="M447.64,128.29h-1.12v-4c0-1.49-.54-2.23-1.63-2.23a1.77,1.77,0,0,0-1.39.63,2.34,2.34,0,0,0-.55,1.6v4h-1.12v-7H443v1.16h0a2.53,2.53,0,0,1,2.3-1.32,2.11,2.11,0,0,1,1.75.74,3.27,3.27,0,0,1,.61,2.14Z" fill="#2f2f2f"/>
-      <path d="M455.47,128.29H453.9l-3.09-3.36h0v3.36h-1.12V117.93h1.12v6.57h0l2.94-3.21h1.47L452,124.67Z" fill="#2f2f2f"/>
-    </g>
-    <g>
-      <path d="M538.59,101.69l-3.63,9.8h-1.27l-3.55-9.8h1.28l2.71,7.77a4.66,4.66,0,0,1,.2.87h0a4,4,0,0,1,.22-.88l2.77-7.76Z" fill="#2f2f2f"/>
-      <path d="M547.82,111.49h-1.41l-5-7.81a3.64,3.64,0,0,1-.32-.62h0a9.25,9.25,0,0,1,.06,1.35v7.08h-1.15v-9.8h1.49l4.91,7.69c.2.32.34.54.39.65h0a11.18,11.18,0,0,1-.07-1.44v-6.9h1.15Z" fill="#2f2f2f"/>
-      <path d="M555.8,108.27h-4.94a2.66,2.66,0,0,0,.63,1.81,2.17,2.17,0,0,0,1.65.63,3.45,3.45,0,0,0,2.18-.78v1a4.05,4.05,0,0,1-2.44.67,3,3,0,0,1-2.34-1,3.91,3.91,0,0,1-.84-2.68,3.79,3.79,0,0,1,.92-2.66,3,3,0,0,1,2.3-1,2.61,2.61,0,0,1,2.13.89,3.69,3.69,0,0,1,.75,2.46Zm-1.15-1a2.24,2.24,0,0,0-.47-1.51,1.58,1.58,0,0,0-1.28-.54,1.78,1.78,0,0,0-1.34.57,2.59,2.59,0,0,0-.69,1.48Z" fill="#2f2f2f"/>
-      <path d="M560.73,111.42a2.15,2.15,0,0,1-1.05.22c-1.23,0-1.84-.68-1.84-2v-4.14h-1.2v-1h1.2v-1.71l1.12-.36v2.07h1.77v1H559v3.94a1.65,1.65,0,0,0,.24,1,1,1,0,0,0,.79.3,1.23,1.23,0,0,0,.74-.23Z" fill="#2f2f2f"/>
-      <path d="M542.08,128.29H541V117.93h1.12Z" fill="#2f2f2f"/>
-      <path d="M544.76,119.51a.73.73,0,0,1-.51-.2.7.7,0,0,1-.21-.52.69.69,0,0,1,.21-.52.69.69,0,0,1,.51-.21.74.74,0,0,1,.53.21.69.69,0,0,1,.21.52.69.69,0,0,1-.21.51A.74.74,0,0,1,544.76,119.51Zm.55,8.78h-1.12v-7h1.12Z" fill="#2f2f2f"/>
-      <path d="M553.24,128.29h-1.12v-4c0-1.49-.54-2.23-1.63-2.23a1.77,1.77,0,0,0-1.39.63,2.34,2.34,0,0,0-.55,1.6v4h-1.12v-7h1.12v1.16h0a2.53,2.53,0,0,1,2.3-1.32,2.11,2.11,0,0,1,1.75.74,3.27,3.27,0,0,1,.61,2.14Z" fill="#2f2f2f"/>
-      <path d="M561.07,128.29H559.5l-3.09-3.36h0v3.36h-1.12V117.93h1.12v6.57h0l2.94-3.21h1.47l-3.25,3.38Z" fill="#2f2f2f"/>
-    </g>
-    <g>
-      <path d="M104.22,114.33H99v-9.81h5v1h-3.83v3.26h3.54v1h-3.54v3.43h4Z" fill="#2f2f2f"/>
-      <path d="M111.31,107.33,109,110.87l2.31,3.46H110l-1.37-2.27c-.09-.14-.19-.32-.31-.54h0s-.13.22-.32.54l-1.4,2.27h-1.29l2.39-3.43-2.29-3.57h1.31l1.35,2.39c.1.18.2.36.29.55h0l1.75-2.94Z" fill="#2f2f2f"/>
-      <path d="M113.75,113.32h0v4.23H112.6V107.33h1.13v1.23h0a2.66,2.66,0,0,1,2.42-1.4,2.57,2.57,0,0,1,2.11.94,3.88,3.88,0,0,1,.76,2.52,4.37,4.37,0,0,1-.85,2.82,2.86,2.86,0,0,1-2.34,1A2.34,2.34,0,0,1,113.75,113.32Zm0-2.83v1a2,2,0,0,0,.56,1.47,1.85,1.85,0,0,0,1.43.61,1.89,1.89,0,0,0,1.6-.78,3.61,3.61,0,0,0,.58-2.17,2.81,2.81,0,0,0-.55-1.83,1.77,1.77,0,0,0-1.46-.66,2,2,0,0,0-1.57.68A2.46,2.46,0,0,0,113.73,110.49Z" fill="#2f2f2f"/>
-      <path d="M124.41,108.46a1.39,1.39,0,0,0-.85-.22,1.42,1.42,0,0,0-1.2.67,3.15,3.15,0,0,0-.48,1.85v3.57h-1.12v-7h1.12v1.44h0a2.41,2.41,0,0,1,.73-1.15,1.65,1.65,0,0,1,1.1-.42,1.89,1.89,0,0,1,.67.1Z" fill="#2f2f2f"/>
-      <path d="M131.25,111.11h-4.94a2.61,2.61,0,0,0,.63,1.8,2.14,2.14,0,0,0,1.65.64,3.45,3.45,0,0,0,2.18-.78v1a4.05,4.05,0,0,1-2.44.67,3,3,0,0,1-2.33-.95,3.89,3.89,0,0,1-.85-2.69,3.83,3.83,0,0,1,.93-2.66,3,3,0,0,1,2.3-1,2.63,2.63,0,0,1,2.12.89,3.72,3.72,0,0,1,.75,2.47Zm-1.15-1a2.29,2.29,0,0,0-.46-1.51,1.61,1.61,0,0,0-1.29-.54,1.84,1.84,0,0,0-1.34.56,2.62,2.62,0,0,0-.69,1.49Z" fill="#2f2f2f"/>
-      <path d="M132.5,114.07v-1.2a3.32,3.32,0,0,0,2,.68c1,0,1.48-.33,1.48-1a.81.81,0,0,0-.13-.47,1.25,1.25,0,0,0-.34-.35,2.43,2.43,0,0,0-.51-.27l-.62-.25a7.11,7.11,0,0,1-.82-.37,2.7,2.7,0,0,1-.59-.42,1.73,1.73,0,0,1-.35-.54,1.86,1.86,0,0,1-.12-.7,1.72,1.72,0,0,1,.22-.88,2.15,2.15,0,0,1,.61-.63,2.88,2.88,0,0,1,.85-.39,4.22,4.22,0,0,1,1-.13,4.05,4.05,0,0,1,1.63.32v1.13a3.16,3.16,0,0,0-1.78-.5,2,2,0,0,0-.57.07,1.32,1.32,0,0,0-.43.2.91.91,0,0,0-.28.31.77.77,0,0,0-.1.4.92.92,0,0,0,.1.46,1,1,0,0,0,.29.33,2.43,2.43,0,0,0,.46.26l.62.25a8.42,8.42,0,0,1,.84.37,2.88,2.88,0,0,1,.63.42,1.9,1.9,0,0,1,.4.54,1.83,1.83,0,0,1,.14.73,1.78,1.78,0,0,1-.23.91,2,2,0,0,1-.61.63,2.75,2.75,0,0,1-.89.38,4.42,4.42,0,0,1-1,.12A3.91,3.91,0,0,1,132.5,114.07Z" fill="#2f2f2f"/>
-      <path d="M138.42,114.07v-1.2a3.32,3.32,0,0,0,2,.68c1,0,1.48-.33,1.48-1a.89.89,0,0,0-.13-.47,1.41,1.41,0,0,0-.34-.35,3.05,3.05,0,0,0-.51-.27l-.62-.25a6.41,6.41,0,0,1-.82-.37,2.48,2.48,0,0,1-.59-.42,1.44,1.44,0,0,1-.35-.54,1.86,1.86,0,0,1-.12-.7,1.72,1.72,0,0,1,.22-.88,2,2,0,0,1,.6-.63,2.94,2.94,0,0,1,.86-.39,4.09,4.09,0,0,1,1-.13,4,4,0,0,1,1.62.32v1.13a3.14,3.14,0,0,0-1.78-.5,2,2,0,0,0-.56.07,1.37,1.37,0,0,0-.44.2,1,1,0,0,0-.28.31.88.88,0,0,0-.1.4,1,1,0,0,0,.1.46,1.28,1.28,0,0,0,.29.33,2.92,2.92,0,0,0,.47.26l.62.25a7.3,7.3,0,0,1,.83.37,2.47,2.47,0,0,1,.63.42,1.58,1.58,0,0,1,.4.54,1.67,1.67,0,0,1,.14.73,1.69,1.69,0,0,1-.23.91,1.93,1.93,0,0,1-.61.63,2.7,2.7,0,0,1-.88.38,4.44,4.44,0,0,1-1.05.12A3.94,3.94,0,0,1,138.42,114.07Z" fill="#2f2f2f"/>
-      <path d="M151.83,114.33h-1.36l-1.64-2.75a5.6,5.6,0,0,0-.44-.65,2.29,2.29,0,0,0-.44-.44,1.26,1.26,0,0,0-.47-.25,1.81,1.81,0,0,0-.58-.08h-1v4.17h-1.14v-9.81h2.92a4.07,4.07,0,0,1,1.19.17,2.7,2.7,0,0,1,.94.48,2.31,2.31,0,0,1,.63.82,2.74,2.74,0,0,1,.22,1.15,2.85,2.85,0,0,1-.15.94,2.52,2.52,0,0,1-.44.76,2.9,2.9,0,0,1-.68.57,3.26,3.26,0,0,1-.9.36v0a2.21,2.21,0,0,1,.43.25,2.63,2.63,0,0,1,.34.33c.11.13.22.28.33.44l.35.56ZM146,105.56v3.56h1.56a2.53,2.53,0,0,0,.8-.13,2,2,0,0,0,.63-.37,1.71,1.71,0,0,0,.42-.6,2,2,0,0,0,.15-.79A1.56,1.56,0,0,0,149,106a2.21,2.21,0,0,0-1.47-.44Z" fill="#2f2f2f"/>
-      <path d="M155.75,114.49a3.26,3.26,0,0,1-2.48-1,3.62,3.62,0,0,1-.93-2.6,3.76,3.76,0,0,1,1-2.76,3.46,3.46,0,0,1,2.6-1,3.11,3.11,0,0,1,2.44,1,3.79,3.79,0,0,1,.88,2.67,3.75,3.75,0,0,1-.94,2.68A3.31,3.31,0,0,1,155.75,114.49Zm.08-6.38a2.13,2.13,0,0,0-1.71.73,3,3,0,0,0-.63,2,2.82,2.82,0,0,0,.64,2,2.15,2.15,0,0,0,1.7.72,2.06,2.06,0,0,0,1.67-.71,3,3,0,0,0,.58-2,3.1,3.1,0,0,0-.58-2A2,2,0,0,0,155.83,108.11Z" fill="#2f2f2f"/>
-      <path d="M166.64,114.33h-1.12v-1.11h0a2.29,2.29,0,0,1-2.16,1.27c-1.67,0-2.5-1-2.5-3v-4.18h1.11v4c0,1.48.57,2.22,1.7,2.22a1.69,1.69,0,0,0,1.35-.61,2.32,2.32,0,0,0,.53-1.58v-4h1.12Z" fill="#2f2f2f"/>
-      <path d="M172.08,114.26a2.2,2.2,0,0,1-1,.22c-1.23,0-1.84-.69-1.84-2v-4.15H168v-1h1.2v-1.71l1.12-.36v2.07h1.76v1h-1.76v4a1.61,1.61,0,0,0,.24,1,1,1,0,0,0,.79.3,1.12,1.12,0,0,0,.73-.23Z" fill="#2f2f2f"/>
-      <path d="M179.08,111.11h-5a2.61,2.61,0,0,0,.63,1.8,2.16,2.16,0,0,0,1.66.64,3.42,3.42,0,0,0,2.17-.78v1a4,4,0,0,1-2.44.67,3,3,0,0,1-2.33-.95,3.89,3.89,0,0,1-.85-2.69,3.83,3.83,0,0,1,.93-2.66,3,3,0,0,1,2.3-1,2.63,2.63,0,0,1,2.12.89,3.67,3.67,0,0,1,.76,2.47Zm-1.15-1a2.29,2.29,0,0,0-.47-1.51,1.59,1.59,0,0,0-1.28-.54,1.84,1.84,0,0,0-1.35.56,2.55,2.55,0,0,0-.68,1.49Z" fill="#2f2f2f"/>
-      <path d="M126.34,130.81a3.7,3.7,0,0,1-1.92.48,3.14,3.14,0,0,1-2.41-1,3.5,3.5,0,0,1-.92-2.53,3.89,3.89,0,0,1,1-2.78,3.46,3.46,0,0,1,2.64-1.05,3.8,3.8,0,0,1,1.63.34v1.15a2.89,2.89,0,0,0-1.67-.54,2.24,2.24,0,0,0-1.76.77,2.89,2.89,0,0,0-.68,2,2.79,2.79,0,0,0,.64,1.94,2.24,2.24,0,0,0,1.73.71,2.79,2.79,0,0,0,1.73-.61Z" fill="#2f2f2f"/>
-      <path d="M128.4,122.35a.69.69,0,0,1-.51-.21.69.69,0,0,1-.22-.51.73.73,0,0,1,.22-.53.69.69,0,0,1,.51-.21.72.72,0,0,1,.52.21.69.69,0,0,1,.22.53.67.67,0,0,1-.22.51A.72.72,0,0,1,128.4,122.35Zm.55,8.78h-1.12v-7H129Z" fill="#2f2f2f"/>
-      <path d="M134.71,125.26a1.34,1.34,0,0,0-.84-.22,1.42,1.42,0,0,0-1.2.67,3.15,3.15,0,0,0-.48,1.85v3.57h-1.13v-7h1.13v1.44h0a2.48,2.48,0,0,1,.73-1.15A1.67,1.67,0,0,1,134,124a1.85,1.85,0,0,1,.67.1Z" fill="#2f2f2f"/>
-      <path d="M140.67,130.81a3.66,3.66,0,0,1-1.91.48,3.16,3.16,0,0,1-2.42-1,3.55,3.55,0,0,1-.92-2.53,3.89,3.89,0,0,1,1-2.78,3.48,3.48,0,0,1,2.65-1.05,3.83,3.83,0,0,1,1.63.34v1.15a2.89,2.89,0,0,0-1.67-.54,2.23,2.23,0,0,0-1.76.77,2.9,2.9,0,0,0-.69,2,2.79,2.79,0,0,0,.65,1.94,2.24,2.24,0,0,0,1.73.71,2.78,2.78,0,0,0,1.72-.61Z" fill="#2f2f2f"/>
-      <path d="M147.9,131.13h-1.12V130h0a2.31,2.31,0,0,1-2.16,1.27c-1.67,0-2.5-1-2.5-3v-4.18h1.11v4c0,1.48.57,2.22,1.7,2.22a1.72,1.72,0,0,0,1.35-.61,2.32,2.32,0,0,0,.53-1.58v-4h1.12Z" fill="#2f2f2f"/>
-      <path d="M150.59,122.35a.72.72,0,0,1-.52-.21.68.68,0,0,1-.21-.51.73.73,0,1,1,1.46,0,.69.69,0,0,1-.21.51A.72.72,0,0,1,150.59,122.35Zm.54,8.78H150v-7h1.12Z" fill="#2f2f2f"/>
-      <path d="M156.58,131.06a2.2,2.2,0,0,1-1,.22c-1.23,0-1.84-.69-1.84-2.05v-4.15h-1.21v-1h1.21v-1.71l1.12-.36v2.07h1.76v1h-1.76v4a1.61,1.61,0,0,0,.24,1,1,1,0,0,0,.79.3,1.14,1.14,0,0,0,.73-.23Z" fill="#2f2f2f"/>
-    </g>
-    <g>
-      <path d="M503.3,426.1l-3.63,9.8h-1.26l-3.56-9.8h1.28l2.71,7.77a4,4,0,0,1,.2.87h0a4,4,0,0,1,.23-.88l2.77-7.76Z" fill="#2f2f2f"/>
-      <path d="M505.21,427.12a.73.73,0,0,1-.51-.2.7.7,0,0,1-.21-.52.7.7,0,0,1,.72-.73.78.78,0,0,1,.53.2.72.72,0,0,1,.21.53.69.69,0,0,1-.21.51A.74.74,0,0,1,505.21,427.12Zm.55,8.78h-1.12v-7h1.12Z" fill="#2f2f2f"/>
-      <path d="M511.53,430a1.39,1.39,0,0,0-.85-.22,1.41,1.41,0,0,0-1.2.68,3.12,3.12,0,0,0-.48,1.84v3.57h-1.12v-7H509v1.44h0a2.46,2.46,0,0,1,.73-1.15,1.64,1.64,0,0,1,1.1-.41,1.92,1.92,0,0,1,.67.09Z" fill="#2f2f2f"/>
-      <path d="M516.45,435.83a2.13,2.13,0,0,1-1.05.22c-1.22,0-1.84-.68-1.84-2.05v-4.14h-1.2v-1h1.2v-1.71l1.12-.36v2.07h1.77v1h-1.77v3.94a1.65,1.65,0,0,0,.24,1,1,1,0,0,0,.8.3,1.16,1.16,0,0,0,.73-.24Z" fill="#2f2f2f"/>
-      <path d="M523.57,435.9h-1.12v-1.11h0a2.31,2.31,0,0,1-2.16,1.27c-1.67,0-2.5-1-2.5-3V428.9h1.11v4c0,1.47.56,2.21,1.7,2.21a1.74,1.74,0,0,0,1.35-.6,2.37,2.37,0,0,0,.53-1.59v-4h1.12Z" fill="#2f2f2f"/>
-      <path d="M530.72,435.9H529.6v-1.09h0a2.34,2.34,0,0,1-2.15,1.25,2.31,2.31,0,0,1-1.64-.55,1.94,1.94,0,0,1-.59-1.47q0-2,2.31-2.28l2.1-.3c0-1.19-.48-1.78-1.44-1.78a3.45,3.45,0,0,0-2.28.86v-1.15a4.28,4.28,0,0,1,2.37-.65c1.65,0,2.47.87,2.47,2.61Zm-1.12-3.54-1.69.23a2.58,2.58,0,0,0-1.17.39,1.09,1.09,0,0,0-.4,1,1.07,1.07,0,0,0,.37.84,1.42,1.42,0,0,0,1,.32,1.79,1.79,0,0,0,1.38-.58,2.11,2.11,0,0,0,.54-1.48Z" fill="#2f2f2f"/>
-      <path d="M533.86,435.9h-1.12V425.54h1.12Z" fill="#2f2f2f"/>
-      <path d="M497.66,452.7h-1.4l-5.05-7.81a3.26,3.26,0,0,1-.31-.62h0a11.85,11.85,0,0,1,.05,1.35v7.08h-1.15v-9.8h1.49l4.91,7.69c.21.32.34.53.4.65h0a11.72,11.72,0,0,1-.06-1.44v-6.9h1.14Z" fill="#2f2f2f"/>
-      <path d="M505.64,449.48H500.7a2.61,2.61,0,0,0,.63,1.8,2.14,2.14,0,0,0,1.65.64,3.45,3.45,0,0,0,2.18-.78v1.05a4.05,4.05,0,0,1-2.44.67,2.93,2.93,0,0,1-2.33-.95,4.49,4.49,0,0,1,.07-5.35,3,3,0,0,1,2.3-1,2.63,2.63,0,0,1,2.13.88,3.74,3.74,0,0,1,.75,2.47Zm-1.15-1A2.29,2.29,0,0,0,504,447a1.61,1.61,0,0,0-1.29-.54,1.81,1.81,0,0,0-1.34.57,2.56,2.56,0,0,0-.69,1.48Z" fill="#2f2f2f"/>
-      <path d="M510.57,452.63a2.15,2.15,0,0,1-1.05.22c-1.23,0-1.84-.68-1.84-2.05v-4.14h-1.2v-1h1.2V444l1.12-.36v2.07h1.77v1H508.8v3.94a1.67,1.67,0,0,0,.24,1,1,1,0,0,0,.79.3,1.17,1.17,0,0,0,.74-.24Z" fill="#2f2f2f"/>
-      <path d="M521.26,445.7l-2.1,7H518l-1.45-5a3.06,3.06,0,0,1-.1-.65h0a2.93,2.93,0,0,1-.15.63l-1.56,5h-1.12l-2.12-7h1.17l1.45,5.26a3,3,0,0,1,.1.63h0a3.31,3.31,0,0,1,.13-.64L516,445.7h1l1.45,5.28a6,6,0,0,1,.1.63h.05a2.86,2.86,0,0,1,.12-.63l1.42-5.28Z" fill="#2f2f2f"/>
-      <path d="M525.33,452.86a3.24,3.24,0,0,1-2.48-1,3.65,3.65,0,0,1-.92-2.6,3.79,3.79,0,0,1,1-2.75,3.47,3.47,0,0,1,2.61-1,3.15,3.15,0,0,1,2.44,1,4.38,4.38,0,0,1-.07,5.36A3.32,3.32,0,0,1,525.33,452.86Zm.09-6.38a2.12,2.12,0,0,0-1.71.73,3,3,0,0,0-.63,2,2.87,2.87,0,0,0,.63,2,2.17,2.17,0,0,0,1.71.72,2,2,0,0,0,1.67-.7,3.79,3.79,0,0,0,0-4A2.06,2.06,0,0,0,525.42,446.48Z" fill="#2f2f2f"/>
-      <path d="M534.18,446.83a1.34,1.34,0,0,0-.84-.22,1.41,1.41,0,0,0-1.2.68,3.12,3.12,0,0,0-.48,1.84v3.57h-1.13v-7h1.13v1.44h0a2.54,2.54,0,0,1,.73-1.15,1.65,1.65,0,0,1,1.1-.41,1.89,1.89,0,0,1,.67.09Z" fill="#2f2f2f"/>
-      <path d="M541.24,452.7h-1.57l-3.09-3.36h0v3.36h-1.12V442.34h1.12v6.57h0l2.94-3.21H541l-3.25,3.38Z" fill="#2f2f2f"/>
-      <path d="M493.56,468.49h0v4.23h-1.12V462.5h1.12v1.23h0a2.65,2.65,0,0,1,2.42-1.39,2.56,2.56,0,0,1,2.12.94,3.89,3.89,0,0,1,.75,2.51,4.35,4.35,0,0,1-.85,2.82,2.86,2.86,0,0,1-2.34,1.05A2.35,2.35,0,0,1,493.56,468.49Zm0-2.83v1a2.09,2.09,0,0,0,.56,1.48,2,2,0,0,0,3-.18,3.61,3.61,0,0,0,.58-2.17,2.81,2.81,0,0,0-.54-1.83,1.8,1.8,0,0,0-1.47-.66,2,2,0,0,0-1.57.68A2.46,2.46,0,0,0,493.54,465.66Z" fill="#2f2f2f"/>
-      <path d="M506.26,466.28h-4.94a2.61,2.61,0,0,0,.63,1.8,2.14,2.14,0,0,0,1.65.64,3.42,3.42,0,0,0,2.17-.78V469a4,4,0,0,1-2.44.67,3,3,0,0,1-2.33-1,3.93,3.93,0,0,1-.84-2.68,3.84,3.84,0,0,1,.92-2.67,3,3,0,0,1,2.3-1,2.63,2.63,0,0,1,2.13.88,3.74,3.74,0,0,1,.75,2.47Zm-1.15-.95a2.24,2.24,0,0,0-.47-1.51,1.58,1.58,0,0,0-1.28-.54,1.81,1.81,0,0,0-1.35.57,2.62,2.62,0,0,0-.68,1.48Z" fill="#2f2f2f"/>
-      <path d="M513.61,466.28h-4.94a2.61,2.61,0,0,0,.63,1.8,2.14,2.14,0,0,0,1.65.64,3.45,3.45,0,0,0,2.18-.78V469a4.05,4.05,0,0,1-2.44.67,2.93,2.93,0,0,1-2.33-1,4.49,4.49,0,0,1,.07-5.35,3,3,0,0,1,2.3-1,2.63,2.63,0,0,1,2.13.88,3.74,3.74,0,0,1,.75,2.47Zm-1.15-.95a2.29,2.29,0,0,0-.46-1.51,1.61,1.61,0,0,0-1.29-.54,1.79,1.79,0,0,0-1.34.57,2.56,2.56,0,0,0-.69,1.48Z" fill="#2f2f2f"/>
-      <path d="M519,463.63a1.39,1.39,0,0,0-.85-.22,1.41,1.41,0,0,0-1.2.68,3.12,3.12,0,0,0-.48,1.84v3.57h-1.13v-7h1.13v1.44h0a2.54,2.54,0,0,1,.73-1.15,1.66,1.66,0,0,1,1.11-.41,2,2,0,0,1,.67.09Z" fill="#2f2f2f"/>
-      <path d="M520.76,460.72a.73.73,0,0,1-.51-.2A.7.7,0,0,1,520,460a.7.7,0,0,1,.72-.73.78.78,0,0,1,.53.2.72.72,0,0,1,.21.53.69.69,0,0,1-.21.51A.74.74,0,0,1,520.76,460.72Zm.55,8.78h-1.12v-7h1.12Z" fill="#2f2f2f"/>
-      <path d="M529.24,469.5h-1.12v-4c0-1.49-.54-2.23-1.63-2.23a1.77,1.77,0,0,0-1.39.63,2.32,2.32,0,0,0-.55,1.6v4h-1.12v-7h1.12v1.16h0a2.52,2.52,0,0,1,2.29-1.32,2.13,2.13,0,0,1,1.76.74,3.27,3.27,0,0,1,.61,2.14Z" fill="#2f2f2f"/>
-      <path d="M537.31,468.94q0,3.85-3.69,3.85a5,5,0,0,1-2.27-.49v-1.12a4.65,4.65,0,0,0,2.26.66c1.72,0,2.58-.92,2.58-2.75v-.77h0a2.84,2.84,0,0,1-4.51.41,3.73,3.73,0,0,1-.8-2.5,4.37,4.37,0,0,1,.86-2.84,2.86,2.86,0,0,1,2.35-1.05,2.28,2.28,0,0,1,2.1,1.13h0v-1h1.12Zm-1.12-2.61v-1a2,2,0,0,0-.56-1.43,1.89,1.89,0,0,0-1.41-.59,1.94,1.94,0,0,0-1.62.75,3.34,3.34,0,0,0-.59,2.12,2.93,2.93,0,0,0,.56,1.87,1.83,1.83,0,0,0,1.5.7,1.94,1.94,0,0,0,1.53-.67A2.48,2.48,0,0,0,536.19,466.33Z" fill="#2f2f2f"/>
-    </g>
-    <g>
-      <path d="M219.92,176.83h-1.27l-1-2.75h-4.15l-1,2.75H211.2L215,167h1.19Zm-2.68-3.78-1.54-4.18a4.18,4.18,0,0,1-.15-.66h0a4.14,4.14,0,0,1-.15.66l-1.53,4.18Z" fill="#2f2f2f"/>
-      <path d="M226.54,170.15l-4.15,5.72h4.1v1h-5.74v-.35l4.14-5.7h-3.76v-.95h5.41Z" fill="#2f2f2f"/>
-      <path d="M233.63,176.83h-1.12v-1.11h0a2.29,2.29,0,0,1-2.16,1.27c-1.66,0-2.5-1-2.5-3v-4.18h1.12v4c0,1.48.56,2.22,1.69,2.22a1.69,1.69,0,0,0,1.35-.61,2.32,2.32,0,0,0,.53-1.58v-4h1.12Z" fill="#2f2f2f"/>
-      <path d="M239.39,171a1.39,1.39,0,0,0-.85-.22,1.42,1.42,0,0,0-1.2.67,3.15,3.15,0,0,0-.48,1.85v3.57h-1.12v-7h1.12v1.44h0a2.41,2.41,0,0,1,.73-1.15,1.65,1.65,0,0,1,1.1-.42,1.89,1.89,0,0,1,.67.1Z" fill="#2f2f2f"/>
-      <path d="M246.23,173.61h-4.94a2.61,2.61,0,0,0,.63,1.8,2.14,2.14,0,0,0,1.65.64,3.45,3.45,0,0,0,2.18-.78v1a4.05,4.05,0,0,1-2.44.67,3,3,0,0,1-2.33-1,4.49,4.49,0,0,1,.07-5.35,3,3,0,0,1,2.3-1,2.64,2.64,0,0,1,2.13.89,3.72,3.72,0,0,1,.75,2.47Zm-1.15-1a2.29,2.29,0,0,0-.46-1.51,1.61,1.61,0,0,0-1.29-.54,1.84,1.84,0,0,0-1.34.56,2.62,2.62,0,0,0-.69,1.49Z" fill="#2f2f2f"/>
-      <path d="M256.89,168.06h-3.83v3.39h3.54v1h-3.54v4.34h-1.15V167h5Z" fill="#2f2f2f"/>
-      <path d="M259,168.05a.73.73,0,0,1-.52-.21.68.68,0,0,1-.21-.51.72.72,0,0,1,.21-.53.73.73,0,0,1,.52-.21.72.72,0,0,1,.73.74.69.69,0,0,1-.21.51A.72.72,0,0,1,259,168.05Zm.54,8.78h-1.12v-7h1.12Z" fill="#2f2f2f"/>
-      <path d="M265.35,171a1.39,1.39,0,0,0-.85-.22,1.42,1.42,0,0,0-1.2.67,3.15,3.15,0,0,0-.48,1.85v3.57H261.7v-7h1.12v1.44h0a2.42,2.42,0,0,1,.74-1.15,1.63,1.63,0,0,1,1.1-.42,1.93,1.93,0,0,1,.67.1Z" fill="#2f2f2f"/>
-      <path d="M272.19,173.61h-4.94a2.52,2.52,0,0,0,.63,1.8,2.14,2.14,0,0,0,1.65.64,3.42,3.42,0,0,0,2.17-.78v1a4,4,0,0,1-2.44.67,3,3,0,0,1-2.33-1,3.94,3.94,0,0,1-.85-2.69,3.83,3.83,0,0,1,.93-2.66,3,3,0,0,1,2.3-1,2.64,2.64,0,0,1,2.13.89,3.72,3.72,0,0,1,.75,2.47Zm-1.15-1a2.24,2.24,0,0,0-.47-1.51,1.59,1.59,0,0,0-1.28-.54,1.84,1.84,0,0,0-1.35.56,2.61,2.61,0,0,0-.68,1.49Z" fill="#2f2f2f"/>
-      <path d="M282.66,169.83l-2.1,7H279.4l-1.44-5a3.82,3.82,0,0,1-.11-.65h0a2.93,2.93,0,0,1-.14.63l-1.57,5H275l-2.12-7h1.18l1.45,5.26a3,3,0,0,1,.09.63h.06a2.65,2.65,0,0,1,.12-.64l1.62-5.25h1l1.45,5.27a3.2,3.2,0,0,1,.1.63H280a3.81,3.81,0,0,1,.11-.63l1.43-5.27Z" fill="#2f2f2f"/>
-      <path d="M288.84,176.83h-1.12v-1.1h0a2.35,2.35,0,0,1-2.15,1.26,2.29,2.29,0,0,1-1.64-.55,1.9,1.9,0,0,1-.59-1.47c0-1.31.77-2.07,2.31-2.29l2.1-.29c0-1.19-.48-1.78-1.45-1.78a3.42,3.42,0,0,0-2.28.86v-1.15a4.32,4.32,0,0,1,2.38-.66c1.64,0,2.47.87,2.47,2.61Zm-1.12-3.54-1.69.23a2.82,2.82,0,0,0-1.18.38,1.15,1.15,0,0,0-.39,1,1.05,1.05,0,0,0,.36.83,1.39,1.39,0,0,0,1,.33,1.8,1.8,0,0,0,1.38-.59,2.06,2.06,0,0,0,.55-1.48Z" fill="#2f2f2f"/>
-      <path d="M292,176.83h-1.12V166.46H292Z" fill="#2f2f2f"/>
-      <path d="M295.21,176.83h-1.12V166.46h1.12Z" fill="#2f2f2f"/>
-      <path d="M233.57,193.37v-1.2a3.32,3.32,0,0,0,2,.68c1,0,1.48-.33,1.48-1a.81.81,0,0,0-.13-.47,1.13,1.13,0,0,0-.34-.35,2.61,2.61,0,0,0-.5-.27l-.63-.25a7.11,7.11,0,0,1-.82-.37,2.41,2.41,0,0,1-.58-.42,1.6,1.6,0,0,1-.36-.54,1.86,1.86,0,0,1-.12-.7,1.72,1.72,0,0,1,.23-.88,2,2,0,0,1,.6-.63,2.82,2.82,0,0,1,.86-.39,4.07,4.07,0,0,1,1-.13,4,4,0,0,1,1.63.32v1.13a3.16,3.16,0,0,0-1.78-.5,2,2,0,0,0-.57.07,1.32,1.32,0,0,0-.43.2.91.91,0,0,0-.28.31.77.77,0,0,0-.1.4.92.92,0,0,0,.1.46,1,1,0,0,0,.29.33,2.79,2.79,0,0,0,.46.26l.63.25a8.19,8.19,0,0,1,.83.37,2.47,2.47,0,0,1,.63.42,1.72,1.72,0,0,1,.4.54,1.83,1.83,0,0,1,.14.73,1.78,1.78,0,0,1-.23.91,2,2,0,0,1-.61.63,2.79,2.79,0,0,1-.88.38,4.57,4.57,0,0,1-1.05.12A3.94,3.94,0,0,1,233.57,193.37Z" fill="#2f2f2f"/>
-      <path d="M245.48,193.63h-1.13v-1.11h0a2.31,2.31,0,0,1-2.16,1.27c-1.67,0-2.5-1-2.5-3v-4.18h1.11v4c0,1.48.56,2.22,1.69,2.22a1.69,1.69,0,0,0,1.35-.61,2.27,2.27,0,0,0,.53-1.58v-4h1.13Z" fill="#2f2f2f"/>
-      <path d="M248.73,192.62h0v1h-1.12V183.26h1.12v4.6h0a2.66,2.66,0,0,1,2.42-1.4,2.59,2.59,0,0,1,2.11.94,3.88,3.88,0,0,1,.76,2.52,4.32,4.32,0,0,1-.85,2.81,2.83,2.83,0,0,1-2.34,1.06A2.31,2.31,0,0,1,248.73,192.62Zm0-2.83v1a2.05,2.05,0,0,0,.57,1.47,1.84,1.84,0,0,0,1.43.61,1.89,1.89,0,0,0,1.6-.78,3.61,3.61,0,0,0,.57-2.17,2.81,2.81,0,0,0-.54-1.83,1.78,1.78,0,0,0-1.46-.66,2,2,0,0,0-1.57.68A2.47,2.47,0,0,0,248.7,189.79Z" fill="#2f2f2f"/>
-      <path d="M261.55,193.63h-1.12v-4c0-1.48-.54-2.22-1.63-2.22a1.77,1.77,0,0,0-1.39.63,2.31,2.31,0,0,0-.55,1.59v4h-1.12v-7h1.12v1.16h0a2.51,2.51,0,0,1,2.29-1.33,2.15,2.15,0,0,1,1.76.74,3.3,3.3,0,0,1,.61,2.15Z" fill="#2f2f2f"/>
-      <path d="M269.25,190.41h-4.94a2.61,2.61,0,0,0,.63,1.8,2.14,2.14,0,0,0,1.65.64,3.45,3.45,0,0,0,2.18-.78v1.05a4.05,4.05,0,0,1-2.44.67,3,3,0,0,1-2.33-.95,4.49,4.49,0,0,1,.07-5.35,3,3,0,0,1,2.31-1,2.63,2.63,0,0,1,2.12.89,3.72,3.72,0,0,1,.75,2.47Zm-1.15-.95a2.29,2.29,0,0,0-.46-1.51,1.61,1.61,0,0,0-1.29-.54A1.84,1.84,0,0,0,265,188a2.62,2.62,0,0,0-.69,1.49Z" fill="#2f2f2f"/>
-      <path d="M274.18,193.56a2.27,2.27,0,0,1-1.05.22c-1.22,0-1.84-.69-1.84-2.05v-4.15h-1.2v-1h1.2v-1.71l1.12-.36v2.07h1.77v1h-1.77v3.95a1.61,1.61,0,0,0,.24,1,1,1,0,0,0,.8.3,1.16,1.16,0,0,0,.73-.23Z" fill="#2f2f2f"/>
-    </g>
-    <g>
-      <path d="M222,260a5.79,5.79,0,0,1-2.71.57,4.37,4.37,0,0,1-3.35-1.35,5,5,0,0,1-1.25-3.53,5.22,5.22,0,0,1,1.41-3.8,4.8,4.8,0,0,1,3.59-1.45,5.73,5.73,0,0,1,2.31.4v1.23a4.6,4.6,0,0,0-2.32-.59,3.57,3.57,0,0,0-2.74,1.13,4.23,4.23,0,0,0-1.05,3,4.07,4.07,0,0,0,1,2.86,3.35,3.35,0,0,0,2.57,1.06,4.81,4.81,0,0,0,2.56-.66Z" fill="#2f2f2f"/>
-      <path d="M226.58,260.59a3.26,3.26,0,0,1-2.48-1,3.61,3.61,0,0,1-.92-2.6,3.8,3.8,0,0,1,1-2.76,3.46,3.46,0,0,1,2.6-1,3.13,3.13,0,0,1,2.45,1,3.84,3.84,0,0,1,.88,2.67,3.75,3.75,0,0,1-.95,2.68A3.33,3.33,0,0,1,226.58,260.59Zm.08-6.38a2.13,2.13,0,0,0-1.71.73,3,3,0,0,0-.63,2,2.87,2.87,0,0,0,.64,2,2.15,2.15,0,0,0,1.7.72,2,2,0,0,0,1.67-.71,3,3,0,0,0,.59-2,3.1,3.1,0,0,0-.59-2A2,2,0,0,0,226.66,254.21Z" fill="#2f2f2f"/>
-      <path d="M235.43,254.56a1.37,1.37,0,0,0-.85-.22,1.45,1.45,0,0,0-1.2.67,3.15,3.15,0,0,0-.48,1.85v3.57h-1.12v-7h1.12v1.44h0a2.41,2.41,0,0,1,.73-1.15,1.67,1.67,0,0,1,1.1-.42,1.89,1.89,0,0,1,.67.1Z" fill="#2f2f2f"/>
-      <path d="M237.82,259.42h0v4.23h-1.12V253.43h1.12v1.23h0a2.67,2.67,0,0,1,2.42-1.4,2.59,2.59,0,0,1,2.12.94,3.94,3.94,0,0,1,.76,2.52,4.32,4.32,0,0,1-.86,2.81,2.83,2.83,0,0,1-2.34,1.06A2.36,2.36,0,0,1,237.82,259.42Zm0-2.83v1a2,2,0,0,0,.56,1.47,1.85,1.85,0,0,0,1.43.61,1.89,1.89,0,0,0,1.6-.78,3.61,3.61,0,0,0,.58-2.17,2.81,2.81,0,0,0-.54-1.83,1.8,1.8,0,0,0-1.47-.66,2,2,0,0,0-1.57.68A2.51,2.51,0,0,0,237.8,256.59Z" fill="#2f2f2f"/>
-      <path d="M253.87,251.66H250v3.39h3.54v1H250v4.34h-1.15v-9.81h5Z" fill="#2f2f2f"/>
-      <path d="M256,251.65a.69.69,0,0,1-.51-.21.69.69,0,0,1-.21-.52.72.72,0,0,1,.21-.52.69.69,0,0,1,.51-.21.74.74,0,0,1,.53.21.72.72,0,0,1,.21.52.7.7,0,0,1-.21.52A.74.74,0,0,1,256,251.65Zm.55,8.78h-1.12v-7h1.12Z" fill="#2f2f2f"/>
-      <path d="M262.32,254.56a1.34,1.34,0,0,0-.84-.22,1.42,1.42,0,0,0-1.2.67,3.15,3.15,0,0,0-.49,1.85v3.57h-1.12v-7h1.12v1.44h0a2.48,2.48,0,0,1,.73-1.15,1.67,1.67,0,0,1,1.1-.42,1.85,1.85,0,0,1,.67.1Z" fill="#2f2f2f"/>
-      <path d="M269.17,257.21h-4.95a2.61,2.61,0,0,0,.63,1.8,2.16,2.16,0,0,0,1.66.64,3.42,3.42,0,0,0,2.17-.78v1.05a4,4,0,0,1-2.44.67,3,3,0,0,1-2.33-.95,3.89,3.89,0,0,1-.85-2.69,3.82,3.82,0,0,1,.93-2.66,3,3,0,0,1,2.3-1,2.65,2.65,0,0,1,2.13.89,3.72,3.72,0,0,1,.75,2.47Zm-1.15-.95a2.29,2.29,0,0,0-.47-1.51,1.59,1.59,0,0,0-1.28-.54,1.84,1.84,0,0,0-1.35.56,2.61,2.61,0,0,0-.68,1.49Z" fill="#2f2f2f"/>
-      <path d="M279.64,253.43l-2.1,7h-1.16l-1.44-5a3.15,3.15,0,0,1-.11-.65h0a2.93,2.93,0,0,1-.14.63l-1.57,5H272l-2.12-7H271l1.45,5.26a3.93,3.93,0,0,1,.09.63h.06a2.56,2.56,0,0,1,.12-.64l1.61-5.25h1l1.45,5.27a4.17,4.17,0,0,1,.1.63H277a2.45,2.45,0,0,1,.11-.63l1.42-5.27Z" fill="#2f2f2f"/>
-      <path d="M285.82,260.43h-1.13v-1.1h0a2.36,2.36,0,0,1-2.16,1.26,2.28,2.28,0,0,1-1.63-.55,1.9,1.9,0,0,1-.59-1.47c0-1.31.77-2.07,2.31-2.29l2.09-.29c0-1.19-.48-1.78-1.44-1.78a3.42,3.42,0,0,0-2.28.86v-1.15a4.32,4.32,0,0,1,2.38-.66c1.64,0,2.47.87,2.47,2.61Zm-1.13-3.54-1.68.23a2.77,2.77,0,0,0-1.18.38,1.15,1.15,0,0,0-.4,1,1.06,1.06,0,0,0,.37.83,1.39,1.39,0,0,0,1,.33,1.8,1.8,0,0,0,1.38-.59,2.09,2.09,0,0,0,.54-1.48Z" fill="#2f2f2f"/>
-      <path d="M289,260.43h-1.13V250.06H289Z" fill="#2f2f2f"/>
-      <path d="M292.19,260.43h-1.12V250.06h1.12Z" fill="#2f2f2f"/>
-    </g>
-    <g>
-      <path d="M361.77,176.83H360.5l-1-2.75H355.3l-1,2.75H353L356.8,167H358Zm-2.69-3.78-1.54-4.18a4.18,4.18,0,0,1-.15-.66h0a4,4,0,0,1-.16.66l-1.53,4.18Z" fill="#2f2f2f"/>
-      <path d="M364.19,175.82h0v4.23H363V169.83h1.12v1.23h0a2.66,2.66,0,0,1,2.42-1.4,2.59,2.59,0,0,1,2.11.94,3.88,3.88,0,0,1,.76,2.52,4.37,4.37,0,0,1-.85,2.82,2.86,2.86,0,0,1-2.34,1.05A2.34,2.34,0,0,1,364.19,175.82Zm0-2.83v1a2.05,2.05,0,0,0,.57,1.47,2,2,0,0,0,3-.17,3.54,3.54,0,0,0,.58-2.17,2.81,2.81,0,0,0-.54-1.83,1.79,1.79,0,0,0-1.46-.66,2,2,0,0,0-1.57.68A2.47,2.47,0,0,0,364.16,173Z" fill="#2f2f2f"/>
-      <path d="M372.34,175.82h0v4.23H371.2V169.83h1.12v1.23h0a2.67,2.67,0,0,1,2.42-1.4,2.59,2.59,0,0,1,2.12.94,3.94,3.94,0,0,1,.76,2.52,4.37,4.37,0,0,1-.86,2.82,2.86,2.86,0,0,1-2.34,1.05A2.36,2.36,0,0,1,372.34,175.82Zm0-2.83v1a2.09,2.09,0,0,0,.56,1.47,1.87,1.87,0,0,0,1.43.61,1.89,1.89,0,0,0,1.6-.78,3.61,3.61,0,0,0,.58-2.17,2.81,2.81,0,0,0-.54-1.83,1.8,1.8,0,0,0-1.47-.66,2,2,0,0,0-1.57.68A2.51,2.51,0,0,0,372.32,173Z" fill="#2f2f2f"/>
-      <path d="M390.74,176.16a6.61,6.61,0,0,1-3.28.83,4.47,4.47,0,0,1-3.39-1.35,4.94,4.94,0,0,1-1.3-3.58,5.1,5.1,0,0,1,1.44-3.74,4.91,4.91,0,0,1,3.65-1.46,6.13,6.13,0,0,1,2.68.52v1.27a5.15,5.15,0,0,0-2.81-.75A3.53,3.53,0,0,0,385,169,4.13,4.13,0,0,0,384,172a4.18,4.18,0,0,0,1,2.93A3.46,3.46,0,0,0,387.6,176a4,4,0,0,0,2-.46v-2.75h-2.14v-1h3.29Z" fill="#2f2f2f"/>
-      <path d="M397.83,176.83h-1.12v-1.1h0a2.35,2.35,0,0,1-2.15,1.26,2.29,2.29,0,0,1-1.64-.55,1.9,1.9,0,0,1-.59-1.47c0-1.31.77-2.07,2.31-2.29l2.1-.29c0-1.19-.48-1.78-1.45-1.78a3.42,3.42,0,0,0-2.28.86v-1.15a4.32,4.32,0,0,1,2.38-.66c1.64,0,2.47.87,2.47,2.61Zm-1.12-3.54-1.69.23a2.82,2.82,0,0,0-1.18.38,1.15,1.15,0,0,0-.39,1,1.05,1.05,0,0,0,.36.83,1.4,1.4,0,0,0,1,.33,1.79,1.79,0,0,0,1.37-.59,2.06,2.06,0,0,0,.55-1.48Z" fill="#2f2f2f"/>
-      <path d="M403.09,176.76a2.27,2.27,0,0,1-1,.22c-1.23,0-1.84-.69-1.84-2v-4.15H399v-.95h1.2v-1.71l1.12-.36v2.07h1.77v.95h-1.77v3.95a1.61,1.61,0,0,0,.24,1,1,1,0,0,0,.79.3,1.17,1.17,0,0,0,.74-.23Z" fill="#2f2f2f"/>
-      <path d="M410.08,173.61h-4.94a2.56,2.56,0,0,0,.62,1.8,2.18,2.18,0,0,0,1.66.64,3.42,3.42,0,0,0,2.17-.78v1a4,4,0,0,1-2.44.67,3,3,0,0,1-2.33-1,3.94,3.94,0,0,1-.85-2.69,3.83,3.83,0,0,1,.93-2.66,3,3,0,0,1,2.3-1,2.64,2.64,0,0,1,2.13.89,3.72,3.72,0,0,1,.75,2.47Zm-1.15-1a2.29,2.29,0,0,0-.47-1.51,1.59,1.59,0,0,0-1.28-.54,1.84,1.84,0,0,0-1.35.56,2.61,2.61,0,0,0-.68,1.49Z" fill="#2f2f2f"/>
-      <path d="M420.55,169.83l-2.1,7h-1.16l-1.44-5a3,3,0,0,1-.11-.65h0a2.93,2.93,0,0,1-.14.63l-1.57,5h-1.12l-2.12-7h1.18l1.45,5.26a3,3,0,0,1,.09.63h.06a2.65,2.65,0,0,1,.12-.64l1.62-5.25h1l1.45,5.27a3.2,3.2,0,0,1,.1.63h.06a3.81,3.81,0,0,1,.11-.63l1.43-5.27Z" fill="#2f2f2f"/>
-      <path d="M426.73,176.83h-1.12v-1.1h0a2.36,2.36,0,0,1-2.16,1.26,2.28,2.28,0,0,1-1.63-.55,1.9,1.9,0,0,1-.59-1.47c0-1.31.77-2.07,2.31-2.29l2.1-.29c0-1.19-.48-1.78-1.45-1.78a3.42,3.42,0,0,0-2.28.86v-1.15a4.32,4.32,0,0,1,2.38-.66c1.64,0,2.47.87,2.47,2.61Zm-1.12-3.54-1.69.23a2.82,2.82,0,0,0-1.18.38,1.15,1.15,0,0,0-.4,1,1.06,1.06,0,0,0,.37.83,1.39,1.39,0,0,0,1,.33,1.8,1.8,0,0,0,1.38-.59,2.1,2.1,0,0,0,.55-1.48Z" fill="#2f2f2f"/>
-      <path d="M434.24,169.83,431,178c-.58,1.45-1.38,2.17-2.42,2.17a2.5,2.5,0,0,1-.73-.09v-1a2.1,2.1,0,0,0,.66.12,1.37,1.37,0,0,0,1.27-1l.56-1.33-2.73-7h1.24l1.9,5.38c0,.07.07.25.14.54h0c0-.11.07-.29.14-.52l2-5.4Z" fill="#2f2f2f"/>
-      <path d="M375.39,193.37v-1.2a3.32,3.32,0,0,0,2,.68c1,0,1.48-.33,1.48-1a.81.81,0,0,0-.13-.47,1.13,1.13,0,0,0-.34-.35,2.61,2.61,0,0,0-.5-.27l-.63-.25a7.11,7.11,0,0,1-.82-.37,2.41,2.41,0,0,1-.58-.42,1.6,1.6,0,0,1-.36-.54,1.86,1.86,0,0,1-.12-.7,1.72,1.72,0,0,1,.23-.88,2,2,0,0,1,.6-.63,2.82,2.82,0,0,1,.86-.39,4.07,4.07,0,0,1,1-.13,4,4,0,0,1,1.63.32v1.13a3.16,3.16,0,0,0-1.78-.5,2,2,0,0,0-.57.07,1.32,1.32,0,0,0-.43.2.91.91,0,0,0-.28.31.77.77,0,0,0-.1.4.92.92,0,0,0,.1.46,1,1,0,0,0,.29.33,2.79,2.79,0,0,0,.46.26l.63.25a8.19,8.19,0,0,1,.83.37,2.47,2.47,0,0,1,.63.42,1.72,1.72,0,0,1,.4.54,1.83,1.83,0,0,1,.14.73,1.78,1.78,0,0,1-.23.91,2,2,0,0,1-.61.63,2.79,2.79,0,0,1-.88.38,4.51,4.51,0,0,1-1.05.12A3.94,3.94,0,0,1,375.39,193.37Z" fill="#2f2f2f"/>
-      <path d="M387.3,193.63h-1.13v-1.11h0a2.31,2.31,0,0,1-2.16,1.27c-1.67,0-2.5-1-2.5-3v-4.18h1.11v4c0,1.48.56,2.22,1.69,2.22a1.69,1.69,0,0,0,1.35-.61,2.27,2.27,0,0,0,.53-1.58v-4h1.13Z" fill="#2f2f2f"/>
-      <path d="M390.55,192.62h0v1H389.4V183.26h1.12v4.6h0a2.66,2.66,0,0,1,2.42-1.4,2.59,2.59,0,0,1,2.11.94,3.88,3.88,0,0,1,.76,2.52,4.32,4.32,0,0,1-.85,2.81,2.83,2.83,0,0,1-2.34,1.06A2.31,2.31,0,0,1,390.55,192.62Zm0-2.83v1a2.05,2.05,0,0,0,.57,1.47,1.84,1.84,0,0,0,1.43.61,1.89,1.89,0,0,0,1.6-.78,3.61,3.61,0,0,0,.57-2.17,2.81,2.81,0,0,0-.54-1.83,1.78,1.78,0,0,0-1.46-.66,2,2,0,0,0-1.57.68A2.47,2.47,0,0,0,390.52,189.79Z" fill="#2f2f2f"/>
-      <path d="M403.37,193.63h-1.12v-4c0-1.48-.54-2.22-1.63-2.22a1.77,1.77,0,0,0-1.39.63,2.31,2.31,0,0,0-.55,1.59v4h-1.12v-7h1.12v1.16h0a2.51,2.51,0,0,1,2.29-1.33,2.15,2.15,0,0,1,1.76.74,3.3,3.3,0,0,1,.61,2.15Z" fill="#2f2f2f"/>
-      <path d="M411.07,190.41h-4.94a2.61,2.61,0,0,0,.63,1.8,2.14,2.14,0,0,0,1.65.64,3.45,3.45,0,0,0,2.18-.78v1.05a4.05,4.05,0,0,1-2.44.67,3,3,0,0,1-2.33-.95,4.49,4.49,0,0,1,.07-5.35,3,3,0,0,1,2.31-1,2.63,2.63,0,0,1,2.12.89,3.72,3.72,0,0,1,.75,2.47Zm-1.15-.95a2.29,2.29,0,0,0-.46-1.51,1.61,1.61,0,0,0-1.29-.54,1.84,1.84,0,0,0-1.34.56,2.62,2.62,0,0,0-.69,1.49Z" fill="#2f2f2f"/>
-      <path d="M416,193.56a2.27,2.27,0,0,1-1.05.22c-1.22,0-1.84-.69-1.84-2.05v-4.15h-1.2v-1h1.2v-1.71l1.12-.36v2.07H416v1h-1.77v3.95a1.61,1.61,0,0,0,.24,1,1,1,0,0,0,.8.3,1.16,1.16,0,0,0,.73-.23Z" fill="#2f2f2f"/>
-    </g>
-    <g>
-      <path d="M579.51,171.19v-1.35a2.86,2.86,0,0,0,.56.37,4.12,4.12,0,0,0,.69.27,4.46,4.46,0,0,0,.72.18,4.06,4.06,0,0,0,.67.06,2.65,2.65,0,0,0,1.58-.39,1.32,1.32,0,0,0,.52-1.13,1.36,1.36,0,0,0-.17-.69,2,2,0,0,0-.48-.54,5.42,5.42,0,0,0-.73-.47L582,167c-.34-.18-.66-.35-1-.53a4.23,4.23,0,0,1-.77-.59,2.29,2.29,0,0,1-.51-.73,2.15,2.15,0,0,1-.19-.95,2.33,2.33,0,0,1,.29-1.17,2.59,2.59,0,0,1,.77-.81,3.31,3.31,0,0,1,1.1-.48,4.69,4.69,0,0,1,1.24-.16A4.78,4.78,0,0,1,585,162v1.29a3.8,3.8,0,0,0-2.22-.6,4,4,0,0,0-.76.08,2.08,2.08,0,0,0-.67.26,1.44,1.44,0,0,0-.47.45,1.19,1.19,0,0,0-.19.69,1.45,1.45,0,0,0,.14.65,1.5,1.5,0,0,0,.42.5,4,4,0,0,0,.66.43l.91.47a10.66,10.66,0,0,1,1,.55,4.44,4.44,0,0,1,.82.63,2.8,2.8,0,0,1,.57.77,2.19,2.19,0,0,1,.21,1,2.43,2.43,0,0,1-.29,1.23,2.3,2.3,0,0,1-.76.82,3.38,3.38,0,0,1-1.12.45,5.63,5.63,0,0,1-1.32.14l-.58,0-.69-.11a6.75,6.75,0,0,1-.68-.18A2,2,0,0,1,579.51,171.19Z" fill="#2f2f2f"/>
-      <path d="M592.84,168.37h-5a2.61,2.61,0,0,0,.63,1.8,2.16,2.16,0,0,0,1.66.64,3.42,3.42,0,0,0,2.17-.78v1.05a4,4,0,0,1-2.44.67,3,3,0,0,1-2.33-.95,3.88,3.88,0,0,1-.85-2.68,3.84,3.84,0,0,1,.93-2.67,3,3,0,0,1,2.3-1,2.62,2.62,0,0,1,2.12.89,3.69,3.69,0,0,1,.76,2.47Zm-1.15-1a2.29,2.29,0,0,0-.47-1.51,1.59,1.59,0,0,0-1.28-.54,1.81,1.81,0,0,0-1.35.57,2.55,2.55,0,0,0-.68,1.48Z" fill="#2f2f2f"/>
-      <path d="M598.17,165.72a1.39,1.39,0,0,0-.85-.22,1.42,1.42,0,0,0-1.2.67,3.17,3.17,0,0,0-.48,1.85v3.57h-1.12v-7h1.12V166h0a2.46,2.46,0,0,1,.73-1.15,1.64,1.64,0,0,1,1.1-.41,2,2,0,0,1,.67.09Z" fill="#2f2f2f"/>
-      <path d="M605.44,164.59l-2.79,7h-1.1l-2.65-7h1.23l1.78,5.08a4.6,4.6,0,0,1,.24,1h0a4.92,4.92,0,0,1,.22-1l1.86-5.11Z" fill="#2f2f2f"/>
-      <path d="M607.26,162.81a.73.73,0,0,1-.51-.2.67.67,0,0,1-.22-.52.69.69,0,0,1,.22-.53.69.69,0,0,1,.51-.2.71.71,0,0,1,.52.2.73.73,0,0,1,.22.53.7.7,0,0,1-.22.51A.72.72,0,0,1,607.26,162.81Zm.54,8.78h-1.12v-7h1.12Z" fill="#2f2f2f"/>
-      <path d="M614.72,171.27a3.7,3.7,0,0,1-1.92.48,3.14,3.14,0,0,1-2.41-1,3.5,3.5,0,0,1-.92-2.53,3.89,3.89,0,0,1,1-2.78,3.46,3.46,0,0,1,2.64-1.05,3.66,3.66,0,0,1,1.63.35v1.15a2.81,2.81,0,0,0-1.67-.55,2.24,2.24,0,0,0-1.76.77,2.89,2.89,0,0,0-.68,2,2.79,2.79,0,0,0,.64,1.94,2.24,2.24,0,0,0,1.73.71,2.81,2.81,0,0,0,1.73-.61Z" fill="#2f2f2f"/>
-      <path d="M621.89,168.37h-4.95a2.61,2.61,0,0,0,.63,1.8,2.16,2.16,0,0,0,1.66.64,3.42,3.42,0,0,0,2.17-.78v1.05a4,4,0,0,1-2.44.67,3,3,0,0,1-2.33-.95,3.88,3.88,0,0,1-.85-2.68,3.84,3.84,0,0,1,.93-2.67,3,3,0,0,1,2.3-1,2.63,2.63,0,0,1,2.12.89,3.69,3.69,0,0,1,.76,2.47Zm-1.15-1a2.29,2.29,0,0,0-.47-1.51,1.59,1.59,0,0,0-1.28-.54,1.81,1.81,0,0,0-1.35.57,2.49,2.49,0,0,0-.68,1.48Z" fill="#2f2f2f"/>
-      <path d="M634.59,171.59h-1.36l-1.64-2.75a6.61,6.61,0,0,0-.44-.65,2.58,2.58,0,0,0-.43-.44,1.38,1.38,0,0,0-.48-.25,2.08,2.08,0,0,0-.58-.08h-.94v4.17h-1.15v-9.8h2.92a4.08,4.08,0,0,1,1.19.16,2.48,2.48,0,0,1,.94.49,2.19,2.19,0,0,1,.63.81,2.74,2.74,0,0,1,.22,1.15,2.85,2.85,0,0,1-.15.94,2.4,2.4,0,0,1-.44.76,2.71,2.71,0,0,1-.68.57,3.62,3.62,0,0,1-.9.37v0a2.87,2.87,0,0,1,.43.25,3.51,3.51,0,0,1,.34.33c.11.13.22.28.33.44l.36.56Zm-5.87-8.76v3.55h1.55a2.28,2.28,0,0,0,.8-.13,1.87,1.87,0,0,0,.63-.37,1.63,1.63,0,0,0,.42-.6,2,2,0,0,0,.15-.79,1.52,1.52,0,0,0-.51-1.22,2.15,2.15,0,0,0-1.47-.44Z" fill="#2f2f2f"/>
-      <path d="M641.26,171.59h-1.12v-1.11h0a2.31,2.31,0,0,1-2.16,1.27c-1.67,0-2.51-1-2.51-3v-4.18h1.12v4c0,1.48.56,2.22,1.69,2.22a1.69,1.69,0,0,0,1.35-.61,2.27,2.27,0,0,0,.53-1.58v-4h1.12Z" fill="#2f2f2f"/>
-      <path d="M649.18,171.59h-1.12v-4c0-1.49-.54-2.23-1.63-2.23A1.77,1.77,0,0,0,645,166a2.37,2.37,0,0,0-.55,1.6v4h-1.12v-7h1.12v1.16h0a2.54,2.54,0,0,1,2.3-1.33,2.12,2.12,0,0,1,1.75.75,3.27,3.27,0,0,1,.61,2.14Z" fill="#2f2f2f"/>
-      <path d="M654.41,171.52a2.09,2.09,0,0,1-1,.22c-1.23,0-1.84-.68-1.84-2.05v-4.14h-1.21v-1h1.21v-1.71l1.12-.36v2.07h1.76v1h-1.76v3.94a1.67,1.67,0,0,0,.24,1,1,1,0,0,0,.79.3,1.14,1.14,0,0,0,.73-.24Z" fill="#2f2f2f"/>
-      <path d="M656.37,162.81a.77.77,0,0,1-.52-.2.7.7,0,0,1-.21-.52.7.7,0,0,1,.73-.73.71.71,0,0,1,.52.2.72.72,0,0,1,.21.53.69.69,0,0,1-.21.51A.72.72,0,0,1,656.37,162.81Zm.54,8.78h-1.12v-7h1.12Z" fill="#2f2f2f"/>
-      <path d="M669,171.59h-1.12v-4a3,3,0,0,0-.36-1.68,1.35,1.35,0,0,0-1.21-.52,1.53,1.53,0,0,0-1.22.65,2.57,2.57,0,0,0-.5,1.58v4h-1.12v-4.16c0-1.37-.53-2.06-1.59-2.06a1.47,1.47,0,0,0-1.22.62,2.55,2.55,0,0,0-.48,1.61v4H659v-7h1.12v1.11h0a2.38,2.38,0,0,1,2.17-1.28,2.05,2.05,0,0,1,1.25.4,2.07,2.07,0,0,1,.74,1.05,2.5,2.5,0,0,1,2.32-1.45c1.54,0,2.31,1,2.31,2.86Z" fill="#2f2f2f"/>
-      <path d="M676.68,168.37h-4.94a2.56,2.56,0,0,0,.62,1.8,2.18,2.18,0,0,0,1.66.64,3.42,3.42,0,0,0,2.17-.78v1.05a4,4,0,0,1-2.44.67,3,3,0,0,1-2.33-.95,3.93,3.93,0,0,1-.85-2.68,3.84,3.84,0,0,1,.93-2.67,3,3,0,0,1,2.3-1,2.65,2.65,0,0,1,2.13.89,3.74,3.74,0,0,1,.75,2.47Zm-1.15-1a2.29,2.29,0,0,0-.47-1.51,1.59,1.59,0,0,0-1.28-.54,1.81,1.81,0,0,0-1.35.57,2.55,2.55,0,0,0-.68,1.48Z" fill="#2f2f2f"/>
-      <path d="M681.78,171.34v-1.21a3.34,3.34,0,0,0,2,.68c1,0,1.48-.33,1.48-1a.82.82,0,0,0-.13-.48,1.4,1.4,0,0,0-.34-.35,2.43,2.43,0,0,0-.51-.27l-.62-.24c-.31-.13-.58-.25-.82-.38a2.4,2.4,0,0,1-.59-.42,1.73,1.73,0,0,1-.35-.54,1.86,1.86,0,0,1-.12-.7,1.66,1.66,0,0,1,.22-.87,1.87,1.87,0,0,1,.61-.64,2.88,2.88,0,0,1,.85-.39,4.15,4.15,0,0,1,1-.13,4,4,0,0,1,1.62.32v1.13a3.19,3.19,0,0,0-1.77-.5,2,2,0,0,0-.57.07,1.56,1.56,0,0,0-.43.2.91.91,0,0,0-.28.31.79.79,0,0,0-.1.4.92.92,0,0,0,.1.46,1,1,0,0,0,.29.33,2.43,2.43,0,0,0,.46.26l.62.25a8.42,8.42,0,0,1,.84.37,2.88,2.88,0,0,1,.63.42,1.9,1.9,0,0,1,.4.54,1.84,1.84,0,0,1,.14.74,1.77,1.77,0,0,1-.23.9,2,2,0,0,1-.62.63,2.61,2.61,0,0,1-.88.38,4.42,4.42,0,0,1-1,.12A4.1,4.1,0,0,1,681.78,171.34Z" fill="#2f2f2f"/>
-      <path d="M693.69,171.59h-1.12v-1.11h0a2.29,2.29,0,0,1-2.16,1.27c-1.66,0-2.5-1-2.5-3v-4.18H689v4c0,1.48.56,2.22,1.69,2.22a1.69,1.69,0,0,0,1.35-.61,2.32,2.32,0,0,0,.53-1.58v-4h1.12Z" fill="#2f2f2f"/>
-      <path d="M697,170.58h0v1H695.8V161.23h1.12v4.59h0a2.66,2.66,0,0,1,2.42-1.4,2.59,2.59,0,0,1,2.11.94,3.88,3.88,0,0,1,.76,2.52,4.35,4.35,0,0,1-.86,2.82,2.82,2.82,0,0,1-2.33,1.05A2.3,2.3,0,0,1,697,170.58Zm0-2.83v1a2.05,2.05,0,0,0,.57,1.47,2,2,0,0,0,3-.17,3.54,3.54,0,0,0,.58-2.17,2.81,2.81,0,0,0-.54-1.83,1.79,1.79,0,0,0-1.46-.66,2,2,0,0,0-1.57.68A2.47,2.47,0,0,0,696.92,167.75Z" fill="#2f2f2f"/>
-      <path d="M709.77,171.59h-1.12v-4c0-1.49-.55-2.23-1.63-2.23a1.76,1.76,0,0,0-1.39.63,2.32,2.32,0,0,0-.55,1.6v4H704v-7h1.12v1.16h0a2.55,2.55,0,0,1,2.3-1.33,2.14,2.14,0,0,1,1.76.75,3.33,3.33,0,0,1,.61,2.14Z" fill="#2f2f2f"/>
-      <path d="M717.47,168.37h-4.94a2.56,2.56,0,0,0,.63,1.8,2.14,2.14,0,0,0,1.65.64A3.42,3.42,0,0,0,717,170v1.05a4,4,0,0,1-2.44.67,3,3,0,0,1-2.33-.95,3.93,3.93,0,0,1-.84-2.68,3.84,3.84,0,0,1,.92-2.67,3,3,0,0,1,2.3-1,2.64,2.64,0,0,1,2.13.89,3.74,3.74,0,0,1,.75,2.47Zm-1.15-1a2.24,2.24,0,0,0-.47-1.51,1.59,1.59,0,0,0-1.28-.54,1.81,1.81,0,0,0-1.35.57,2.62,2.62,0,0,0-.68,1.48Z" fill="#2f2f2f"/>
-      <path d="M722.39,171.52a2.09,2.09,0,0,1-1,.22c-1.23,0-1.84-.68-1.84-2.05v-4.14h-1.2v-1h1.2v-1.71l1.12-.36v2.07h1.76v1h-1.76v3.94a1.67,1.67,0,0,0,.24,1,1,1,0,0,0,.79.3,1.13,1.13,0,0,0,.73-.24Z" fill="#2f2f2f"/>
-    </g>
-    <g>
-      <path d="M587.56,327.69h-1.27l-1-2.75h-4.16l-1,2.75h-1.28l3.76-9.8h1.19Zm-2.69-3.78-1.53-4.18a4,4,0,0,1-.15-.65h0a4.1,4.1,0,0,1-.16.65l-1.52,4.18Z" fill="#2f2f2f"/>
-      <path d="M590,326.68h0v4.23h-1.12V320.69H590v1.23h0a2.66,2.66,0,0,1,2.42-1.4,2.57,2.57,0,0,1,2.11.94,3.88,3.88,0,0,1,.76,2.52,4.35,4.35,0,0,1-.85,2.82,2.86,2.86,0,0,1-2.34,1.05A2.34,2.34,0,0,1,590,326.68Zm0-2.83v1a2.05,2.05,0,0,0,.57,1.47,1.84,1.84,0,0,0,1.43.61,1.89,1.89,0,0,0,1.6-.78,3.61,3.61,0,0,0,.57-2.17,2.81,2.81,0,0,0-.54-1.83,1.78,1.78,0,0,0-1.46-.66,2,2,0,0,0-1.57.68A2.47,2.47,0,0,0,590,323.85Z" fill="#2f2f2f"/>
-      <path d="M598.14,326.68h0v4.23H597V320.69h1.12v1.23h0a2.66,2.66,0,0,1,2.42-1.4,2.59,2.59,0,0,1,2.11.94,3.88,3.88,0,0,1,.76,2.52,4.35,4.35,0,0,1-.86,2.82,2.84,2.84,0,0,1-2.33,1.05A2.34,2.34,0,0,1,598.14,326.68Zm0-2.83v1a2.09,2.09,0,0,0,.56,1.47,2,2,0,0,0,3-.17,3.54,3.54,0,0,0,.58-2.17,2.81,2.81,0,0,0-.54-1.83,1.79,1.79,0,0,0-1.46-.66,2,2,0,0,0-1.57.68A2.47,2.47,0,0,0,598.11,323.85Z" fill="#2f2f2f"/>
-      <path d="M604.71,327.44v-1.21a3.32,3.32,0,0,0,2,.68c1,0,1.48-.33,1.48-1a.89.89,0,0,0-.12-.47,1.45,1.45,0,0,0-.35-.35,2.61,2.61,0,0,0-.5-.27l-.63-.25a7.11,7.11,0,0,1-.82-.37,2.17,2.17,0,0,1-.58-.42,1.6,1.6,0,0,1-.36-.54,1.86,1.86,0,0,1-.12-.7,1.66,1.66,0,0,1,.23-.87,1.93,1.93,0,0,1,.6-.64,2.82,2.82,0,0,1,.86-.39,4.07,4.07,0,0,1,1-.13,4,4,0,0,1,1.63.32V322a3.25,3.25,0,0,0-1.78-.5,2,2,0,0,0-.57.07,1.56,1.56,0,0,0-.43.2,1,1,0,0,0-.28.31.79.79,0,0,0-.1.4.92.92,0,0,0,.1.46,1.11,1.11,0,0,0,.29.33,2.79,2.79,0,0,0,.46.26l.63.25a8.19,8.19,0,0,1,.83.37,2.47,2.47,0,0,1,.63.42,1.72,1.72,0,0,1,.4.54,1.84,1.84,0,0,1,.14.74,1.77,1.77,0,0,1-.23.9,1.93,1.93,0,0,1-.61.63,2.79,2.79,0,0,1-.88.38,4.51,4.51,0,0,1-1,.12A4.06,4.06,0,0,1,604.71,327.44Z" fill="#2f2f2f"/>
-      <path d="M614.48,327.44v-1.21a3.34,3.34,0,0,0,2,.68c1,0,1.48-.33,1.48-1a.89.89,0,0,0-.13-.47,1.4,1.4,0,0,0-.34-.35,2.7,2.7,0,0,0-.51-.27l-.62-.25a6.41,6.41,0,0,1-.82-.37,2.4,2.4,0,0,1-.59-.42,1.73,1.73,0,0,1-.35-.54,1.86,1.86,0,0,1-.12-.7,1.66,1.66,0,0,1,.22-.87,1.93,1.93,0,0,1,.6-.64,3.06,3.06,0,0,1,.86-.39,4.09,4.09,0,0,1,1-.13,4,4,0,0,1,1.62.32V322a3.19,3.19,0,0,0-1.77-.5,2,2,0,0,0-.57.07,1.78,1.78,0,0,0-.44.2.88.88,0,0,0-.27.31.79.79,0,0,0-.1.4.92.92,0,0,0,.1.46,1,1,0,0,0,.29.33,2.43,2.43,0,0,0,.46.26l.62.25a8.42,8.42,0,0,1,.84.37,2.59,2.59,0,0,1,.62.42,1.76,1.76,0,0,1,.41.54,1.84,1.84,0,0,1,.14.74,1.77,1.77,0,0,1-.23.9,2,2,0,0,1-.62.63,2.61,2.61,0,0,1-.88.38,4.42,4.42,0,0,1-1,.12A4.1,4.1,0,0,1,614.48,327.44Z" fill="#2f2f2f"/>
-      <path d="M626.39,327.69h-1.12v-1.11h0a2.29,2.29,0,0,1-2.16,1.27c-1.66,0-2.5-1-2.5-3v-4.18h1.12v4c0,1.48.56,2.22,1.69,2.22a1.69,1.69,0,0,0,1.35-.61,2.32,2.32,0,0,0,.53-1.58v-4h1.12Z" fill="#2f2f2f"/>
-      <path d="M629.65,326.68h0v1H628.5V317.33h1.12v4.59h0a2.66,2.66,0,0,1,2.42-1.4,2.6,2.6,0,0,1,2.11.94,3.94,3.94,0,0,1,.76,2.52,4.35,4.35,0,0,1-.86,2.82,2.84,2.84,0,0,1-2.33,1.05A2.3,2.3,0,0,1,629.65,326.68Zm0-2.83v1a2.09,2.09,0,0,0,.56,1.47,2,2,0,0,0,3-.17,3.54,3.54,0,0,0,.58-2.17,2.81,2.81,0,0,0-.54-1.83,1.79,1.79,0,0,0-1.46-.66,2,2,0,0,0-1.58.68A2.51,2.51,0,0,0,629.62,323.85Z" fill="#2f2f2f"/>
-      <path d="M642.47,327.69h-1.13v-4c0-1.49-.54-2.23-1.62-2.23a1.76,1.76,0,0,0-1.39.63,2.32,2.32,0,0,0-.55,1.6v4h-1.12v-7h1.12v1.16h0a2.55,2.55,0,0,1,2.3-1.33,2.14,2.14,0,0,1,1.76.75,3.33,3.33,0,0,1,.61,2.14Z" fill="#2f2f2f"/>
-      <path d="M650.17,324.47h-4.94a2.56,2.56,0,0,0,.63,1.8,2.14,2.14,0,0,0,1.65.64,3.42,3.42,0,0,0,2.17-.78v1.05a4,4,0,0,1-2.44.67,3,3,0,0,1-2.33-1,3.93,3.93,0,0,1-.85-2.68,3.84,3.84,0,0,1,.93-2.67,3,3,0,0,1,2.3-1,2.64,2.64,0,0,1,2.13.89,3.74,3.74,0,0,1,.75,2.47Zm-1.15-1a2.24,2.24,0,0,0-.47-1.51,1.59,1.59,0,0,0-1.28-.54,1.81,1.81,0,0,0-1.35.57,2.55,2.55,0,0,0-.68,1.48Z" fill="#2f2f2f"/>
-      <path d="M655.09,327.62a2.09,2.09,0,0,1-1,.22c-1.23,0-1.84-.68-1.84-2v-4.14H651v-1h1.21V319l1.12-.36v2.07h1.76v1h-1.76v3.94a1.61,1.61,0,0,0,.24,1,.92.92,0,0,0,.79.31,1.14,1.14,0,0,0,.73-.24Z" fill="#2f2f2f"/>
-    </g>
-    <g>
-      <path d="M889.05,329.79V320h2.71q5.18,0,5.18,4.77a4.81,4.81,0,0,1-1.44,3.65,5.33,5.33,0,0,1-3.85,1.38ZM890.2,321v7.73h1.46a4.12,4.12,0,0,0,3-1,3.87,3.87,0,0,0,1.07-2.93q0-3.77-4-3.77Z" fill="#2f2f2f"/>
-      <path d="M903.57,329.79h-1.12v-1.1h0a2.35,2.35,0,0,1-2.15,1.26,2.29,2.29,0,0,1-1.64-.55,1.94,1.94,0,0,1-.59-1.47q0-2,2.31-2.28l2.1-.3c0-1.19-.48-1.78-1.44-1.78a3.47,3.47,0,0,0-2.29.86v-1.15a4.32,4.32,0,0,1,2.38-.66c1.65,0,2.47.88,2.47,2.62Zm-1.12-3.54-1.69.23a2.67,2.67,0,0,0-1.18.39,1.11,1.11,0,0,0-.39,1,1.05,1.05,0,0,0,.36.83,1.42,1.42,0,0,0,1,.33,1.79,1.79,0,0,0,1.37-.59,2,2,0,0,0,.55-1.48Z" fill="#2f2f2f"/>
-      <path d="M908.83,329.72a2.15,2.15,0,0,1-1.05.22c-1.22,0-1.84-.68-1.84-2.05v-4.14h-1.2v-1h1.2v-1.71l1.12-.36v2.07h1.77v1h-1.77v3.94a1.61,1.61,0,0,0,.24,1,1,1,0,0,0,.8.31,1.16,1.16,0,0,0,.73-.24Z" fill="#2f2f2f"/>
-      <path d="M915.44,329.79h-1.12v-1.1h0a2.36,2.36,0,0,1-2.16,1.26,2.28,2.28,0,0,1-1.63-.55,1.91,1.91,0,0,1-.6-1.47q0-2,2.31-2.28l2.1-.3c0-1.19-.48-1.78-1.44-1.78a3.47,3.47,0,0,0-2.28.86v-1.15a4.32,4.32,0,0,1,2.38-.66c1.64,0,2.46.88,2.46,2.62Zm-1.12-3.54-1.69.23a2.63,2.63,0,0,0-1.17.39,1.12,1.12,0,0,0-.4,1,1,1,0,0,0,.37.83,1.39,1.39,0,0,0,1,.33,1.8,1.8,0,0,0,1.38-.59,2.07,2.07,0,0,0,.54-1.48Z" fill="#2f2f2f"/>
-      <path d="M921.08,329.39V328a2.59,2.59,0,0,0,.56.37,4.12,4.12,0,0,0,.69.27,4.21,4.21,0,0,0,.72.18,4.06,4.06,0,0,0,.67.06,2.65,2.65,0,0,0,1.58-.39,1.32,1.32,0,0,0,.52-1.13,1.36,1.36,0,0,0-.17-.69,2,2,0,0,0-.48-.54,5.42,5.42,0,0,0-.73-.47l-.91-.46c-.34-.18-.66-.35-1-.53a4.23,4.23,0,0,1-.77-.59,2.29,2.29,0,0,1-.51-.73,2.18,2.18,0,0,1-.19-.95,2.33,2.33,0,0,1,.29-1.17,2.59,2.59,0,0,1,.77-.81,3.35,3.35,0,0,1,1.09-.48,5.85,5.85,0,0,1,3.36.19v1.29a3.8,3.8,0,0,0-2.22-.6,3.92,3.92,0,0,0-.76.08,2.08,2.08,0,0,0-.67.26,1.44,1.44,0,0,0-.47.45,1.19,1.19,0,0,0-.19.69,1.48,1.48,0,0,0,.14.65,1.59,1.59,0,0,0,.41.5,4.57,4.57,0,0,0,.67.43c.26.14.56.3.91.47a9.37,9.37,0,0,1,1,.55,4.21,4.21,0,0,1,.83.63,2.8,2.8,0,0,1,.57.77,2.19,2.19,0,0,1,.2,1,2.43,2.43,0,0,1-.28,1.23,2.3,2.3,0,0,1-.76.82,3.38,3.38,0,0,1-1.12.45,5.63,5.63,0,0,1-1.32.14l-.58,0-.69-.11a6.75,6.75,0,0,1-.68-.18A2,2,0,0,1,921.08,329.39Z" fill="#2f2f2f"/>
-      <path d="M934.41,326.57h-4.95a2.61,2.61,0,0,0,.63,1.8,2.16,2.16,0,0,0,1.66.64,3.42,3.42,0,0,0,2.17-.78v1a4,4,0,0,1-2.44.67,3,3,0,0,1-2.33-.95,3.88,3.88,0,0,1-.85-2.68,3.84,3.84,0,0,1,.93-2.67,3,3,0,0,1,2.3-1,2.67,2.67,0,0,1,2.13.89,3.74,3.74,0,0,1,.75,2.47Zm-1.15-.95a2.29,2.29,0,0,0-.47-1.51,1.59,1.59,0,0,0-1.28-.54,1.81,1.81,0,0,0-1.35.57,2.49,2.49,0,0,0-.68,1.48Z" fill="#2f2f2f"/>
-      <path d="M939.74,323.92a1.39,1.39,0,0,0-.85-.22,1.42,1.42,0,0,0-1.2.67,3.17,3.17,0,0,0-.48,1.85v3.57h-1.12v-7h1.12v1.44h0a2.46,2.46,0,0,1,.73-1.15,1.65,1.65,0,0,1,1.1-.41,2,2,0,0,1,.67.09Z" fill="#2f2f2f"/>
-      <path d="M947,322.79l-2.79,7h-1.1l-2.65-7h1.23l1.78,5.08a4.6,4.6,0,0,1,.24,1h0a4.92,4.92,0,0,1,.22-1l1.86-5.11Z" fill="#2f2f2f"/>
-      <path d="M948.83,321a.73.73,0,0,1-.51-.2.67.67,0,0,1-.22-.52.69.69,0,0,1,.22-.53.69.69,0,0,1,.51-.2.71.71,0,0,1,.52.2.73.73,0,0,1,.22.53.7.7,0,0,1-.22.51A.72.72,0,0,1,948.83,321Zm.55,8.78h-1.13v-7h1.13Z" fill="#2f2f2f"/>
-      <path d="M956.29,329.47a3.7,3.7,0,0,1-1.92.48,3.16,3.16,0,0,1-2.41-1,3.5,3.5,0,0,1-.92-2.53,3.89,3.89,0,0,1,1-2.78,3.46,3.46,0,0,1,2.64-1.05,3.66,3.66,0,0,1,1.63.35v1.14a2.87,2.87,0,0,0-1.67-.54,2.24,2.24,0,0,0-1.76.77,2.89,2.89,0,0,0-.68,2,2.79,2.79,0,0,0,.64,1.94,2.24,2.24,0,0,0,1.73.71,2.81,2.81,0,0,0,1.73-.61Z" fill="#2f2f2f"/>
-      <path d="M963.46,326.57h-5a2.61,2.61,0,0,0,.63,1.8,2.16,2.16,0,0,0,1.66.64,3.42,3.42,0,0,0,2.17-.78v1a4,4,0,0,1-2.44.67,3,3,0,0,1-2.33-.95,3.88,3.88,0,0,1-.85-2.68,3.84,3.84,0,0,1,.93-2.67,3,3,0,0,1,2.3-1,2.65,2.65,0,0,1,2.13.89,3.74,3.74,0,0,1,.75,2.47Zm-1.15-.95a2.29,2.29,0,0,0-.47-1.51,1.59,1.59,0,0,0-1.28-.54,1.81,1.81,0,0,0-1.35.57,2.55,2.55,0,0,0-.68,1.48Z" fill="#2f2f2f"/>
-      <path d="M964.7,329.54v-1.21a3.32,3.32,0,0,0,2,.68q1.47,0,1.47-1a.89.89,0,0,0-.12-.47,1.29,1.29,0,0,0-.35-.35,2.61,2.61,0,0,0-.5-.27l-.63-.24a7.83,7.83,0,0,1-.81-.38,2.22,2.22,0,0,1-.59-.42,1.6,1.6,0,0,1-.36-.54,1.86,1.86,0,0,1-.12-.7,1.66,1.66,0,0,1,.23-.87,1.93,1.93,0,0,1,.6-.64,2.94,2.94,0,0,1,.86-.39,4.07,4.07,0,0,1,1-.13,4,4,0,0,1,1.63.32v1.13a3.25,3.25,0,0,0-1.78-.5,2,2,0,0,0-.57.07,1.42,1.42,0,0,0-.43.2,1,1,0,0,0-.28.31.79.79,0,0,0-.1.4.92.92,0,0,0,.1.46,1.11,1.11,0,0,0,.29.33,2.54,2.54,0,0,0,.47.26l.62.25a7.3,7.3,0,0,1,.83.37,2.47,2.47,0,0,1,.63.42,1.72,1.72,0,0,1,.4.54,1.84,1.84,0,0,1,.14.74,1.77,1.77,0,0,1-.23.9,1.93,1.93,0,0,1-.61.63,2.7,2.7,0,0,1-.88.38,4.44,4.44,0,0,1-1,.12A4.06,4.06,0,0,1,964.7,329.54Z" fill="#2f2f2f"/>
-      <path d="M974.47,329.54v-1.21a3.34,3.34,0,0,0,2,.68c1,0,1.48-.33,1.48-1a.81.81,0,0,0-.13-.47,1.25,1.25,0,0,0-.34-.35,2.43,2.43,0,0,0-.51-.27l-.62-.24c-.31-.13-.58-.25-.82-.38a2.4,2.4,0,0,1-.59-.42,1.73,1.73,0,0,1-.35-.54,1.86,1.86,0,0,1-.12-.7,1.66,1.66,0,0,1,.22-.87,1.87,1.87,0,0,1,.61-.64,2.88,2.88,0,0,1,.85-.39,4.15,4.15,0,0,1,1-.13,4,4,0,0,1,1.62.32v1.13a3.19,3.19,0,0,0-1.77-.5,2,2,0,0,0-.57.07,1.32,1.32,0,0,0-.43.2.91.91,0,0,0-.28.31.79.79,0,0,0-.1.4.92.92,0,0,0,.1.46,1,1,0,0,0,.29.33,2.43,2.43,0,0,0,.46.26l.62.25a8.42,8.42,0,0,1,.84.37,2.88,2.88,0,0,1,.63.42,1.9,1.9,0,0,1,.4.54,1.84,1.84,0,0,1,.14.74,1.77,1.77,0,0,1-.23.9,2,2,0,0,1-.61.63,2.75,2.75,0,0,1-.89.38,4.42,4.42,0,0,1-1,.12A4.1,4.1,0,0,1,974.47,329.54Z" fill="#2f2f2f"/>
-      <path d="M986.38,329.79h-1.12v-1.11h0a2.29,2.29,0,0,1-2.16,1.27c-1.66,0-2.5-1-2.5-3v-4.18h1.12v4c0,1.48.56,2.22,1.69,2.22a1.69,1.69,0,0,0,1.35-.61,2.32,2.32,0,0,0,.53-1.58v-4h1.12Z" fill="#2f2f2f"/>
-      <path d="M989.64,328.78h0v1h-1.12V319.43h1.12V324h0a2.66,2.66,0,0,1,2.42-1.4,2.59,2.59,0,0,1,2.11.94,3.88,3.88,0,0,1,.76,2.52,4.43,4.43,0,0,1-.85,2.82,2.86,2.86,0,0,1-2.34,1.05A2.3,2.3,0,0,1,989.64,328.78Zm0-2.83v1a2.05,2.05,0,0,0,.57,1.47,2,2,0,0,0,3-.17,3.54,3.54,0,0,0,.58-2.17,2.81,2.81,0,0,0-.54-1.83,1.79,1.79,0,0,0-1.46-.66,2,2,0,0,0-1.57.68A2.47,2.47,0,0,0,989.61,326Z" fill="#2f2f2f"/>
-      <path d="M1002.46,329.79h-1.12v-4c0-1.49-.55-2.23-1.63-2.23a1.76,1.76,0,0,0-1.39.63,2.32,2.32,0,0,0-.55,1.6v4h-1.12v-7h1.12V324h0a2.55,2.55,0,0,1,2.3-1.33,2.14,2.14,0,0,1,1.76.75,3.33,3.33,0,0,1,.61,2.14Z" fill="#2f2f2f"/>
-      <path d="M1010.16,326.57h-4.94a2.61,2.61,0,0,0,.63,1.8,2.14,2.14,0,0,0,1.65.64,3.42,3.42,0,0,0,2.17-.78v1a4,4,0,0,1-2.44.67,3,3,0,0,1-2.33-.95,3.93,3.93,0,0,1-.84-2.68,3.84,3.84,0,0,1,.92-2.67,3,3,0,0,1,2.3-1,2.64,2.64,0,0,1,2.13.89,3.74,3.74,0,0,1,.75,2.47Zm-1.15-.95a2.24,2.24,0,0,0-.47-1.51,1.58,1.58,0,0,0-1.28-.54,1.78,1.78,0,0,0-1.34.57,2.56,2.56,0,0,0-.69,1.48Z" fill="#2f2f2f"/>
-      <path d="M1015.08,329.72a2.09,2.09,0,0,1-1,.22c-1.23,0-1.84-.68-1.84-2.05v-4.14H1011v-1h1.2v-1.71l1.12-.36v2.07h1.76v1h-1.76v3.94a1.61,1.61,0,0,0,.24,1,.92.92,0,0,0,.79.31,1.13,1.13,0,0,0,.73-.24Z" fill="#2f2f2f"/>
-    </g>
-    <g>
-      <path d="M911.3,401.31v-9.8H914q5.19,0,5.19,4.77a4.81,4.81,0,0,1-1.44,3.65,5.35,5.35,0,0,1-3.86,1.38Zm1.15-8.76v7.72h1.46a4.16,4.16,0,0,0,3-1,3.87,3.87,0,0,0,1.07-2.93q0-3.76-4-3.76Z" fill="#2f2f2f"/>
-      <path d="M925.82,401.31H924.7v-1.09h0a2.36,2.36,0,0,1-2.15,1.25,2.29,2.29,0,0,1-1.64-.55,1.9,1.9,0,0,1-.59-1.47q0-2,2.31-2.28l2.1-.3c0-1.19-.49-1.78-1.45-1.78A3.47,3.47,0,0,0,921,396V394.8a4.32,4.32,0,0,1,2.38-.65c1.64,0,2.47.87,2.47,2.61Zm-1.12-3.54L923,398a2.67,2.67,0,0,0-1.18.39,1.11,1.11,0,0,0-.39,1,1.09,1.09,0,0,0,.36.84,1.44,1.44,0,0,0,1,.32,1.82,1.82,0,0,0,1.37-.58,2.12,2.12,0,0,0,.55-1.48Z" fill="#2f2f2f"/>
-      <path d="M931.08,401.24a2.15,2.15,0,0,1-1.05.22c-1.23,0-1.84-.68-1.84-2v-4.14H927v-1h1.2V392.6l1.12-.36v2.07h1.77v1h-1.77v3.94a1.67,1.67,0,0,0,.24,1,1,1,0,0,0,.79.3,1.17,1.17,0,0,0,.74-.24Z" fill="#2f2f2f"/>
-      <path d="M937.69,401.31h-1.12v-1.09h0a2.34,2.34,0,0,1-2.15,1.25,2.31,2.31,0,0,1-1.64-.55,1.94,1.94,0,0,1-.59-1.47q0-2,2.31-2.28l2.1-.3c0-1.19-.48-1.78-1.44-1.78a3.45,3.45,0,0,0-2.28.86V394.8a4.28,4.28,0,0,1,2.37-.65c1.65,0,2.47.87,2.47,2.61Zm-1.12-3.54-1.69.23a2.58,2.58,0,0,0-1.17.39,1.09,1.09,0,0,0-.4,1,1.07,1.07,0,0,0,.37.84,1.44,1.44,0,0,0,1,.32A1.83,1.83,0,0,0,936,400a2.11,2.11,0,0,0,.54-1.48Z" fill="#2f2f2f"/>
-      <path d="M901,417.86v-1.21a3.32,3.32,0,0,0,2,.68c1,0,1.48-.33,1.48-1a.9.9,0,0,0-.12-.48,1.45,1.45,0,0,0-.35-.35,2.61,2.61,0,0,0-.5-.27l-.63-.24a7.83,7.83,0,0,1-.81-.38,2.07,2.07,0,0,1-.59-.42,1.6,1.6,0,0,1-.36-.54,1.86,1.86,0,0,1-.12-.7,1.66,1.66,0,0,1,.23-.87,1.93,1.93,0,0,1,.6-.64,2.94,2.94,0,0,1,.86-.39,4.07,4.07,0,0,1,1-.13,4,4,0,0,1,1.63.32v1.13a3.25,3.25,0,0,0-1.78-.5,2,2,0,0,0-.57.07,1.71,1.71,0,0,0-.43.2,1,1,0,0,0-.28.31.79.79,0,0,0-.1.4.92.92,0,0,0,.1.46,1.11,1.11,0,0,0,.29.33,2.79,2.79,0,0,0,.46.26l.63.25a8.19,8.19,0,0,1,.83.37,2.47,2.47,0,0,1,.63.42,1.72,1.72,0,0,1,.4.54,1.84,1.84,0,0,1,.14.74,1.77,1.77,0,0,1-.23.9,1.93,1.93,0,0,1-.61.63,2.79,2.79,0,0,1-.88.38,4.51,4.51,0,0,1-1,.12A4.06,4.06,0,0,1,901,417.86Z" fill="#2f2f2f"/>
-      <path d="M912.91,414.89H908a2.61,2.61,0,0,0,.63,1.8,2.14,2.14,0,0,0,1.65.64,3.45,3.45,0,0,0,2.18-.78v1.05a4.05,4.05,0,0,1-2.44.67,2.93,2.93,0,0,1-2.33-.95,3.88,3.88,0,0,1-.85-2.68,3.84,3.84,0,0,1,.93-2.67,3,3,0,0,1,2.3-1,2.63,2.63,0,0,1,2.12.89,3.74,3.74,0,0,1,.75,2.47Zm-1.15-.95a2.29,2.29,0,0,0-.46-1.51,1.61,1.61,0,0,0-1.29-.54,1.81,1.81,0,0,0-1.34.57,2.56,2.56,0,0,0-.69,1.48Z" fill="#2f2f2f"/>
-      <path d="M918.25,412.24a1.39,1.39,0,0,0-.85-.22,1.42,1.42,0,0,0-1.2.67,3.17,3.17,0,0,0-.48,1.85v3.57H914.6v-7h1.12v1.44h0a2.38,2.38,0,0,1,.73-1.15,1.62,1.62,0,0,1,1.1-.41,2,2,0,0,1,.67.09Z" fill="#2f2f2f"/>
-      <path d="M925.52,411.11l-2.79,7h-1.1l-2.65-7h1.23l1.78,5.08a4.6,4.6,0,0,1,.24,1h0a4.28,4.28,0,0,1,.22-.95l1.86-5.11Z" fill="#2f2f2f"/>
-      <path d="M927.33,409.33a.73.73,0,0,1-.51-.2.7.7,0,0,1-.21-.52.72.72,0,0,1,.21-.53.69.69,0,0,1,.51-.2.73.73,0,0,1,.53.2.72.72,0,0,1,.21.53.69.69,0,0,1-.21.51A.74.74,0,0,1,927.33,409.33Zm.55,8.78h-1.12v-7h1.12Z" fill="#2f2f2f"/>
-      <path d="M934.79,417.79a3.66,3.66,0,0,1-1.91.48,3.18,3.18,0,0,1-2.42-1,3.55,3.55,0,0,1-.92-2.53,3.89,3.89,0,0,1,1-2.78,3.49,3.49,0,0,1,2.65-1.05,3.69,3.69,0,0,1,1.63.35v1.15a2.83,2.83,0,0,0-1.67-.55,2.23,2.23,0,0,0-1.76.77,2.9,2.9,0,0,0-.69,2,2.79,2.79,0,0,0,.65,1.94,2.24,2.24,0,0,0,1.73.71,2.78,2.78,0,0,0,1.72-.61Z" fill="#2f2f2f"/>
-      <path d="M942,414.89H937a2.61,2.61,0,0,0,.63,1.8,2.14,2.14,0,0,0,1.65.64,3.45,3.45,0,0,0,2.18-.78v1.05a4.05,4.05,0,0,1-2.44.67,2.93,2.93,0,0,1-2.33-.95,3.88,3.88,0,0,1-.85-2.68,3.84,3.84,0,0,1,.93-2.67,3,3,0,0,1,2.3-1,2.63,2.63,0,0,1,2.12.89,3.74,3.74,0,0,1,.75,2.47Zm-1.14-.95a2.35,2.35,0,0,0-.47-1.51,1.6,1.6,0,0,0-1.28-.54,1.81,1.81,0,0,0-1.35.57,2.49,2.49,0,0,0-.68,1.48Z" fill="#2f2f2f"/>
-      <path d="M943.21,417.86v-1.21a3.32,3.32,0,0,0,2,.68c1,0,1.48-.33,1.48-1a.82.82,0,0,0-.13-.48,1.4,1.4,0,0,0-.34-.35,2.43,2.43,0,0,0-.51-.27l-.62-.24c-.31-.13-.58-.25-.82-.38a2.4,2.4,0,0,1-.59-.42,1.73,1.73,0,0,1-.35-.54,1.86,1.86,0,0,1-.12-.7,1.66,1.66,0,0,1,.22-.87,1.87,1.87,0,0,1,.61-.64,2.88,2.88,0,0,1,.85-.39,4.15,4.15,0,0,1,1-.13,4.05,4.05,0,0,1,1.63.32v1.13a3.25,3.25,0,0,0-1.78-.5,2,2,0,0,0-.57.07,1.56,1.56,0,0,0-.43.2.91.91,0,0,0-.28.31.79.79,0,0,0-.1.4.92.92,0,0,0,.1.46,1,1,0,0,0,.29.33,2.43,2.43,0,0,0,.46.26l.62.25a8.42,8.42,0,0,1,.84.37,2.88,2.88,0,0,1,.63.42,1.9,1.9,0,0,1,.4.54,1.84,1.84,0,0,1,.14.74,1.77,1.77,0,0,1-.23.9,2,2,0,0,1-.61.63,2.75,2.75,0,0,1-.89.38,4.42,4.42,0,0,1-1,.12A4,4,0,0,1,943.21,417.86Z" fill="#2f2f2f"/>
-    </g>
-    <g>
-      <path d="M1018.12,361.71h-1.28l-1-2.75h-4.16l-1,2.75h-1.28l3.76-9.8h1.19Zm-2.69-3.78-1.54-4.18a3.75,3.75,0,0,1-.15-.65h0a3.32,3.32,0,0,1-.15.65l-1.53,4.18Z" fill="#2f2f2f"/>
-      <path d="M1024.73,355l-4.15,5.72h4.11v1h-5.75v-.35l4.14-5.69h-3.75v-1h5.4Z" fill="#2f2f2f"/>
-      <path d="M1031.82,361.71h-1.12V360.6h0a2.31,2.31,0,0,1-2.16,1.27c-1.67,0-2.51-1-2.51-3v-4.18h1.12v4c0,1.48.56,2.22,1.69,2.22a1.69,1.69,0,0,0,1.35-.61,2.27,2.27,0,0,0,.53-1.58v-4h1.12Z" fill="#2f2f2f"/>
-      <path d="M1037.58,355.84a1.37,1.37,0,0,0-.85-.22,1.45,1.45,0,0,0-1.2.67,3.17,3.17,0,0,0-.48,1.85v3.57h-1.12v-7h1.12v1.44h0a2.46,2.46,0,0,1,.73-1.15,1.65,1.65,0,0,1,1.1-.41,1.92,1.92,0,0,1,.67.09Z" fill="#2f2f2f"/>
-      <path d="M1044.42,358.49h-4.94a2.61,2.61,0,0,0,.63,1.8,2.15,2.15,0,0,0,1.66.64,3.44,3.44,0,0,0,2.17-.78v1.05a4.05,4.05,0,0,1-2.44.67,2.93,2.93,0,0,1-2.33-.95,3.88,3.88,0,0,1-.85-2.68,3.84,3.84,0,0,1,.93-2.67,3,3,0,0,1,2.3-1,2.63,2.63,0,0,1,2.12.89,3.74,3.74,0,0,1,.75,2.47Zm-1.14-.95a2.29,2.29,0,0,0-.47-1.51,1.6,1.6,0,0,0-1.28-.54,1.81,1.81,0,0,0-1.35.57,2.49,2.49,0,0,0-.68,1.48Z" fill="#2f2f2f"/>
-      <path d="M1017.2,378.1a5.79,5.79,0,0,1-2.71.57,4.4,4.4,0,0,1-3.35-1.34,5,5,0,0,1-1.25-3.54,5.22,5.22,0,0,1,1.41-3.8,4.79,4.79,0,0,1,3.59-1.45,5.72,5.72,0,0,1,2.31.41v1.22a4.71,4.71,0,0,0-2.32-.59,3.57,3.57,0,0,0-2.74,1.13,4.25,4.25,0,0,0-1,3,4.07,4.07,0,0,0,1,2.86,3.32,3.32,0,0,0,2.57,1.06,4.81,4.81,0,0,0,2.56-.66Z" fill="#2f2f2f"/>
-      <path d="M1021.75,378.67a3.22,3.22,0,0,1-2.48-1,3.62,3.62,0,0,1-.93-2.6,3.79,3.79,0,0,1,1-2.75,3.47,3.47,0,0,1,2.6-1,3.16,3.16,0,0,1,2.45,1,3.84,3.84,0,0,1,.88,2.67,3.75,3.75,0,0,1-1,2.68A3.29,3.29,0,0,1,1021.75,378.67Zm.08-6.38a2.13,2.13,0,0,0-1.71.73,3,3,0,0,0-.63,2,2.87,2.87,0,0,0,.64,2,2.15,2.15,0,0,0,1.7.72,2.07,2.07,0,0,0,1.67-.7,3.74,3.74,0,0,0,0-4A2,2,0,0,0,1021.83,372.29Z" fill="#2f2f2f"/>
-      <path d="M1026.5,378.26v-1.21a3.32,3.32,0,0,0,2,.68c1,0,1.47-.33,1.47-1a.9.9,0,0,0-.12-.48,1.41,1.41,0,0,0-.34-.35,3.05,3.05,0,0,0-.51-.27l-.63-.24a7.83,7.83,0,0,1-.81-.38,2.22,2.22,0,0,1-.59-.42,1.6,1.6,0,0,1-.36-.54,1.86,1.86,0,0,1-.12-.7,1.66,1.66,0,0,1,.23-.87,1.93,1.93,0,0,1,.6-.64,2.94,2.94,0,0,1,.86-.39,4.07,4.07,0,0,1,1-.13,4,4,0,0,1,1.63.32v1.13a3.22,3.22,0,0,0-1.78-.5,1.91,1.91,0,0,0-.56.07,1.63,1.63,0,0,0-.44.2,1,1,0,0,0-.28.31.91.91,0,0,0-.1.4,1,1,0,0,0,.1.46,1.11,1.11,0,0,0,.29.33,2.54,2.54,0,0,0,.47.26l.62.25a7.3,7.3,0,0,1,.83.37,2.47,2.47,0,0,1,.63.42,1.58,1.58,0,0,1,.4.54,1.94,1.94,0,0,1-.09,1.64,1.84,1.84,0,0,1-.61.63,2.7,2.7,0,0,1-.88.38,4.44,4.44,0,0,1-1.05.12A4.06,4.06,0,0,1,1026.5,378.26Z" fill="#2f2f2f"/>
-      <path d="M1042.67,378.51h-1.13v-4a3.09,3.09,0,0,0-.35-1.68,1.37,1.37,0,0,0-1.21-.52,1.5,1.5,0,0,0-1.22.65,2.51,2.51,0,0,0-.5,1.58v4h-1.12v-4.16c0-1.37-.54-2.06-1.6-2.06a1.44,1.44,0,0,0-1.21.62,2.55,2.55,0,0,0-.48,1.61v4h-1.12v-7h1.12v1.11h0a2.37,2.37,0,0,1,2.17-1.28,2.07,2.07,0,0,1,1.25.4,2,2,0,0,1,.73,1.05,2.52,2.52,0,0,1,2.33-1.45c1.54,0,2.31,1,2.31,2.86Z" fill="#2f2f2f"/>
-      <path d="M1047.67,378.67a3.24,3.24,0,0,1-2.48-1,3.65,3.65,0,0,1-.92-2.6,3.79,3.79,0,0,1,1-2.75,3.49,3.49,0,0,1,2.61-1,3.14,3.14,0,0,1,2.44,1,3.79,3.79,0,0,1,.88,2.67,3.75,3.75,0,0,1-1,2.68A3.29,3.29,0,0,1,1047.67,378.67Zm.08-6.38a2.11,2.11,0,0,0-1.7.73,3,3,0,0,0-.63,2,2.87,2.87,0,0,0,.63,2,2.16,2.16,0,0,0,1.7.72,2.09,2.09,0,0,0,1.68-.7,3.79,3.79,0,0,0,0-4A2,2,0,0,0,1047.75,372.29Z" fill="#2f2f2f"/>
-      <path d="M1052.42,378.26v-1.21a3.34,3.34,0,0,0,2,.68c1,0,1.48-.33,1.48-1a.82.82,0,0,0-.13-.48,1.25,1.25,0,0,0-.34-.35,2.7,2.7,0,0,0-.51-.27l-.62-.24c-.31-.13-.58-.25-.82-.38a2.4,2.4,0,0,1-.59-.42,1.73,1.73,0,0,1-.35-.54,1.86,1.86,0,0,1-.12-.7,1.66,1.66,0,0,1,.22-.87,1.93,1.93,0,0,1,.6-.64,3.06,3.06,0,0,1,.86-.39,4.15,4.15,0,0,1,1-.13,4,4,0,0,1,1.62.32v1.13a3.19,3.19,0,0,0-1.77-.5,2,2,0,0,0-.57.07,1.78,1.78,0,0,0-.44.2.88.88,0,0,0-.27.31.79.79,0,0,0-.1.4.92.92,0,0,0,.1.46,1,1,0,0,0,.29.33,2.43,2.43,0,0,0,.46.26l.62.25a8.42,8.42,0,0,1,.84.37,2.88,2.88,0,0,1,.63.42,1.9,1.9,0,0,1,.4.54,1.84,1.84,0,0,1,.14.74,1.77,1.77,0,0,1-.23.9,2,2,0,0,1-.62.63,2.61,2.61,0,0,1-.88.38,4.42,4.42,0,0,1-1,.12A4.1,4.1,0,0,1,1052.42,378.26Z" fill="#2f2f2f"/>
-      <path d="M1062.77,378.51v-9.8h2.71q5.18,0,5.18,4.77a4.81,4.81,0,0,1-1.44,3.65,5.33,5.33,0,0,1-3.85,1.38Zm1.15-8.76v7.72h1.46a4.17,4.17,0,0,0,3-1,3.91,3.91,0,0,0,1.07-2.93q0-3.76-4-3.76Z" fill="#2f2f2f"/>
-      <path d="M1072.51,378.51v-9.8h2.79a3,3,0,0,1,2,.62,2,2,0,0,1,.74,1.62,2.35,2.35,0,0,1-1.69,2.32v0a2.49,2.49,0,0,1,1.58.75,2.29,2.29,0,0,1,.6,1.64,2.57,2.57,0,0,1-.9,2,3.37,3.37,0,0,1-2.28.78Zm1.15-8.76v3.16h1.18a2.24,2.24,0,0,0,1.48-.45,1.6,1.6,0,0,0,.54-1.29c0-.95-.63-1.42-1.88-1.42Zm0,4.19v3.53h1.56a2.34,2.34,0,0,0,1.57-.48,1.65,1.65,0,0,0,.56-1.31q0-1.74-2.37-1.74Z" fill="#2f2f2f"/>
-    </g>
-    <g>
-      <path d="M351.12,250a5.81,5.81,0,0,1-2.71.57,4.4,4.4,0,0,1-3.35-1.34,5,5,0,0,1-1.26-3.54,5.19,5.19,0,0,1,1.42-3.8,4.82,4.82,0,0,1,3.59-1.45,5.72,5.72,0,0,1,2.31.41v1.22a4.72,4.72,0,0,0-2.33-.59,3.55,3.55,0,0,0-2.73,1.13,4.25,4.25,0,0,0-1.05,3,4,4,0,0,0,1,2.86,3.32,3.32,0,0,0,2.57,1.06,4.83,4.83,0,0,0,2.56-.66Z" fill="#2f2f2f"/>
-      <path d="M355.67,250.55a3.22,3.22,0,0,1-2.48-1,3.62,3.62,0,0,1-.93-2.6,3.75,3.75,0,0,1,1-2.75,3.46,3.46,0,0,1,2.6-1,3.13,3.13,0,0,1,2.44,1,3.79,3.79,0,0,1,.88,2.67,3.75,3.75,0,0,1-.94,2.68A3.31,3.31,0,0,1,355.67,250.55Zm.08-6.38a2.13,2.13,0,0,0-1.71.73,3,3,0,0,0-.63,2,2.82,2.82,0,0,0,.64,2,2.15,2.15,0,0,0,1.7.72,2,2,0,0,0,1.67-.7,3.79,3.79,0,0,0,0-4A2.06,2.06,0,0,0,355.75,244.17Z" fill="#2f2f2f"/>
-      <path d="M364.52,244.52a1.39,1.39,0,0,0-.85-.22,1.41,1.41,0,0,0-1.2.68,3.12,3.12,0,0,0-.48,1.84v3.57h-1.12v-7H362v1.44h0a2.46,2.46,0,0,1,.73-1.15,1.64,1.64,0,0,1,1.1-.41,2,2,0,0,1,.67.09Z" fill="#2f2f2f"/>
-      <path d="M366.91,249.38h0v4.23h-1.12V243.39h1.12v1.23h0a2.65,2.65,0,0,1,2.42-1.39,2.54,2.54,0,0,1,2.11.94,3.84,3.84,0,0,1,.76,2.51,4.35,4.35,0,0,1-.85,2.82,2.86,2.86,0,0,1-2.34,1.05A2.34,2.34,0,0,1,366.91,249.38Zm0-2.83v1a2.05,2.05,0,0,0,.57,1.47,1.84,1.84,0,0,0,1.43.61,1.89,1.89,0,0,0,1.6-.78,3.61,3.61,0,0,0,.57-2.17,2.81,2.81,0,0,0-.54-1.83,1.78,1.78,0,0,0-1.46-.66,2,2,0,0,0-1.57.68A2.47,2.47,0,0,0,366.88,246.55Z" fill="#2f2f2f"/>
-      <path d="M382.84,250.39h-1.12V249.3h0a2.36,2.36,0,0,1-2.15,1.25,2.29,2.29,0,0,1-1.64-.55,1.9,1.9,0,0,1-.59-1.47q0-2,2.31-2.28l2.1-.3c0-1.19-.48-1.78-1.45-1.78A3.47,3.47,0,0,0,378,245v-1.15a4.32,4.32,0,0,1,2.38-.65c1.65,0,2.47.87,2.47,2.61Zm-1.12-3.54-1.69.23a2.67,2.67,0,0,0-1.18.39,1.11,1.11,0,0,0-.39,1,1.09,1.09,0,0,0,.36.84,1.46,1.46,0,0,0,1,.32,1.78,1.78,0,0,0,1.37-.58,2.07,2.07,0,0,0,.55-1.48Z" fill="#2f2f2f"/>
-      <path d="M386,249.38h0v4.23h-1.12V243.39H386v1.23h0a2.65,2.65,0,0,1,2.42-1.39,2.56,2.56,0,0,1,2.11.94,3.84,3.84,0,0,1,.76,2.51,4.35,4.35,0,0,1-.86,2.82,2.85,2.85,0,0,1-2.33,1.05A2.34,2.34,0,0,1,386,249.38Zm0-2.83v1a2.09,2.09,0,0,0,.56,1.47,2,2,0,0,0,3-.17,3.54,3.54,0,0,0,.58-2.17,2.81,2.81,0,0,0-.54-1.83,1.79,1.79,0,0,0-1.46-.66,2,2,0,0,0-1.57.68A2.47,2.47,0,0,0,386,246.55Z" fill="#2f2f2f"/>
-      <path d="M394.16,249.38h0v4.23H393V243.39h1.12v1.23h0a2.66,2.66,0,0,1,2.42-1.39,2.56,2.56,0,0,1,2.12.94,3.89,3.89,0,0,1,.76,2.51,4.35,4.35,0,0,1-.86,2.82,2.86,2.86,0,0,1-2.34,1.05A2.36,2.36,0,0,1,394.16,249.38Zm0-2.83v1a2,2,0,0,0,.56,1.47,1.85,1.85,0,0,0,1.43.61,1.89,1.89,0,0,0,1.6-.78,3.61,3.61,0,0,0,.58-2.17,2.81,2.81,0,0,0-.54-1.83,1.8,1.8,0,0,0-1.47-.66,2,2,0,0,0-1.57.68A2.46,2.46,0,0,0,394.14,246.55Z" fill="#2f2f2f"/>
-      <path d="M402.31,250.39h-1.13V240h1.13Z" fill="#2f2f2f"/>
-      <path d="M405,241.61a.73.73,0,0,1-.51-.2.7.7,0,0,1-.21-.52.7.7,0,0,1,.72-.73.78.78,0,0,1,.53.2.72.72,0,0,1,.21.53.69.69,0,0,1-.21.51A.74.74,0,0,1,405,241.61Zm.55,8.78h-1.12v-7h1.12Z" fill="#2f2f2f"/>
-      <path d="M412.45,250.07a3.66,3.66,0,0,1-1.91.48,3.16,3.16,0,0,1-2.42-1,3.55,3.55,0,0,1-.92-2.53,3.89,3.89,0,0,1,1-2.78,3.47,3.47,0,0,1,2.65-1,3.68,3.68,0,0,1,1.63.34v1.15a2.83,2.83,0,0,0-1.67-.55,2.23,2.23,0,0,0-1.76.77,2.9,2.9,0,0,0-.69,2,2.79,2.79,0,0,0,.65,1.94,2.22,2.22,0,0,0,1.73.71,2.78,2.78,0,0,0,1.72-.61Z" fill="#2f2f2f"/>
-      <path d="M419.2,250.39h-1.13V249.3h0a2.37,2.37,0,0,1-2.16,1.25,2.28,2.28,0,0,1-1.63-.55,1.9,1.9,0,0,1-.59-1.47q0-2,2.31-2.28l2.09-.3c0-1.19-.48-1.78-1.44-1.78a3.47,3.47,0,0,0-2.28.86v-1.15a4.32,4.32,0,0,1,2.38-.65c1.64,0,2.47.87,2.47,2.61Zm-1.13-3.54-1.68.23a2.63,2.63,0,0,0-1.18.39,1.12,1.12,0,0,0-.4,1,1.1,1.1,0,0,0,.37.84,1.44,1.44,0,0,0,1,.32,1.79,1.79,0,0,0,1.38-.58,2.11,2.11,0,0,0,.54-1.48Z" fill="#2f2f2f"/>
-      <path d="M424.45,250.32a2.09,2.09,0,0,1-1,.22c-1.23,0-1.84-.68-1.84-2v-4.14h-1.2v-1h1.2v-1.71l1.12-.36v2.07h1.76v1h-1.76v3.94a1.67,1.67,0,0,0,.24,1,1,1,0,0,0,.79.3,1.14,1.14,0,0,0,.73-.24Z" fill="#2f2f2f"/>
-      <path d="M426.41,241.61a.73.73,0,0,1-.51-.2.67.67,0,0,1-.22-.52.69.69,0,0,1,.22-.53.73.73,0,0,1,.51-.2.75.75,0,0,1,.52.2.69.69,0,0,1,.22.53.67.67,0,0,1-.22.51A.72.72,0,0,1,426.41,241.61Zm.55,8.78h-1.13v-7H427Z" fill="#2f2f2f"/>
-      <path d="M432.05,250.55a3.24,3.24,0,0,1-2.48-1,3.65,3.65,0,0,1-.92-2.6,3.79,3.79,0,0,1,1-2.75,3.46,3.46,0,0,1,2.6-1,3.16,3.16,0,0,1,2.45,1,3.84,3.84,0,0,1,.88,2.67,3.75,3.75,0,0,1-1,2.68A3.29,3.29,0,0,1,432.05,250.55Zm.08-6.38a2.13,2.13,0,0,0-1.71.73,3,3,0,0,0-.63,2,2.87,2.87,0,0,0,.64,2,2.15,2.15,0,0,0,1.7.72,2,2,0,0,0,1.67-.7,3.74,3.74,0,0,0,0-4A2,2,0,0,0,432.13,244.17Z" fill="#2f2f2f"/>
-      <path d="M443.06,250.39h-1.12v-4c0-1.49-.54-2.23-1.62-2.23a1.78,1.78,0,0,0-1.4.63,2.37,2.37,0,0,0-.55,1.6v4h-1.12v-7h1.12v1.16h0a2.54,2.54,0,0,1,2.3-1.32,2.14,2.14,0,0,1,1.76.74,3.33,3.33,0,0,1,.6,2.14Z" fill="#2f2f2f"/>
-      <path d="M376.12,266.52a6.48,6.48,0,0,1-3.28.83,4.47,4.47,0,0,1-3.39-1.35,4.94,4.94,0,0,1-1.3-3.58,5.1,5.1,0,0,1,1.44-3.74,4.93,4.93,0,0,1,3.65-1.46,6.32,6.32,0,0,1,2.69.52V259a5.21,5.21,0,0,0-2.82-.75,3.51,3.51,0,0,0-2.7,1.14,4.76,4.76,0,0,0-.08,5.86,3.44,3.44,0,0,0,2.66,1.06,4.06,4.06,0,0,0,2-.46v-2.75h-2.15v-1h3.29Z" fill="#2f2f2f"/>
-      <path d="M383.21,267.19h-1.12V266.1h0a2.35,2.35,0,0,1-2.15,1.25,2.31,2.31,0,0,1-1.64-.55,1.94,1.94,0,0,1-.59-1.47q0-2,2.31-2.28l2.1-.3c0-1.19-.48-1.78-1.44-1.78a3.47,3.47,0,0,0-2.29.86v-1.15a4.32,4.32,0,0,1,2.38-.66c1.65,0,2.47.88,2.47,2.62Zm-1.12-3.54-1.69.23a2.58,2.58,0,0,0-1.17.39,1.09,1.09,0,0,0-.4,1,1.05,1.05,0,0,0,.36.83,1.42,1.42,0,0,0,1,.33,1.86,1.86,0,0,0,1.38-.58,2.11,2.11,0,0,0,.54-1.48Z" fill="#2f2f2f"/>
-      <path d="M388.47,267.12a2.1,2.1,0,0,1-1.05.22c-1.22,0-1.84-.68-1.84-2v-4.14h-1.2v-1h1.2v-1.71l1.13-.36v2.07h1.76v1h-1.76v3.94a1.75,1.75,0,0,0,.23,1,1,1,0,0,0,.8.3,1.16,1.16,0,0,0,.73-.24Z" fill="#2f2f2f"/>
-      <path d="M395.46,264h-4.94a2.61,2.61,0,0,0,.63,1.8,2.14,2.14,0,0,0,1.65.64,3.45,3.45,0,0,0,2.18-.78v1.05a4.05,4.05,0,0,1-2.44.67,2.93,2.93,0,0,1-2.33-1,4.49,4.49,0,0,1,.07-5.35,3,3,0,0,1,2.3-1,2.64,2.64,0,0,1,2.13.89,3.74,3.74,0,0,1,.75,2.47Zm-1.15-1a2.29,2.29,0,0,0-.46-1.51,1.61,1.61,0,0,0-1.29-.54,1.81,1.81,0,0,0-1.34.57,2.56,2.56,0,0,0-.69,1.48Z" fill="#2f2f2f"/>
-      <path d="M405.94,260.19l-2.1,7h-1.16l-1.45-5a3.82,3.82,0,0,1-.11-.65h0a3.07,3.07,0,0,1-.15.63l-1.56,5h-1.12l-2.12-7h1.17l1.45,5.26a3,3,0,0,1,.1.63h.05a3.31,3.31,0,0,1,.13-.64l1.61-5.25h1l1.45,5.28a3.66,3.66,0,0,1,.11.63h.05a2.86,2.86,0,0,1,.12-.63l1.42-5.28Z" fill="#2f2f2f"/>
-      <path d="M412.11,267.19H411V266.1h0a2.35,2.35,0,0,1-2.15,1.25,2.31,2.31,0,0,1-1.64-.55,1.94,1.94,0,0,1-.59-1.47q0-2,2.31-2.28l2.1-.3c0-1.19-.48-1.78-1.44-1.78a3.47,3.47,0,0,0-2.29.86v-1.15a4.35,4.35,0,0,1,2.38-.66c1.65,0,2.47.88,2.47,2.62ZM411,263.65l-1.69.23a2.58,2.58,0,0,0-1.17.39,1.09,1.09,0,0,0-.4,1,1.05,1.05,0,0,0,.36.83,1.42,1.42,0,0,0,1,.33,1.86,1.86,0,0,0,1.38-.58,2.11,2.11,0,0,0,.54-1.48Z" fill="#2f2f2f"/>
-      <path d="M419.62,260.19l-3.22,8.12c-.57,1.45-1.38,2.17-2.42,2.17a3,3,0,0,1-.73-.08v-1a2.1,2.1,0,0,0,.66.12,1.38,1.38,0,0,0,1.28-1l.56-1.32-2.74-7h1.25l1.89,5.39c0,.06.07.24.14.53h0c0-.11.07-.28.14-.52l2-5.4Z" fill="#2f2f2f"/>
-    </g>
-    <g>
-      <path d="M614.61,238.83h-1.27l-1-2.75h-4.16l-1,2.75h-1.27l3.76-9.8h1.18Zm-2.69-3.78-1.54-4.17a4.18,4.18,0,0,1-.15-.66h0a4,4,0,0,1-.16.66l-1.53,4.17Z" fill="#2f2f2f"/>
-      <path d="M621.22,232.15l-4.14,5.73h4.1v1h-5.75v-.35l4.14-5.69h-3.75v-1h5.4Z" fill="#2f2f2f"/>
-      <path d="M628.32,238.83H627.2v-1.11h0A2.32,2.32,0,0,1,625,239c-1.67,0-2.5-1-2.5-3v-4.19h1.11v4c0,1.47.57,2.21,1.7,2.21a1.74,1.74,0,0,0,1.35-.6,2.34,2.34,0,0,0,.53-1.58v-4h1.12Z" fill="#2f2f2f"/>
-      <path d="M634.07,233a1.33,1.33,0,0,0-.84-.23,1.43,1.43,0,0,0-1.2.68,3.11,3.11,0,0,0-.49,1.84v3.57h-1.12v-7h1.12v1.44h0a2.54,2.54,0,0,1,.73-1.15,1.71,1.71,0,0,1,1.1-.41,1.89,1.89,0,0,1,.67.09Z" fill="#2f2f2f"/>
-      <path d="M640.92,235.61H636a2.66,2.66,0,0,0,.63,1.81,2.19,2.19,0,0,0,1.66.63,3.42,3.42,0,0,0,2.17-.78v1.06A4.1,4.1,0,0,1,638,239a3,3,0,0,1-2.33-1,3.87,3.87,0,0,1-.85-2.68,3.8,3.8,0,0,1,.93-2.66,3,3,0,0,1,2.3-1,2.62,2.62,0,0,1,2.13.89,3.69,3.69,0,0,1,.75,2.46Zm-1.15-1a2.31,2.31,0,0,0-.47-1.51,1.59,1.59,0,0,0-1.28-.54,1.81,1.81,0,0,0-1.35.57,2.58,2.58,0,0,0-.68,1.48Z" fill="#2f2f2f"/>
-      <path d="M587.22,255.63h-5.09v-9.8h1.15v8.76h3.94Z" fill="#2f2f2f"/>
-      <path d="M591.4,255.8a3.25,3.25,0,0,1-2.48-1,3.65,3.65,0,0,1-.92-2.6,3.79,3.79,0,0,1,1-2.75,3.48,3.48,0,0,1,2.61-1,3.13,3.13,0,0,1,2.44,1,4.38,4.38,0,0,1-.07,5.36A3.33,3.33,0,0,1,591.4,255.8Zm.09-6.39a2.13,2.13,0,0,0-1.71.74,3,3,0,0,0-.63,2,2.85,2.85,0,0,0,.63,2,2.17,2.17,0,0,0,1.71.72,2,2,0,0,0,1.67-.7,3.06,3.06,0,0,0,.58-2,3.13,3.13,0,0,0-.58-2A2.06,2.06,0,0,0,591.49,249.41Z" fill="#2f2f2f"/>
-      <path d="M601.64,255.63h-1.12v-1.09h0a2.35,2.35,0,0,1-2.15,1.26,2.3,2.3,0,0,1-1.64-.56,1.9,1.9,0,0,1-.59-1.47q0-2,2.31-2.28l2.1-.29c0-1.19-.48-1.79-1.45-1.79a3.47,3.47,0,0,0-2.28.86v-1.15a4.4,4.4,0,0,1,2.38-.65c1.65,0,2.47.87,2.47,2.61Zm-1.12-3.54-1.69.23a2.81,2.81,0,0,0-1.18.39,1.11,1.11,0,0,0-.39,1,1.09,1.09,0,0,0,.36.84,1.46,1.46,0,0,0,1,.32,1.78,1.78,0,0,0,1.37-.58,2.06,2.06,0,0,0,.55-1.48Z" fill="#2f2f2f"/>
-      <path d="M609.71,255.63h-1.12v-1.19h0a2.6,2.6,0,0,1-2.41,1.36,2.64,2.64,0,0,1-2.11-.94,3.9,3.9,0,0,1-.79-2.56,4.18,4.18,0,0,1,.88-2.79,2.9,2.9,0,0,1,2.33-1,2.26,2.26,0,0,1,2.1,1.13h0v-4.33h1.12Zm-1.12-3.16v-1A2,2,0,0,0,608,250a1.91,1.91,0,0,0-1.43-.59,1.93,1.93,0,0,0-1.61.75,3.32,3.32,0,0,0-.59,2.08,2.94,2.94,0,0,0,.57,1.91,1.82,1.82,0,0,0,1.51.7,1.92,1.92,0,0,0,1.52-.67A2.56,2.56,0,0,0,608.59,252.47Z" fill="#2f2f2f"/>
-      <path d="M616,255.63v-9.8h2.79a3.09,3.09,0,0,1,2,.62,2,2,0,0,1,.74,1.62,2.38,2.38,0,0,1-.45,1.45,2.46,2.46,0,0,1-1.24.88v0a2.49,2.49,0,0,1,1.58.75,2.29,2.29,0,0,1,.6,1.65,2.56,2.56,0,0,1-.9,2,3.37,3.37,0,0,1-2.28.78Zm1.15-8.76V250h1.18a2.24,2.24,0,0,0,1.48-.45,1.58,1.58,0,0,0,.54-1.28c0-1-.63-1.43-1.88-1.43Zm0,4.2v3.52h1.56a2.34,2.34,0,0,0,1.57-.48,1.62,1.62,0,0,0,.55-1.31c0-1.16-.78-1.73-2.36-1.73Z" fill="#2f2f2f"/>
-      <path d="M628.81,255.63h-1.13v-1.09h0a2.36,2.36,0,0,1-2.16,1.26,2.29,2.29,0,0,1-1.63-.56,1.9,1.9,0,0,1-.59-1.47q0-2,2.31-2.28l2.09-.29c0-1.19-.48-1.79-1.44-1.79a3.47,3.47,0,0,0-2.28.86v-1.15a4.4,4.4,0,0,1,2.38-.65c1.64,0,2.47.87,2.47,2.61Zm-1.13-3.54-1.68.23a2.76,2.76,0,0,0-1.18.39,1.12,1.12,0,0,0-.4,1,1.1,1.1,0,0,0,.37.84,1.44,1.44,0,0,0,1,.32,1.79,1.79,0,0,0,1.38-.58,2.09,2.09,0,0,0,.54-1.48Z" fill="#2f2f2f"/>
-      <path d="M632,255.63h-1.12V245.27H632Z" fill="#2f2f2f"/>
-      <path d="M639.1,255.63H638v-1.09h0a2.34,2.34,0,0,1-2.15,1.26,2.31,2.31,0,0,1-1.64-.56,1.94,1.94,0,0,1-.59-1.47q0-2,2.31-2.28l2.1-.29c0-1.19-.48-1.79-1.44-1.79a3.47,3.47,0,0,0-2.29.86v-1.15a4.43,4.43,0,0,1,2.38-.65c1.65,0,2.47.87,2.47,2.61ZM638,252.09l-1.69.23a2.71,2.71,0,0,0-1.17.39,1.28,1.28,0,0,0,0,1.82,1.46,1.46,0,0,0,1,.32,1.82,1.82,0,0,0,1.38-.58,2.09,2.09,0,0,0,.54-1.48Z" fill="#2f2f2f"/>
-      <path d="M646.93,255.63h-1.12v-4c0-1.49-.54-2.23-1.63-2.23a1.77,1.77,0,0,0-1.39.63,2.39,2.39,0,0,0-.55,1.6v4h-1.12v-7h1.12v1.16h0a2.53,2.53,0,0,1,2.3-1.32,2.11,2.11,0,0,1,1.75.74,3.27,3.27,0,0,1,.61,2.14Z" fill="#2f2f2f"/>
-      <path d="M653.78,255.31a3.66,3.66,0,0,1-1.91.49,3.17,3.17,0,0,1-2.42-1,3.54,3.54,0,0,1-.92-2.52,3.88,3.88,0,0,1,1-2.78,3.48,3.48,0,0,1,2.65-1.05,3.61,3.61,0,0,1,1.62.34V250a2.78,2.78,0,0,0-1.66-.55,2.25,2.25,0,0,0-1.76.77,2.91,2.91,0,0,0-.69,2,2.73,2.73,0,0,0,.65,1.94,2.19,2.19,0,0,0,1.73.71,2.78,2.78,0,0,0,1.72-.61Z" fill="#2f2f2f"/>
-      <path d="M661,252.41H656a2.66,2.66,0,0,0,.63,1.81,2.17,2.17,0,0,0,1.65.63,3.47,3.47,0,0,0,2.18-.78v1.06a4.12,4.12,0,0,1-2.44.67,3,3,0,0,1-2.34-1,3.91,3.91,0,0,1-.84-2.68,3.84,3.84,0,0,1,.92-2.66,3,3,0,0,1,2.3-1,2.61,2.61,0,0,1,2.13.89,3.69,3.69,0,0,1,.75,2.46Zm-1.15-.95a2.24,2.24,0,0,0-.47-1.51,1.58,1.58,0,0,0-1.28-.54,1.79,1.79,0,0,0-1.34.57,2.59,2.59,0,0,0-.69,1.48Z" fill="#2f2f2f"/>
-      <path d="M666.28,249.77a1.33,1.33,0,0,0-.84-.23,1.43,1.43,0,0,0-1.2.68,3.11,3.11,0,0,0-.49,1.84v3.57h-1.12v-7h1.12v1.44h0a2.54,2.54,0,0,1,.73-1.15,1.71,1.71,0,0,1,1.1-.41,1.89,1.89,0,0,1,.67.09Z" fill="#2f2f2f"/>
-    </g>
-    <g>
-      <path d="M665.75,23h-1.14V16.46c0-.52,0-1.16.1-1.91h0a7.17,7.17,0,0,1-.29.95L661,23h-.56l-3.35-7.48a6.47,6.47,0,0,1-.29-1h0q.06.58.06,1.92V23h-1.11v-9.8h1.52l3,6.83a8.57,8.57,0,0,1,.46,1.18h0c.19-.54.35-.94.47-1.2l3.07-6.81h1.43Z" fill="#2f2f2f"/>
-      <path d="M671.29,23.2a3.23,3.23,0,0,1-2.48-1,3.61,3.61,0,0,1-.92-2.6,3.79,3.79,0,0,1,1-2.75,3.46,3.46,0,0,1,2.6-1,3.16,3.16,0,0,1,2.45,1,3.85,3.85,0,0,1,.88,2.67,3.78,3.78,0,0,1-.95,2.69A3.33,3.33,0,0,1,671.29,23.2Zm.08-6.39a2.14,2.14,0,0,0-1.71.74,3,3,0,0,0-.63,2,2.85,2.85,0,0,0,.64,2,2.15,2.15,0,0,0,1.7.72,2,2,0,0,0,1.67-.7,3.06,3.06,0,0,0,.59-2,3.13,3.13,0,0,0-.59-2A2,2,0,0,0,671.37,16.81Z" fill="#2f2f2f"/>
-      <path d="M682.58,23h-1.12V19c0-1.49-.54-2.23-1.63-2.23a1.77,1.77,0,0,0-1.39.63,2.39,2.39,0,0,0-.55,1.6v4h-1.12V16h1.12v1.16h0a2.53,2.53,0,0,1,2.3-1.32,2.11,2.11,0,0,1,1.75.74,3.27,3.27,0,0,1,.61,2.14Z" fill="#2f2f2f"/>
-      <path d="M685.45,14.25a.72.72,0,0,1-.52-.2.75.75,0,0,1,0-1,.73.73,0,0,1,.52-.21A.72.72,0,0,1,686,13a.74.74,0,0,1,0,1A.72.72,0,0,1,685.45,14.25ZM686,23h-1.12V16H686Z" fill="#2f2f2f"/>
-      <path d="M691.72,23a2.09,2.09,0,0,1-1,.22c-1.23,0-1.84-.68-1.84-2.05V17h-1.21V16h1.21V14.32L690,14V16h1.76v1H690v3.94a1.65,1.65,0,0,0,.24,1,1,1,0,0,0,.79.3,1.2,1.2,0,0,0,.73-.23Z" fill="#2f2f2f"/>
-      <path d="M696.26,23.2a3.23,3.23,0,0,1-2.48-1,3.62,3.62,0,0,1-.93-2.6,3.79,3.79,0,0,1,1-2.75,3.46,3.46,0,0,1,2.6-1,3.16,3.16,0,0,1,2.45,1,3.85,3.85,0,0,1,.88,2.67,3.78,3.78,0,0,1-1,2.69A3.33,3.33,0,0,1,696.26,23.2Zm.08-6.39a2.14,2.14,0,0,0-1.71.74,3,3,0,0,0-.63,2,2.81,2.81,0,0,0,.64,2,2.15,2.15,0,0,0,1.7.72,2,2,0,0,0,1.67-.7,3.06,3.06,0,0,0,.59-2,3.13,3.13,0,0,0-.59-2A2,2,0,0,0,696.34,16.81Z" fill="#2f2f2f"/>
-      <path d="M705.39,17.17a1.39,1.39,0,0,0-.85-.23,1.43,1.43,0,0,0-1.2.68,3.12,3.12,0,0,0-.48,1.84V23h-1.12V16h1.12v1.44h0a2.46,2.46,0,0,1,.73-1.15,1.71,1.71,0,0,1,1.1-.41,1.92,1.92,0,0,1,.67.09Z" fill="#2f2f2f"/>
-      <path d="M707.49,14.25a.69.69,0,0,1-.51-.2.72.72,0,0,1,0-1,.69.69,0,0,1,.51-.21A.72.72,0,0,1,708,13a.71.71,0,0,1,0,1A.72.72,0,0,1,707.49,14.25ZM708,23h-1.13V16H708Z" fill="#2f2f2f"/>
-      <path d="M716.24,23h-1.12V19c0-1.49-.54-2.23-1.62-2.23a1.76,1.76,0,0,0-1.39.63,2.35,2.35,0,0,0-.56,1.6v4h-1.12V16h1.12v1.16h0a2.54,2.54,0,0,1,2.3-1.32,2.14,2.14,0,0,1,1.76.74,3.33,3.33,0,0,1,.6,2.14Z" fill="#2f2f2f"/>
-      <path d="M724.6,22.47q0,3.86-3.69,3.86a4.93,4.93,0,0,1-2.27-.5V24.71a4.64,4.64,0,0,0,2.25.66c1.73,0,2.59-.92,2.59-2.75v-.76h0a2.83,2.83,0,0,1-4.51.4,3.71,3.71,0,0,1-.79-2.5,4.37,4.37,0,0,1,.85-2.84,2.89,2.89,0,0,1,2.35-1.05,2.3,2.3,0,0,1,2.1,1.13h0V16h1.12Zm-1.12-2.6v-1a2,2,0,0,0-.57-1.42,1.83,1.83,0,0,0-1.4-.6,1.94,1.94,0,0,0-1.63.76,3.37,3.37,0,0,0-.59,2.11,2.88,2.88,0,0,0,.57,1.87,1.8,1.8,0,0,0,1.49.7,2,2,0,0,0,1.54-.67A2.5,2.5,0,0,0,723.48,19.87Z" fill="#2f2f2f"/>
-      <path d="M649,31.05a.72.72,0,0,1-.52-.2.75.75,0,0,1,0-1,.73.73,0,0,1,.52-.21.72.72,0,0,1,.52.21.71.71,0,0,1,0,1A.72.72,0,0,1,649,31.05Zm.54,8.78h-1.12v-7h1.12Z" fill="#2f2f2f"/>
-      <path d="M657.71,39.83h-1.12v-4c0-1.49-.54-2.23-1.63-2.23a1.77,1.77,0,0,0-1.39.63,2.39,2.39,0,0,0-.55,1.6v4H651.9v-7H653V34h0a2.54,2.54,0,0,1,2.3-1.32,2.11,2.11,0,0,1,1.75.74,3.27,3.27,0,0,1,.61,2.14Z" fill="#2f2f2f"/>
-      <path d="M663.4,30.45a1.54,1.54,0,0,0-.75-.18c-.78,0-1.17.49-1.17,1.48v1.08h1.64v1h-1.64v6h-1.12v-6h-1.19v-1h1.19V31.7A2.36,2.36,0,0,1,661,30a2.13,2.13,0,0,1,1.59-.64,2.23,2.23,0,0,1,.81.12Z" fill="#2f2f2f"/>
-      <path d="M668.29,34a1.39,1.39,0,0,0-.85-.23,1.43,1.43,0,0,0-1.2.68,3.12,3.12,0,0,0-.48,1.84v3.57h-1.12v-7h1.12v1.44h0a2.46,2.46,0,0,1,.73-1.15,1.69,1.69,0,0,1,1.1-.41,1.92,1.92,0,0,1,.67.09Z" fill="#2f2f2f"/>
-      <path d="M674.75,39.83h-1.12V38.74h0A2.36,2.36,0,0,1,671.44,40a2.29,2.29,0,0,1-1.63-.56,1.9,1.9,0,0,1-.59-1.47q0-2,2.31-2.28l2.1-.29c0-1.19-.49-1.79-1.45-1.79a3.47,3.47,0,0,0-2.28.86V33.32a4.4,4.4,0,0,1,2.38-.65c1.64,0,2.47.87,2.47,2.61Zm-1.12-3.54-1.69.23a2.76,2.76,0,0,0-1.18.39,1.12,1.12,0,0,0-.4,1,1.1,1.1,0,0,0,.37.84,1.44,1.44,0,0,0,1,.32,1.79,1.79,0,0,0,1.38-.58,2.12,2.12,0,0,0,.55-1.48Z" fill="#2f2f2f"/>
-      <path d="M676.67,39.58v-1.2a3.31,3.31,0,0,0,2,.67c1,0,1.48-.33,1.48-1a.9.9,0,0,0-.12-.48,1.26,1.26,0,0,0-.35-.34,2.61,2.61,0,0,0-.5-.27c-.2-.08-.4-.17-.63-.25a7.93,7.93,0,0,1-.81-.37,2.31,2.31,0,0,1-.59-.43,1.56,1.56,0,0,1-.36-.53,2,2,0,0,1-.12-.71,1.66,1.66,0,0,1,.23-.87,2,2,0,0,1,.6-.64,2.68,2.68,0,0,1,.86-.38,3.64,3.64,0,0,1,1-.13A4,4,0,0,1,681,33v1.14a3.17,3.17,0,0,0-1.78-.51,2,2,0,0,0-.57.07,1.71,1.71,0,0,0-.43.2,1,1,0,0,0-.28.32.77.77,0,0,0-.1.4.88.88,0,0,0,.1.45.91.91,0,0,0,.29.33,2.22,2.22,0,0,0,.46.26l.63.25a8.19,8.19,0,0,1,.83.37,3.13,3.13,0,0,1,.63.42,1.66,1.66,0,0,1,.4.55,1.79,1.79,0,0,1,.14.73,1.74,1.74,0,0,1-.23.9,2,2,0,0,1-.61.64,2.78,2.78,0,0,1-.88.37,4.51,4.51,0,0,1-1.05.13A3.94,3.94,0,0,1,676.67,39.58Z" fill="#2f2f2f"/>
-      <path d="M686.6,39.76a2.09,2.09,0,0,1-1,.22c-1.23,0-1.84-.68-1.84-2V33.79h-1.21v-1h1.21V31.12l1.12-.36v2.07h1.76v1h-1.76v3.94a1.65,1.65,0,0,0,.24,1,1,1,0,0,0,.79.3,1.2,1.2,0,0,0,.73-.23Z" fill="#2f2f2f"/>
-      <path d="M691.91,34a1.37,1.37,0,0,0-.85-.23,1.43,1.43,0,0,0-1.19.68,3,3,0,0,0-.49,1.84v3.57h-1.12v-7h1.12v1.44h0a2.46,2.46,0,0,1,.73-1.15,1.71,1.71,0,0,1,1.1-.41,1.89,1.89,0,0,1,.67.09Z" fill="#2f2f2f"/>
-      <path d="M699.17,39.83h-1.12V38.72h0A2.3,2.3,0,0,1,695.86,40c-1.66,0-2.5-1-2.5-3V32.83h1.12v4c0,1.47.56,2.21,1.69,2.21a1.71,1.71,0,0,0,1.35-.6,2.3,2.3,0,0,0,.53-1.59v-4h1.12Z" fill="#2f2f2f"/>
-      <path d="M706.4,39.51a3.7,3.7,0,0,1-1.92.49,3.15,3.15,0,0,1-2.41-1,3.49,3.49,0,0,1-.92-2.52,3.88,3.88,0,0,1,1-2.78,3.46,3.46,0,0,1,2.64-1,3.65,3.65,0,0,1,1.63.34v1.15a2.83,2.83,0,0,0-1.67-.55,2.27,2.27,0,0,0-1.76.77,2.91,2.91,0,0,0-.69,2,2.77,2.77,0,0,0,.65,1.94,2.21,2.21,0,0,0,1.73.71,2.81,2.81,0,0,0,1.73-.61Z" fill="#2f2f2f"/>
-      <path d="M711.84,39.76a2.1,2.1,0,0,1-1.05.22c-1.22,0-1.83-.68-1.83-2V33.79h-1.21v-1H709V31.12l1.12-.36v2.07h1.76v1h-1.76v3.94a1.65,1.65,0,0,0,.24,1,.94.94,0,0,0,.79.3,1.22,1.22,0,0,0,.73-.23Z" fill="#2f2f2f"/>
-      <path d="M719.24,39.83h-1.12V38.72h0A2.3,2.3,0,0,1,715.93,40c-1.67,0-2.5-1-2.5-3V32.83h1.11v4c0,1.47.57,2.21,1.7,2.21a1.74,1.74,0,0,0,1.35-.6,2.35,2.35,0,0,0,.53-1.59v-4h1.12Z" fill="#2f2f2f"/>
-      <path d="M725.28,34a1.39,1.39,0,0,0-.85-.23,1.43,1.43,0,0,0-1.2.68,3.12,3.12,0,0,0-.48,1.84v3.57h-1.12v-7h1.12v1.44h0a2.54,2.54,0,0,1,.73-1.15,1.71,1.71,0,0,1,1.11-.41,2,2,0,0,1,.67.09Z" fill="#2f2f2f"/>
-      <path d="M732.4,36.61h-4.94a2.6,2.6,0,0,0,.62,1.81,2.21,2.21,0,0,0,1.66.63,3.42,3.42,0,0,0,2.17-.78v1.06a4.1,4.1,0,0,1-2.44.67,3,3,0,0,1-2.33-1,3.92,3.92,0,0,1-.85-2.68,3.8,3.8,0,0,1,.93-2.66,3,3,0,0,1,2.3-1,2.61,2.61,0,0,1,2.13.89A3.69,3.69,0,0,1,732.4,36Zm-1.15-1a2.24,2.24,0,0,0-.47-1.51,1.59,1.59,0,0,0-1.28-.54,1.81,1.81,0,0,0-1.35.57,2.58,2.58,0,0,0-.68,1.48Z" fill="#2f2f2f"/>
-    </g>
-    <g>
-      <path d="M815.06,22.64V21.28a2.52,2.52,0,0,0,.55.37,5.24,5.24,0,0,0,.69.28,6.25,6.25,0,0,0,.72.17,4.06,4.06,0,0,0,.67.06,2.65,2.65,0,0,0,1.58-.39,1.32,1.32,0,0,0,.52-1.13,1.29,1.29,0,0,0-.17-.69,2,2,0,0,0-.48-.54,5.42,5.42,0,0,0-.73-.46c-.28-.15-.58-.31-.91-.47s-.66-.35-1-.53a4,4,0,0,1-.78-.59,2.42,2.42,0,0,1-.51-.72,2.19,2.19,0,0,1-.19-1,2.29,2.29,0,0,1,.29-1.16,2.65,2.65,0,0,1,.78-.82,3.72,3.72,0,0,1,1.09-.48,5.14,5.14,0,0,1,1.24-.16,4.86,4.86,0,0,1,2.12.35v1.3a4.15,4.15,0,0,0-3-.53,2,2,0,0,0-.67.26,1.41,1.41,0,0,0-.48.46,1.14,1.14,0,0,0-.19.68,1.45,1.45,0,0,0,.14.65,1.63,1.63,0,0,0,.42.5,4,4,0,0,0,.66.44l.91.46c.35.17.68.36,1,.55a4.44,4.44,0,0,1,.82.63,2.84,2.84,0,0,1,.57.78,2.13,2.13,0,0,1,.21,1,2.42,2.42,0,0,1-.29,1.22,2.3,2.3,0,0,1-.76.82,3.46,3.46,0,0,1-1.11.46,6.31,6.31,0,0,1-1.33.14c-.15,0-.35,0-.57,0s-.46-.06-.7-.11a5.92,5.92,0,0,1-.67-.18A2.06,2.06,0,0,1,815.06,22.64Z" fill="#2f2f2f"/>
-      <path d="M828.66,19.81h-4.94a2.6,2.6,0,0,0,.62,1.81,2.21,2.21,0,0,0,1.66.63,3.42,3.42,0,0,0,2.17-.78v1.06a4.1,4.1,0,0,1-2.44.67,3,3,0,0,1-2.33-1,3.92,3.92,0,0,1-.85-2.68,3.8,3.8,0,0,1,.93-2.66,3,3,0,0,1,2.3-1,2.61,2.61,0,0,1,2.13.89,3.69,3.69,0,0,1,.75,2.46Zm-1.15-.95a2.24,2.24,0,0,0-.47-1.51,1.59,1.59,0,0,0-1.28-.54,1.81,1.81,0,0,0-1.35.57,2.58,2.58,0,0,0-.68,1.48Z" fill="#2f2f2f"/>
-      <path d="M835.44,22.71a3.7,3.7,0,0,1-1.92.49,3.15,3.15,0,0,1-2.41-1,3.49,3.49,0,0,1-.92-2.52,3.88,3.88,0,0,1,1-2.78,3.46,3.46,0,0,1,2.64-1.05,3.65,3.65,0,0,1,1.63.34v1.15a2.83,2.83,0,0,0-1.67-.55,2.27,2.27,0,0,0-1.76.77,2.91,2.91,0,0,0-.69,2,2.77,2.77,0,0,0,.65,1.94,2.21,2.21,0,0,0,1.73.71,2.81,2.81,0,0,0,1.73-.61Z" fill="#2f2f2f"/>
-      <path d="M842.94,23h-1.12V21.92h0a2.3,2.3,0,0,1-2.16,1.28c-1.67,0-2.5-1-2.5-3V16h1.12v4c0,1.47.56,2.21,1.69,2.21a1.71,1.71,0,0,0,1.35-.6,2.35,2.35,0,0,0,.53-1.59V16h1.12Z" fill="#2f2f2f"/>
-      <path d="M849,17.17a1.39,1.39,0,0,0-.85-.23,1.43,1.43,0,0,0-1.2.68,3.12,3.12,0,0,0-.48,1.84V23h-1.12V16h1.12v1.44h0a2.46,2.46,0,0,1,.73-1.15,1.69,1.69,0,0,1,1.1-.41A2,2,0,0,1,849,16Z" fill="#2f2f2f"/>
-      <path d="M851.08,14.25a.72.72,0,0,1-.52-.2.75.75,0,0,1,0-1,.73.73,0,0,1,.52-.21.72.72,0,0,1,.52.21.71.71,0,0,1,0,1A.72.72,0,0,1,851.08,14.25Zm.54,8.78H850.5V16h1.12Z" fill="#2f2f2f"/>
-      <path d="M857.35,23a2.09,2.09,0,0,1-1,.22c-1.23,0-1.84-.68-1.84-2.05V17h-1.21V16h1.21V14.32l1.12-.36V16h1.76v1h-1.76v3.94a1.65,1.65,0,0,0,.24,1,1,1,0,0,0,.79.3,1.2,1.2,0,0,0,.73-.23Z" fill="#2f2f2f"/>
-      <path d="M865.11,16l-3.22,8.12c-.57,1.45-1.38,2.18-2.42,2.18a2.55,2.55,0,0,1-.73-.09v-1a2.14,2.14,0,0,0,.66.13,1.37,1.37,0,0,0,1.27-1l.56-1.32-2.73-7h1.24l1.9,5.39c0,.07.07.24.14.53h0c0-.11.07-.28.14-.52l2-5.4Z" fill="#2f2f2f"/>
-      <path d="M798.56,31.05a.72.72,0,0,1-.52-.2.75.75,0,0,1,0-1,.73.73,0,0,1,.52-.21.72.72,0,0,1,.52.21.71.71,0,0,1,0,1A.72.72,0,0,1,798.56,31.05Zm.54,8.78H798v-7h1.12Z" fill="#2f2f2f"/>
-      <path d="M807.31,39.83h-1.12v-4c0-1.49-.54-2.23-1.62-2.23a1.78,1.78,0,0,0-1.4.63,2.39,2.39,0,0,0-.55,1.6v4H801.5v-7h1.12V34h0a2.54,2.54,0,0,1,2.3-1.32,2.14,2.14,0,0,1,1.76.74,3.33,3.33,0,0,1,.6,2.14Z" fill="#2f2f2f"/>
-      <path d="M813,30.45a1.54,1.54,0,0,0-.75-.18c-.78,0-1.17.49-1.17,1.48v1.08h1.64v1h-1.64v6H810v-6h-1.19v-1H810V31.7A2.36,2.36,0,0,1,810.6,30a2.13,2.13,0,0,1,1.59-.64,2.23,2.23,0,0,1,.81.12Z" fill="#2f2f2f"/>
-      <path d="M817.89,34a1.39,1.39,0,0,0-.85-.23,1.43,1.43,0,0,0-1.2.68,3.12,3.12,0,0,0-.48,1.84v3.57h-1.12v-7h1.12v1.44h0a2.46,2.46,0,0,1,.73-1.15,1.69,1.69,0,0,1,1.1-.41,1.92,1.92,0,0,1,.67.09Z" fill="#2f2f2f"/>
-      <path d="M824.35,39.83h-1.13V38.74h0A2.36,2.36,0,0,1,821,40a2.29,2.29,0,0,1-1.63-.56,1.9,1.9,0,0,1-.59-1.47q0-2,2.31-2.28l2.09-.29c0-1.19-.48-1.79-1.44-1.79a3.47,3.47,0,0,0-2.28.86V33.32a4.4,4.4,0,0,1,2.38-.65c1.64,0,2.47.87,2.47,2.61Zm-1.13-3.54-1.68.23a2.81,2.81,0,0,0-1.18.39,1.12,1.12,0,0,0-.4,1,1.1,1.1,0,0,0,.37.84,1.44,1.44,0,0,0,1,.32,1.79,1.79,0,0,0,1.38-.58,2.11,2.11,0,0,0,.54-1.48Z" fill="#2f2f2f"/>
-      <path d="M826.27,39.58v-1.2a3.31,3.31,0,0,0,2,.67c1,0,1.47-.33,1.47-1a.82.82,0,0,0-.13-.48,1.1,1.1,0,0,0-.34-.34,2.61,2.61,0,0,0-.5-.27l-.63-.25c-.31-.12-.58-.25-.82-.37a2.43,2.43,0,0,1-.58-.43,1.56,1.56,0,0,1-.36-.53,2,2,0,0,1-.12-.71,1.66,1.66,0,0,1,.23-.87,2,2,0,0,1,.6-.64,2.68,2.68,0,0,1,.86-.38,3.64,3.64,0,0,1,1-.13,4,4,0,0,1,1.63.31v1.14a3.17,3.17,0,0,0-1.78-.51,2,2,0,0,0-.57.07,1.71,1.71,0,0,0-.43.2,1,1,0,0,0-.28.32.77.77,0,0,0-.1.4.88.88,0,0,0,.1.45.91.91,0,0,0,.29.33,2.07,2.07,0,0,0,.47.26l.62.25a7.3,7.3,0,0,1,.83.37,3.13,3.13,0,0,1,.63.42,1.66,1.66,0,0,1,.4.55,1.79,1.79,0,0,1,.14.73,1.74,1.74,0,0,1-.23.9,2,2,0,0,1-.61.64,2.78,2.78,0,0,1-.88.37,4.51,4.51,0,0,1-1.05.13A3.94,3.94,0,0,1,826.27,39.58Z" fill="#2f2f2f"/>
-      <path d="M836.2,39.76a2.09,2.09,0,0,1-1,.22c-1.23,0-1.84-.68-1.84-2V33.79h-1.21v-1h1.21V31.12l1.12-.36v2.07h1.76v1h-1.76v3.94a1.65,1.65,0,0,0,.24,1,1,1,0,0,0,.79.3,1.2,1.2,0,0,0,.73-.23Z" fill="#2f2f2f"/>
-      <path d="M841.51,34a1.35,1.35,0,0,0-.84-.23,1.43,1.43,0,0,0-1.2.68,3,3,0,0,0-.49,1.84v3.57h-1.12v-7H839v1.44h0a2.54,2.54,0,0,1,.73-1.15,1.71,1.71,0,0,1,1.1-.41,1.89,1.89,0,0,1,.67.09Z" fill="#2f2f2f"/>
-      <path d="M848.77,39.83h-1.12V38.72h0A2.32,2.32,0,0,1,845.46,40c-1.66,0-2.5-1-2.5-3V32.83h1.12v4c0,1.47.56,2.21,1.69,2.21a1.71,1.71,0,0,0,1.35-.6,2.3,2.3,0,0,0,.53-1.59v-4h1.12Z" fill="#2f2f2f"/>
-      <path d="M856,39.51a3.7,3.7,0,0,1-1.92.49,3.15,3.15,0,0,1-2.41-1,3.49,3.49,0,0,1-.92-2.52,3.88,3.88,0,0,1,1-2.78,3.46,3.46,0,0,1,2.64-1A3.65,3.65,0,0,1,856,33v1.15a2.81,2.81,0,0,0-1.67-.55,2.27,2.27,0,0,0-1.76.77,2.91,2.91,0,0,0-.68,2,2.77,2.77,0,0,0,.64,1.94,2.21,2.21,0,0,0,1.73.71,2.81,2.81,0,0,0,1.73-.61Z" fill="#2f2f2f"/>
-      <path d="M861.44,39.76a2.1,2.1,0,0,1-1.05.22c-1.22,0-1.83-.68-1.83-2V33.79h-1.21v-1h1.21V31.12l1.12-.36v2.07h1.76v1h-1.76v3.94a1.65,1.65,0,0,0,.24,1,1,1,0,0,0,.79.3,1.2,1.2,0,0,0,.73-.23Z" fill="#2f2f2f"/>
-      <path d="M868.84,39.83h-1.12V38.72h0A2.3,2.3,0,0,1,865.53,40c-1.67,0-2.5-1-2.5-3V32.83h1.11v4c0,1.47.57,2.21,1.7,2.21a1.74,1.74,0,0,0,1.35-.6,2.35,2.35,0,0,0,.53-1.59v-4h1.12Z" fill="#2f2f2f"/>
-      <path d="M874.88,34a1.39,1.39,0,0,0-.85-.23,1.43,1.43,0,0,0-1.2.68,3.12,3.12,0,0,0-.48,1.84v3.57h-1.12v-7h1.12v1.44h0a2.47,2.47,0,0,1,.74-1.15,1.67,1.67,0,0,1,1.1-.41,2,2,0,0,1,.67.09Z" fill="#2f2f2f"/>
-      <path d="M882,36.61h-4.94a2.61,2.61,0,0,0,.63,1.81,2.17,2.17,0,0,0,1.65.63,3.42,3.42,0,0,0,2.17-.78v1.06a4.1,4.1,0,0,1-2.44.67,3,3,0,0,1-2.33-1,3.92,3.92,0,0,1-.85-2.68,3.8,3.8,0,0,1,.93-2.66,3,3,0,0,1,2.3-1,2.61,2.61,0,0,1,2.13.89A3.69,3.69,0,0,1,882,36Zm-1.15-1a2.24,2.24,0,0,0-.47-1.51,1.59,1.59,0,0,0-1.28-.54,1.81,1.81,0,0,0-1.35.57,2.58,2.58,0,0,0-.68,1.48Z" fill="#2f2f2f"/>
-    </g>
-    <g>
-      <path d="M979.71,27.92a5.81,5.81,0,0,1-2.71.58,4.36,4.36,0,0,1-3.35-1.35,5,5,0,0,1-1.26-3.54,5.2,5.2,0,0,1,1.42-3.8,4.82,4.82,0,0,1,3.58-1.45,5.81,5.81,0,0,1,2.32.41V20a4.75,4.75,0,0,0-2.33-.59,3.57,3.57,0,0,0-2.74,1.13,4.25,4.25,0,0,0-1,3,4.06,4.06,0,0,0,1,2.85,3.36,3.36,0,0,0,2.58,1.06,4.94,4.94,0,0,0,2.56-.65Z" fill="#2f2f2f"/>
-      <path d="M982.76,28.33h-1.15v-9.8h1.15Z" fill="#2f2f2f"/>
-      <path d="M989.66,18.53,985,30h-1l4.69-11.43Z" fill="#2f2f2f"/>
-      <path d="M997.42,27.92a5.81,5.81,0,0,1-2.71.58,4.36,4.36,0,0,1-3.35-1.35,5,5,0,0,1-1.26-3.54,5.2,5.2,0,0,1,1.42-3.8,4.82,4.82,0,0,1,3.59-1.45,5.72,5.72,0,0,1,2.31.41V20a4.75,4.75,0,0,0-2.33-.59,3.59,3.59,0,0,0-2.74,1.13,4.25,4.25,0,0,0-1.05,3,4,4,0,0,0,1,2.85,3.32,3.32,0,0,0,2.57,1.06,4.92,4.92,0,0,0,2.56-.65Z" fill="#2f2f2f"/>
-      <path d="M999.32,28.33v-9.8h2.7q5.19,0,5.19,4.78a4.79,4.79,0,0,1-1.44,3.64,5.34,5.34,0,0,1-3.85,1.38Zm1.15-8.76v7.72h1.46a4.16,4.16,0,0,0,3-1,3.89,3.89,0,0,0,1.07-2.93q0-3.76-4-3.76Z" fill="#2f2f2f"/>
-      <path d="M1014.68,24.63v3.7h-1.15v-9.8h2.69a3.57,3.57,0,0,1,2.44.76,2.72,2.72,0,0,1,.86,2.16,3,3,0,0,1-1,2.29,3.67,3.67,0,0,1-2.59.89Zm0-5.06v4h1.2a2.68,2.68,0,0,0,1.82-.55,1.93,1.93,0,0,0,.62-1.53c0-1.3-.77-1.94-2.3-1.94Z" fill="#2f2f2f"/>
-      <path d="M1021.86,19.55a.72.72,0,0,1-.52-.2.75.75,0,0,1,0-1,.73.73,0,0,1,.52-.21.72.72,0,0,1,.52.21.71.71,0,0,1,0,1A.72.72,0,0,1,1021.86,19.55Zm.54,8.78h-1.12v-7h1.12Z" fill="#2f2f2f"/>
-      <path d="M1026,27.32h0v4.23h-1.12V21.33h1.12v1.23h0a2.65,2.65,0,0,1,2.42-1.39,2.54,2.54,0,0,1,2.11.94,3.85,3.85,0,0,1,.76,2.52,4.32,4.32,0,0,1-.85,2.81,2.86,2.86,0,0,1-2.34,1.06A2.35,2.35,0,0,1,1026,27.32Zm0-2.82v1a2.09,2.09,0,0,0,.57,1.48,1.86,1.86,0,0,0,1.43.6,1.89,1.89,0,0,0,1.6-.78,3.6,3.6,0,0,0,.57-2.16,2.86,2.86,0,0,0-.54-1.84,1.78,1.78,0,0,0-1.46-.66,2,2,0,0,0-1.57.68A2.48,2.48,0,0,0,1025.92,24.5Z" fill="#2f2f2f"/>
-      <path d="M1038.93,25.11H1034a2.56,2.56,0,0,0,.63,1.81,2.17,2.17,0,0,0,1.65.63,3.42,3.42,0,0,0,2.17-.78v1.06a4.1,4.1,0,0,1-2.44.67,3,3,0,0,1-2.33-1,3.92,3.92,0,0,1-.85-2.68,3.8,3.8,0,0,1,.93-2.66,3,3,0,0,1,2.3-1,2.61,2.61,0,0,1,2.13.89,3.69,3.69,0,0,1,.75,2.46Zm-1.15-.95a2.24,2.24,0,0,0-.47-1.51,1.59,1.59,0,0,0-1.28-.54,1.81,1.81,0,0,0-1.35.57,2.58,2.58,0,0,0-.68,1.48Z" fill="#2f2f2f"/>
-      <path d="M1042,28.33h-1.12V18H1042Z" fill="#2f2f2f"/>
-      <path d="M1045,19.55a.69.69,0,0,1-.51-.2.73.73,0,0,1,1-1,.71.71,0,0,1,0,1A.7.7,0,0,1,1045,19.55Zm.55,8.78h-1.12v-7h1.12Z" fill="#2f2f2f"/>
-      <path d="M1053.73,28.33h-1.12v-4c0-1.49-.55-2.23-1.63-2.23a1.76,1.76,0,0,0-1.39.63,2.34,2.34,0,0,0-.55,1.6v4h-1.12v-7H1049v1.16h0a2.54,2.54,0,0,1,2.3-1.32,2.13,2.13,0,0,1,1.76.74,3.33,3.33,0,0,1,.61,2.14Z" fill="#2f2f2f"/>
-      <path d="M1061.71,25.11h-4.94a2.66,2.66,0,0,0,.63,1.81,2.17,2.17,0,0,0,1.65.63,3.42,3.42,0,0,0,2.17-.78v1.06a4.08,4.08,0,0,1-2.44.67,3,3,0,0,1-2.33-1,3.91,3.91,0,0,1-.84-2.68,3.79,3.79,0,0,1,.92-2.66,3,3,0,0,1,2.3-1,2.61,2.61,0,0,1,2.13.89,3.69,3.69,0,0,1,.75,2.46Zm-1.15-.95a2.24,2.24,0,0,0-.47-1.51,1.58,1.58,0,0,0-1.28-.54,1.81,1.81,0,0,0-1.35.57,2.65,2.65,0,0,0-.68,1.48Z" fill="#2f2f2f"/>
-      <path d="M1063.23,28.08v-1.2a3.31,3.31,0,0,0,2,.67c1,0,1.47-.33,1.47-1a.9.9,0,0,0-.12-.48,1.37,1.37,0,0,0-.34-.34,3.05,3.05,0,0,0-.51-.27l-.62-.25a8.17,8.17,0,0,1-.82-.37,2.5,2.5,0,0,1-.59-.43,1.56,1.56,0,0,1-.36-.53,2.2,2.2,0,0,1-.11-.71,1.66,1.66,0,0,1,.22-.87,2,2,0,0,1,.6-.64,2.68,2.68,0,0,1,.86-.38,3.64,3.64,0,0,1,1-.13,4,4,0,0,1,1.63.31v1.14a3.15,3.15,0,0,0-1.78-.51,2,2,0,0,0-.56.07,1.63,1.63,0,0,0-.44.2,1,1,0,0,0-.28.32.88.88,0,0,0-.1.4,1,1,0,0,0,.1.45,1,1,0,0,0,.29.33,2.31,2.31,0,0,0,.47.26l.62.25a7.3,7.3,0,0,1,.83.37,3.13,3.13,0,0,1,.63.42,1.53,1.53,0,0,1,.4.55,1.92,1.92,0,0,1-.09,1.63,1.87,1.87,0,0,1-.61.64,2.68,2.68,0,0,1-.88.37,4.44,4.44,0,0,1-1.05.13A3.94,3.94,0,0,1,1063.23,28.08Z" fill="#2f2f2f"/>
-    </g>
-    <g>
-      <path d="M704.17,238.42a5.78,5.78,0,0,1-2.71.58,4.37,4.37,0,0,1-3.35-1.35,5,5,0,0,1-1.25-3.53,5.24,5.24,0,0,1,1.41-3.81,4.81,4.81,0,0,1,3.59-1.44,5.73,5.73,0,0,1,2.31.4v1.22a4.71,4.71,0,0,0-2.32-.59,3.57,3.57,0,0,0-2.74,1.13,4.25,4.25,0,0,0-1.05,3,4.06,4.06,0,0,0,1,2.85,3.32,3.32,0,0,0,2.57,1.06,4.8,4.8,0,0,0,2.56-.65Z" fill="#2f2f2f"/>
-      <path d="M708.72,239a3.26,3.26,0,0,1-2.48-1,3.66,3.66,0,0,1-.93-2.61,3.79,3.79,0,0,1,1-2.75,3.46,3.46,0,0,1,2.6-1,3.16,3.16,0,0,1,2.45,1,3.85,3.85,0,0,1,.88,2.67,3.78,3.78,0,0,1-1,2.69A3.33,3.33,0,0,1,708.72,239Zm.08-6.39a2.14,2.14,0,0,0-1.71.74,3,3,0,0,0-.63,2,2.81,2.81,0,0,0,.64,2,2.15,2.15,0,0,0,1.7.72,2,2,0,0,0,1.67-.7,3.06,3.06,0,0,0,.59-2,3.13,3.13,0,0,0-.59-2A2,2,0,0,0,708.8,232.61Z" fill="#2f2f2f"/>
-      <path d="M719.73,238.83h-1.12v-4c0-1.49-.54-2.23-1.63-2.23a1.77,1.77,0,0,0-1.39.63,2.41,2.41,0,0,0-.55,1.6v4h-1.12v-7H715V233h0a2.53,2.53,0,0,1,2.3-1.32,2.14,2.14,0,0,1,1.75.74,3.27,3.27,0,0,1,.61,2.14Z" fill="#2f2f2f"/>
-      <path d="M725.14,229.45a1.54,1.54,0,0,0-.75-.18c-.78,0-1.17.49-1.17,1.48v1.08h1.64v1h-1.64v6H722.1v-6h-1.19v-1h1.19V230.7a2.32,2.32,0,0,1,.64-1.74,2.12,2.12,0,0,1,1.58-.64,2.25,2.25,0,0,1,.82.12Z" fill="#2f2f2f"/>
-      <path d="M726.89,230.05a.69.69,0,0,1-.51-.2.73.73,0,0,1,1-1,.71.71,0,0,1,0,1A.7.7,0,0,1,726.89,230.05Zm.55,8.78h-1.12v-7h1.12Z" fill="#2f2f2f"/>
-      <path d="M735.58,238.27q0,3.85-3.69,3.86a4.93,4.93,0,0,1-2.27-.5v-1.12a4.65,4.65,0,0,0,2.26.66c1.72,0,2.58-.92,2.58-2.75v-.76h0a2.83,2.83,0,0,1-4.51.4,3.71,3.71,0,0,1-.79-2.5,4.32,4.32,0,0,1,.86-2.84,2.86,2.86,0,0,1,2.34-1.05,2.28,2.28,0,0,1,2.1,1.13h0v-1h1.12Zm-1.12-2.6v-1a2,2,0,0,0-.56-1.42,1.87,1.87,0,0,0-1.41-.6,2,2,0,0,0-1.63.76,3.37,3.37,0,0,0-.58,2.11,2.88,2.88,0,0,0,.56,1.87,1.81,1.81,0,0,0,1.49.7,2,2,0,0,0,1.54-.67A2.5,2.5,0,0,0,734.46,235.67Z" fill="#2f2f2f"/>
-      <path d="M698.51,255.38v-1.2a3.31,3.31,0,0,0,2,.67c1,0,1.47-.33,1.47-1a.9.9,0,0,0-.12-.48,1.37,1.37,0,0,0-.34-.34,3.05,3.05,0,0,0-.51-.27c-.19-.08-.4-.17-.63-.25a7.93,7.93,0,0,1-.81-.37,2.5,2.5,0,0,1-.59-.43,1.56,1.56,0,0,1-.36-.53,2,2,0,0,1-.12-.71,1.66,1.66,0,0,1,.23-.87,2,2,0,0,1,.6-.64,2.68,2.68,0,0,1,.86-.38,3.64,3.64,0,0,1,1-.13,4,4,0,0,1,1.63.31v1.14a3.15,3.15,0,0,0-1.78-.51,2.38,2.38,0,0,0-.56.07,1.63,1.63,0,0,0-.44.2,1.06,1.06,0,0,0-.28.32.88.88,0,0,0-.1.4,1,1,0,0,0,.1.45,1,1,0,0,0,.29.33,2.31,2.31,0,0,0,.47.26l.62.25a7.3,7.3,0,0,1,.83.37,3.13,3.13,0,0,1,.63.42,1.53,1.53,0,0,1,.4.55,1.92,1.92,0,0,1-.09,1.63,1.87,1.87,0,0,1-.61.64,2.68,2.68,0,0,1-.88.37,4.44,4.44,0,0,1-1,.13A3.94,3.94,0,0,1,698.51,255.38Z" fill="#2f2f2f"/>
-      <path d="M710.47,252.41h-5a2.66,2.66,0,0,0,.63,1.81,2.19,2.19,0,0,0,1.66.63,3.42,3.42,0,0,0,2.17-.78v1.06a4.1,4.1,0,0,1-2.44.67,2.94,2.94,0,0,1-2.33-1,3.87,3.87,0,0,1-.85-2.68,3.8,3.8,0,0,1,.93-2.66,3,3,0,0,1,2.3-1,2.6,2.6,0,0,1,2.12.89,3.64,3.64,0,0,1,.76,2.46Zm-1.15-.95a2.29,2.29,0,0,0-.47-1.51,1.6,1.6,0,0,0-1.28-.54,1.81,1.81,0,0,0-1.35.57,2.52,2.52,0,0,0-.68,1.48Z" fill="#2f2f2f"/>
-      <path d="M715.8,249.77a1.39,1.39,0,0,0-.85-.23,1.43,1.43,0,0,0-1.2.68,3.12,3.12,0,0,0-.48,1.84v3.57h-1.12v-7h1.12v1.44h0a2.46,2.46,0,0,1,.73-1.15,1.69,1.69,0,0,1,1.1-.41,2,2,0,0,1,.67.09Z" fill="#2f2f2f"/>
-      <path d="M723.07,248.63l-2.79,7h-1.1l-2.65-7h1.23l1.78,5.09a4.47,4.47,0,0,1,.24,1h0a4.75,4.75,0,0,1,.22-.95l1.86-5.12Z" fill="#2f2f2f"/>
-      <path d="M729.71,252.41h-4.94a2.66,2.66,0,0,0,.63,1.81,2.17,2.17,0,0,0,1.65.63,3.45,3.45,0,0,0,2.18-.78v1.06a4.12,4.12,0,0,1-2.44.67,2.94,2.94,0,0,1-2.33-1,3.87,3.87,0,0,1-.85-2.68,3.8,3.8,0,0,1,.93-2.66,2.94,2.94,0,0,1,2.3-1,2.6,2.6,0,0,1,2.12.89,3.69,3.69,0,0,1,.75,2.46Zm-1.14-.95a2.35,2.35,0,0,0-.47-1.51,1.6,1.6,0,0,0-1.28-.54,1.81,1.81,0,0,0-1.35.57,2.52,2.52,0,0,0-.68,1.48Z" fill="#2f2f2f"/>
-      <path d="M735.05,249.77a1.39,1.39,0,0,0-.85-.23,1.43,1.43,0,0,0-1.2.68,3.12,3.12,0,0,0-.48,1.84v3.57H731.4v-7h1.12v1.44h0a2.47,2.47,0,0,1,.74-1.15,1.67,1.67,0,0,1,1.1-.41,2,2,0,0,1,.67.09Z" fill="#2f2f2f"/>
-    </g>
-    <g>
-      <path d="M761.62,238.44v-1.36a2.59,2.59,0,0,0,.56.37,4.61,4.61,0,0,0,.68.28,6.25,6.25,0,0,0,.72.17,4.25,4.25,0,0,0,.67.06,2.66,2.66,0,0,0,1.59-.39,1.35,1.35,0,0,0,.52-1.13,1.29,1.29,0,0,0-.18-.69,1.73,1.73,0,0,0-.48-.54,4.85,4.85,0,0,0-.73-.46l-.9-.47c-.34-.17-.66-.35-1-.53a4.19,4.19,0,0,1-.77-.58,2.64,2.64,0,0,1-.52-.73,2.35,2.35,0,0,1-.19-1,2.2,2.2,0,0,1,.3-1.16,2.62,2.62,0,0,1,.77-.82,3.72,3.72,0,0,1,1.09-.48,5.28,5.28,0,0,1,1.25-.15,4.81,4.81,0,0,1,2.11.34v1.3a4.15,4.15,0,0,0-3-.53,2.34,2.34,0,0,0-.67.26,1.62,1.62,0,0,0-.48.46,1.21,1.21,0,0,0-.18.68,1.33,1.33,0,0,0,.14.65,1.59,1.59,0,0,0,.41.5,4.09,4.09,0,0,0,.67.44l.9.46c.36.18.69.36,1,.55a4.52,4.52,0,0,1,.83.63,2.8,2.8,0,0,1,.56.78,2.13,2.13,0,0,1,.21,1,2.42,2.42,0,0,1-.28,1.22,2.33,2.33,0,0,1-.77.82,3.46,3.46,0,0,1-1.11.46,6.28,6.28,0,0,1-1.32.14c-.16,0-.35,0-.58,0s-.46-.06-.7-.11a6.55,6.55,0,0,1-.67-.18A2.47,2.47,0,0,1,761.62,238.44Z" fill="#2f2f2f"/>
-      <path d="M774.94,235.61H770a2.66,2.66,0,0,0,.63,1.81,2.17,2.17,0,0,0,1.65.63,3.45,3.45,0,0,0,2.18-.78v1.06A4.12,4.12,0,0,1,772,239a2.94,2.94,0,0,1-2.33-1,3.87,3.87,0,0,1-.85-2.68,3.8,3.8,0,0,1,.93-2.66,2.94,2.94,0,0,1,2.3-1,2.6,2.6,0,0,1,2.12.89,3.69,3.69,0,0,1,.75,2.46Zm-1.15-1a2.31,2.31,0,0,0-.46-1.51,1.61,1.61,0,0,0-1.29-.54,1.81,1.81,0,0,0-1.34.57,2.59,2.59,0,0,0-.69,1.48Z" fill="#2f2f2f"/>
-      <path d="M780.28,233a1.39,1.39,0,0,0-.85-.23,1.43,1.43,0,0,0-1.2.68,3.12,3.12,0,0,0-.48,1.84v3.57h-1.12v-7h1.12v1.44h0a2.47,2.47,0,0,1,.74-1.15,1.67,1.67,0,0,1,1.1-.41,2,2,0,0,1,.67.09Z" fill="#2f2f2f"/>
-      <path d="M787.55,231.83l-2.79,7h-1.1l-2.65-7h1.23l1.77,5.09a4,4,0,0,1,.25,1h0a4.15,4.15,0,0,1,.22-1l1.86-5.12Z" fill="#2f2f2f"/>
-      <path d="M789.36,230.05a.69.69,0,0,1-.51-.2.73.73,0,0,1,.51-1.25.74.74,0,0,1,.53.21.74.74,0,0,1,0,1A.74.74,0,0,1,789.36,230.05Zm.55,8.78h-1.12v-7h1.12Z" fill="#2f2f2f"/>
-      <path d="M796.82,238.51a3.64,3.64,0,0,1-1.91.49,3.19,3.19,0,0,1-2.42-1,3.54,3.54,0,0,1-.92-2.52,3.88,3.88,0,0,1,1-2.78,3.49,3.49,0,0,1,2.65-1.05,3.65,3.65,0,0,1,1.63.34v1.15a2.83,2.83,0,0,0-1.67-.55,2.26,2.26,0,0,0-1.76.77,2.91,2.91,0,0,0-.69,2,2.77,2.77,0,0,0,.65,1.94,2.21,2.21,0,0,0,1.73.71,2.76,2.76,0,0,0,1.72-.61Z" fill="#2f2f2f"/>
-      <path d="M804,235.61h-4.94a2.66,2.66,0,0,0,.63,1.81,2.17,2.17,0,0,0,1.65.63,3.45,3.45,0,0,0,2.18-.78v1.06a4.12,4.12,0,0,1-2.44.67,2.94,2.94,0,0,1-2.33-1,4.47,4.47,0,0,1,.07-5.34,3,3,0,0,1,2.31-1,2.6,2.6,0,0,1,2.12.89A3.69,3.69,0,0,1,804,235Zm-1.15-1a2.31,2.31,0,0,0-.46-1.51,1.61,1.61,0,0,0-1.29-.54,1.81,1.81,0,0,0-1.34.57,2.59,2.59,0,0,0-.69,1.48Z" fill="#2f2f2f"/>
-      <path d="M766.15,255.63h-1.37l-1.64-2.75a6.67,6.67,0,0,0-.43-.65,2.61,2.61,0,0,0-.44-.44,1.57,1.57,0,0,0-.48-.25,2,2,0,0,0-.58-.08h-.94v4.17h-1.15v-9.8h2.93a4,4,0,0,1,1.18.16,2.68,2.68,0,0,1,.95.49,2.31,2.31,0,0,1,.62.82,2.66,2.66,0,0,1,.23,1.14,2.81,2.81,0,0,1-.15.94,2.48,2.48,0,0,1-.44.76,2.39,2.39,0,0,1-.69.57,3.4,3.4,0,0,1-.89.37v0a1.73,1.73,0,0,1,.42.25,2.15,2.15,0,0,1,.35.33,3,3,0,0,1,.32.43q.16.24.36.57Zm-5.88-8.76v3.55h1.56a2.32,2.32,0,0,0,.8-.13,1.81,1.81,0,0,0,.63-.37,1.67,1.67,0,0,0,.42-.59,2,2,0,0,0,.15-.79,1.53,1.53,0,0,0-.51-1.23,2.22,2.22,0,0,0-1.48-.44Z" fill="#2f2f2f"/>
-      <path d="M772.76,252.41h-4.94a2.66,2.66,0,0,0,.63,1.81,2.17,2.17,0,0,0,1.65.63,3.45,3.45,0,0,0,2.18-.78v1.06a4.12,4.12,0,0,1-2.44.67,2.94,2.94,0,0,1-2.33-1,4.47,4.47,0,0,1,.07-5.34,3,3,0,0,1,2.3-1,2.61,2.61,0,0,1,2.13.89,3.69,3.69,0,0,1,.75,2.46Zm-1.15-.95a2.29,2.29,0,0,0-.46-1.51,1.61,1.61,0,0,0-1.29-.54,1.79,1.79,0,0,0-1.34.57,2.59,2.59,0,0,0-.69,1.48Z" fill="#2f2f2f"/>
-      <path d="M780.46,255.07q0,3.85-3.69,3.86a5,5,0,0,1-2.27-.5v-1.12a4.65,4.65,0,0,0,2.26.66c1.72,0,2.58-.92,2.58-2.75v-.76h0a2.82,2.82,0,0,1-4.5.4,3.71,3.71,0,0,1-.8-2.5,4.37,4.37,0,0,1,.86-2.84,2.86,2.86,0,0,1,2.35-1.05,2.27,2.27,0,0,1,2.09,1.13h0v-1h1.12Zm-1.12-2.6v-1a2,2,0,0,0-.56-1.42,1.87,1.87,0,0,0-1.41-.6,1.92,1.92,0,0,0-1.62.76,3.31,3.31,0,0,0-.59,2.11,2.93,2.93,0,0,0,.56,1.87,1.83,1.83,0,0,0,1.5.7,1.94,1.94,0,0,0,1.53-.67A2.5,2.5,0,0,0,779.34,252.47Z" fill="#2f2f2f"/>
-      <path d="M783.15,246.85a.69.69,0,0,1-.51-.2.73.73,0,0,1,.51-1.25.74.74,0,0,1,.53.21.74.74,0,0,1,0,1A.74.74,0,0,1,783.15,246.85Zm.55,8.78h-1.12v-7h1.12Z" fill="#2f2f2f"/>
-      <path d="M785.42,255.38v-1.2a3.31,3.31,0,0,0,2,.67c1,0,1.48-.33,1.48-1a.82.82,0,0,0-.13-.48,1.22,1.22,0,0,0-.34-.34,2.61,2.61,0,0,0-.5-.27l-.63-.25c-.31-.12-.58-.25-.82-.37a2.72,2.72,0,0,1-.59-.43,1.69,1.69,0,0,1-.35-.53,2,2,0,0,1-.12-.71,1.57,1.57,0,0,1,.23-.87,2,2,0,0,1,.6-.64,2.59,2.59,0,0,1,.86-.38,3.64,3.64,0,0,1,1-.13,4,4,0,0,1,1.63.31v1.14a3.17,3.17,0,0,0-1.78-.51,2.47,2.47,0,0,0-.57.07,1.56,1.56,0,0,0-.43.2.94.94,0,0,0-.28.32.77.77,0,0,0-.1.4.88.88,0,0,0,.1.45.83.83,0,0,0,.29.33,2.22,2.22,0,0,0,.46.26l.62.25a8.42,8.42,0,0,1,.84.37,3.83,3.83,0,0,1,.63.42,1.63,1.63,0,0,1,.54,1.28,1.72,1.72,0,0,1-.23.9,2,2,0,0,1-.61.64,2.74,2.74,0,0,1-.89.37,4.42,4.42,0,0,1-1,.13A3.91,3.91,0,0,1,785.42,255.38Z" fill="#2f2f2f"/>
-      <path d="M795.07,255.56a2.13,2.13,0,0,1-1.05.22c-1.22,0-1.84-.68-1.84-2.05v-4.14H791v-1h1.2v-1.71l1.13-.36v2.07h1.76v1h-1.76v3.94a1.73,1.73,0,0,0,.23,1,1,1,0,0,0,.8.3,1.22,1.22,0,0,0,.73-.23Z" fill="#2f2f2f"/>
-      <path d="M800.1,249.77a1.39,1.39,0,0,0-.85-.23,1.43,1.43,0,0,0-1.2.68,3.12,3.12,0,0,0-.48,1.84v3.57h-1.12v-7h1.12v1.44h0a2.46,2.46,0,0,1,.73-1.15,1.71,1.71,0,0,1,1.1-.41,1.92,1.92,0,0,1,.67.09Z" fill="#2f2f2f"/>
-      <path d="M807.44,248.63l-3.22,8.12c-.57,1.45-1.38,2.18-2.42,2.18a2.55,2.55,0,0,1-.73-.09v-1a1.88,1.88,0,0,0,.66.13,1.39,1.39,0,0,0,1.28-1l.56-1.32-2.74-7h1.25L804,254c0,.07.07.24.14.53h0c0-.11.07-.28.14-.52l2-5.4Z" fill="#2f2f2f"/>
-    </g>
-    <g>
-      <path d="M706.59,398.07v3.7h-1.14V392h2.69a3.57,3.57,0,0,1,2.44.77,2.75,2.75,0,0,1,.86,2.16,3,3,0,0,1-1,2.28,3.69,3.69,0,0,1-2.59.89Zm0-5.06v4h1.21a2.7,2.7,0,0,0,1.81-.54,1.94,1.94,0,0,0,.63-1.54c0-1.29-.77-1.94-2.3-1.94Z" fill="#2f2f2f"/>
-      <path d="M716.57,395.91a1.39,1.39,0,0,0-.85-.23,1.43,1.43,0,0,0-1.2.68,3.15,3.15,0,0,0-.48,1.85v3.56h-1.12v-7H714v1.45h0a2.44,2.44,0,0,1,.73-1.16,1.86,1.86,0,0,1,1.77-.31Z" fill="#2f2f2f"/>
-      <path d="M718.39,393a.69.69,0,0,1-.51-.21.72.72,0,0,1,0-1,.69.69,0,0,1,.51-.21.72.72,0,0,1,.52.21.71.71,0,0,1,0,1A.69.69,0,0,1,718.39,393Zm.54,8.77h-1.12v-7h1.12Z" fill="#2f2f2f"/>
-      <path d="M726.73,394.77l-2.79,7h-1.1l-2.65-7h1.23l1.78,5.09a5.23,5.23,0,0,1,.25,1h0a4.92,4.92,0,0,1,.22-.95l1.86-5.12Z" fill="#2f2f2f"/>
-      <path d="M732.85,401.77h-1.12v-1.09h0a2.34,2.34,0,0,1-2.15,1.26,2.31,2.31,0,0,1-1.64-.56,1.91,1.91,0,0,1-.59-1.47q0-1.95,2.31-2.28l2.1-.29c0-1.19-.48-1.79-1.44-1.79a3.47,3.47,0,0,0-2.29.86v-1.14a4.35,4.35,0,0,1,2.38-.66c1.65,0,2.47.87,2.47,2.61Zm-1.12-3.54-1.69.24a2.72,2.72,0,0,0-1.17.38,1.1,1.1,0,0,0-.4,1,1.09,1.09,0,0,0,.36.84,1.41,1.41,0,0,0,1,.32,1.81,1.81,0,0,0,1.38-.58,2.09,2.09,0,0,0,.54-1.48Z" fill="#2f2f2f"/>
-      <path d="M738.11,401.71a2.21,2.21,0,0,1-1,.21c-1.23,0-1.84-.68-1.84-2.05v-4.14H734v-1h1.2v-1.71l1.12-.36v2.07h1.76v1h-1.76v3.95a1.63,1.63,0,0,0,.24,1,1,1,0,0,0,.79.3,1.18,1.18,0,0,0,.73-.23Z" fill="#2f2f2f"/>
-      <path d="M745.11,398.55h-5a2.64,2.64,0,0,0,.63,1.81,2.19,2.19,0,0,0,1.66.63,3.47,3.47,0,0,0,2.17-.77v1a4.1,4.1,0,0,1-2.44.67,3,3,0,0,1-2.33-1,3.92,3.92,0,0,1-.85-2.68,3.8,3.8,0,0,1,.93-2.66,3,3,0,0,1,2.3-1,2.63,2.63,0,0,1,2.12.89,3.65,3.65,0,0,1,.76,2.47ZM744,397.6a2.31,2.31,0,0,0-.47-1.51,1.6,1.6,0,0,0-1.28-.54,1.81,1.81,0,0,0-1.35.57,2.52,2.52,0,0,0-.68,1.48Z" fill="#2f2f2f"/>
-      <path d="M755.76,393h-3.82v3.39h3.54v1h-3.54v4.34h-1.15V392h5Z" fill="#2f2f2f"/>
-      <path d="M761.45,401.94a4.3,4.3,0,0,1-3.34-1.38,5,5,0,0,1-1.25-3.57,5.38,5.38,0,0,1,1.27-3.77,4.49,4.49,0,0,1,3.48-1.41,4.21,4.21,0,0,1,3.27,1.36,5.14,5.14,0,0,1,1.25,3.58,5.4,5.4,0,0,1-1.28,3.79,3.46,3.46,0,0,1-.64.58l2.76,2h-2.09L763,401.71A5.41,5.41,0,0,1,761.45,401.94Zm.08-9.09A3.18,3.18,0,0,0,759,394a4.33,4.33,0,0,0-1,2.93,4.38,4.38,0,0,0,.94,2.92,3.07,3.07,0,0,0,2.45,1.1,3.23,3.23,0,0,0,2.54-1.06,4.29,4.29,0,0,0,.93-2.94,4.48,4.48,0,0,0-.9-3A3.08,3.08,0,0,0,761.53,392.85Z" fill="#2f2f2f"/>
-      <path d="M767.93,401.77V392h2.71q5.18,0,5.18,4.78a4.83,4.83,0,0,1-1.44,3.65,5.38,5.38,0,0,1-3.85,1.37Zm1.15-8.76v7.72h1.46a4.12,4.12,0,0,0,3-1,3.84,3.84,0,0,0,1.07-2.92q0-3.76-4-3.77Z" fill="#2f2f2f"/>
-      <path d="M785.57,401.77h-1.41l-5-7.81a3.24,3.24,0,0,1-.32-.61h0a9,9,0,0,1,.06,1.34v7.08h-1.15V392h1.49l4.91,7.69q.3.48.39.66h0a9.67,9.67,0,0,1-.07-1.44V392h1.15Z" fill="#2f2f2f"/>
-    </g>
-    <g>
-      <path d="M219.23,382.79H214V373h5v1h-3.83v3.26h3.54v1h-3.54v3.43h4Z" fill="#2f2f2f"/>
-      <path d="M226.32,375.79,224,379.33l2.31,3.46H225l-1.37-2.27c-.09-.14-.19-.32-.31-.53h0l-.32.53-1.4,2.27h-1.29l2.39-3.43-2.29-3.57h1.31l1.35,2.39.3.55h0l1.75-2.94Z" fill="#2f2f2f"/>
-      <path d="M228.76,381.78h0V386h-1.13V375.79h1.13V377h0a2.65,2.65,0,0,1,2.42-1.39,2.57,2.57,0,0,1,2.11.93,3.88,3.88,0,0,1,.76,2.52,4.35,4.35,0,0,1-.85,2.82,2.86,2.86,0,0,1-2.34,1.05A2.35,2.35,0,0,1,228.76,381.78Zm0-2.83v1a2,2,0,0,0,.56,1.47,1.85,1.85,0,0,0,1.43.61,1.89,1.89,0,0,0,1.6-.78,3.61,3.61,0,0,0,.58-2.17,2.81,2.81,0,0,0-.54-1.83,1.8,1.8,0,0,0-1.47-.66,2,2,0,0,0-1.57.68A2.46,2.46,0,0,0,228.74,379Z" fill="#2f2f2f"/>
-      <path d="M239.42,376.92a1.37,1.37,0,0,0-.85-.22,1.42,1.42,0,0,0-1.2.68,3.12,3.12,0,0,0-.48,1.84v3.57h-1.12v-7h1.12v1.44h0a2.46,2.46,0,0,1,.73-1.15,1.65,1.65,0,0,1,1.1-.41,1.92,1.92,0,0,1,.67.09Z" fill="#2f2f2f"/>
-      <path d="M246.26,379.57h-4.94a2.61,2.61,0,0,0,.63,1.8,2.14,2.14,0,0,0,1.65.64,3.45,3.45,0,0,0,2.18-.78v1a4.05,4.05,0,0,1-2.44.67A2.93,2.93,0,0,1,241,382a3.88,3.88,0,0,1-.85-2.68,3.84,3.84,0,0,1,.93-2.67,3,3,0,0,1,2.3-1,2.63,2.63,0,0,1,2.12.88,3.74,3.74,0,0,1,.75,2.47Zm-1.14-.95a2.29,2.29,0,0,0-.47-1.51,1.6,1.6,0,0,0-1.28-.54,1.81,1.81,0,0,0-1.35.57,2.56,2.56,0,0,0-.69,1.48Z" fill="#2f2f2f"/>
-      <path d="M247.51,382.54v-1.21a3.32,3.32,0,0,0,2,.68c1,0,1.48-.33,1.48-1a.82.82,0,0,0-.13-.48,1.22,1.22,0,0,0-.34-.34,2.15,2.15,0,0,0-.5-.27l-.63-.25c-.31-.13-.58-.25-.82-.38a2.17,2.17,0,0,1-.58-.42,1.6,1.6,0,0,1-.36-.54,1.86,1.86,0,0,1-.12-.7,1.57,1.57,0,0,1,.23-.87,1.93,1.93,0,0,1,.6-.64,2.82,2.82,0,0,1,.86-.39,4.07,4.07,0,0,1,1-.12,4,4,0,0,1,1.63.31v1.13a3.25,3.25,0,0,0-1.78-.5,2,2,0,0,0-.57.07,1.56,1.56,0,0,0-.43.2.91.91,0,0,0-.28.31.79.79,0,0,0-.1.4.92.92,0,0,0,.1.46,1,1,0,0,0,.29.33,2.79,2.79,0,0,0,.46.26l.62.25a7.5,7.5,0,0,1,.84.37,2.88,2.88,0,0,1,.63.42,1.9,1.9,0,0,1,.4.54,1.84,1.84,0,0,1,.14.74,1.77,1.77,0,0,1-.23.9,1.93,1.93,0,0,1-.61.63,2.75,2.75,0,0,1-.89.38,4.42,4.42,0,0,1-1,.12A4.06,4.06,0,0,1,247.51,382.54Z" fill="#2f2f2f"/>
-      <path d="M253.43,382.54v-1.21a3.32,3.32,0,0,0,2,.68c1,0,1.48-.33,1.48-1a.9.9,0,0,0-.13-.48,1.37,1.37,0,0,0-.34-.34,2.46,2.46,0,0,0-.51-.27l-.62-.25a8.07,8.07,0,0,1-.82-.38,2.22,2.22,0,0,1-.59-.42,1.44,1.44,0,0,1-.35-.54,1.86,1.86,0,0,1-.12-.7,1.66,1.66,0,0,1,.22-.87,1.93,1.93,0,0,1,.6-.64,2.94,2.94,0,0,1,.86-.39,4.09,4.09,0,0,1,1-.12,4,4,0,0,1,1.62.31v1.13a3.22,3.22,0,0,0-1.78-.5,2,2,0,0,0-.56.07,1.63,1.63,0,0,0-.44.2,1,1,0,0,0-.28.31.91.91,0,0,0-.1.4,1,1,0,0,0,.1.46,1.28,1.28,0,0,0,.29.33,2.92,2.92,0,0,0,.47.26l.62.25a7.3,7.3,0,0,1,.83.37,2.47,2.47,0,0,1,.63.42,1.58,1.58,0,0,1,.4.54,1.94,1.94,0,0,1-.09,1.64,1.84,1.84,0,0,1-.61.63,2.7,2.7,0,0,1-.88.38,4.44,4.44,0,0,1-1.05.12A4.09,4.09,0,0,1,253.43,382.54Z" fill="#2f2f2f"/>
-      <path d="M266.84,382.79h-1.36L263.84,380a6.61,6.61,0,0,0-.44-.65A2.29,2.29,0,0,0,263,379a1.26,1.26,0,0,0-.47-.25,2.14,2.14,0,0,0-.58-.08h-1v4.17h-1.14V373h2.92a4.08,4.08,0,0,1,1.19.16,2.48,2.48,0,0,1,.94.49,2.19,2.19,0,0,1,.63.81,2.74,2.74,0,0,1,.22,1.15,2.85,2.85,0,0,1-.15.94,2.4,2.4,0,0,1-.44.76,2.9,2.9,0,0,1-.68.57,3.62,3.62,0,0,1-.9.37v0a2.87,2.87,0,0,1,.43.25,3.51,3.51,0,0,1,.34.33c.11.13.22.28.33.44l.35.56ZM261,374v3.55h1.56a2.28,2.28,0,0,0,.8-.13,2,2,0,0,0,.63-.37,1.63,1.63,0,0,0,.42-.6,2,2,0,0,0,.15-.79,1.52,1.52,0,0,0-.51-1.22,2.15,2.15,0,0,0-1.47-.44Z" fill="#2f2f2f"/>
-      <path d="M270.76,383a3.22,3.22,0,0,1-2.48-1,3.62,3.62,0,0,1-.93-2.6,3.75,3.75,0,0,1,1-2.75,3.46,3.46,0,0,1,2.6-1,3.13,3.13,0,0,1,2.44,1,3.79,3.79,0,0,1,.88,2.67,3.71,3.71,0,0,1-.95,2.68A3.27,3.27,0,0,1,270.76,383Zm.08-6.38a2.13,2.13,0,0,0-1.71.73,3,3,0,0,0-.63,2,2.82,2.82,0,0,0,.64,2,2.15,2.15,0,0,0,1.7.72,2.08,2.08,0,0,0,1.67-.7,3.79,3.79,0,0,0,0-4A2.06,2.06,0,0,0,270.84,376.57Z" fill="#2f2f2f"/>
-      <path d="M281.65,382.79h-1.12v-1.11h0a2.29,2.29,0,0,1-2.16,1.27c-1.67,0-2.5-1-2.5-3v-4.18H277v4c0,1.48.56,2.22,1.69,2.22a1.69,1.69,0,0,0,1.35-.61,2.32,2.32,0,0,0,.53-1.58v-4h1.12Z" fill="#2f2f2f"/>
-      <path d="M287.09,382.72a2.09,2.09,0,0,1-1,.22c-1.23,0-1.84-.68-1.84-2.05v-4.14H283v-1h1.2v-1.71l1.12-.36v2.07h1.76v1h-1.76v3.94a1.67,1.67,0,0,0,.24,1,1,1,0,0,0,.79.3,1.14,1.14,0,0,0,.73-.24Z" fill="#2f2f2f"/>
-      <path d="M294.09,379.57h-4.95a2.61,2.61,0,0,0,.63,1.8,2.16,2.16,0,0,0,1.66.64,3.42,3.42,0,0,0,2.17-.78v1a4,4,0,0,1-2.44.67,3,3,0,0,1-2.33-.95,3.88,3.88,0,0,1-.85-2.68,3.84,3.84,0,0,1,.93-2.67,3,3,0,0,1,2.3-1,2.61,2.61,0,0,1,2.12.88,3.69,3.69,0,0,1,.76,2.47Zm-1.15-.95a2.29,2.29,0,0,0-.47-1.51,1.59,1.59,0,0,0-1.28-.54,1.81,1.81,0,0,0-1.35.57,2.55,2.55,0,0,0-.68,1.48Z" fill="#2f2f2f"/>
-      <path d="M236.22,398.92a6.5,6.5,0,0,1-3.28.83,4.47,4.47,0,0,1-3.39-1.35,4.94,4.94,0,0,1-1.3-3.58,5.1,5.1,0,0,1,1.44-3.74,4.91,4.91,0,0,1,3.65-1.46,6.27,6.27,0,0,1,2.68.52v1.27a5.15,5.15,0,0,0-2.81-.75,3.51,3.51,0,0,0-2.7,1.14,4.1,4.1,0,0,0-1.06,2.94,4.16,4.16,0,0,0,1,2.92,3.42,3.42,0,0,0,2.65,1.06,4,4,0,0,0,2-.46v-2.75h-2.14v-1h3.29Z" fill="#2f2f2f"/>
-      <path d="M243.31,399.59h-1.12V398.5h0a2.36,2.36,0,0,1-2.15,1.25,2.29,2.29,0,0,1-1.64-.55,1.9,1.9,0,0,1-.59-1.47q0-2,2.31-2.28l2.1-.3c0-1.19-.48-1.78-1.45-1.78a3.47,3.47,0,0,0-2.28.86v-1.15a4.32,4.32,0,0,1,2.38-.66c1.65,0,2.47.88,2.47,2.62Zm-1.12-3.54-1.69.23a2.67,2.67,0,0,0-1.18.39,1.11,1.11,0,0,0-.39,1,1.05,1.05,0,0,0,.36.83,1.42,1.42,0,0,0,1,.33,1.82,1.82,0,0,0,1.37-.58,2.07,2.07,0,0,0,.55-1.48Z" fill="#2f2f2f"/>
-      <path d="M248.57,399.52a2.15,2.15,0,0,1-1,.22c-1.23,0-1.84-.68-1.84-2.05v-4.14h-1.2v-1h1.2v-1.71l1.12-.36v2.07h1.77v1H246.8v3.94a1.67,1.67,0,0,0,.24,1,1,1,0,0,0,.79.3,1.17,1.17,0,0,0,.74-.24Z" fill="#2f2f2f"/>
-      <path d="M255.56,396.37h-4.94a2.52,2.52,0,0,0,.63,1.8,2.14,2.14,0,0,0,1.65.64,3.42,3.42,0,0,0,2.17-.78v1.05a4,4,0,0,1-2.44.67,3,3,0,0,1-2.33-.95,3.93,3.93,0,0,1-.84-2.68,3.84,3.84,0,0,1,.92-2.67,3,3,0,0,1,2.3-1,2.64,2.64,0,0,1,2.13.89,3.74,3.74,0,0,1,.75,2.47Zm-1.15-.95a2.24,2.24,0,0,0-.47-1.51,1.59,1.59,0,0,0-1.28-.54,1.81,1.81,0,0,0-1.35.57,2.62,2.62,0,0,0-.68,1.48Z" fill="#2f2f2f"/>
-      <path d="M266,392.59l-2.1,7h-1.16l-1.44-5a3.82,3.82,0,0,1-.11-.65h0a2.93,2.93,0,0,1-.14.63l-1.57,5h-1.12l-2.12-7h1.18l1.45,5.26a2.49,2.49,0,0,1,.09.63H259a2.65,2.65,0,0,1,.12-.64l1.62-5.25h1l1.45,5.28a3,3,0,0,1,.1.63h.06a3.49,3.49,0,0,1,.11-.63l1.43-5.28Z" fill="#2f2f2f"/>
-      <path d="M272.21,399.59h-1.12V398.5h0a2.36,2.36,0,0,1-2.15,1.25,2.29,2.29,0,0,1-1.64-.55,1.9,1.9,0,0,1-.59-1.47q0-2,2.31-2.28l2.1-.3c0-1.19-.48-1.78-1.45-1.78a3.47,3.47,0,0,0-2.28.86v-1.15a4.32,4.32,0,0,1,2.38-.66c1.64,0,2.47.88,2.47,2.62Zm-1.12-3.54-1.69.23a2.67,2.67,0,0,0-1.18.39,1.11,1.11,0,0,0-.39,1,1.05,1.05,0,0,0,.36.83,1.4,1.4,0,0,0,1,.33,1.82,1.82,0,0,0,1.37-.58,2.07,2.07,0,0,0,.55-1.48Z" fill="#2f2f2f"/>
-      <path d="M279.72,392.59l-3.22,8.12c-.58,1.45-1.38,2.17-2.42,2.17a2.5,2.5,0,0,1-.73-.09v-1a2.1,2.1,0,0,0,.66.12,1.36,1.36,0,0,0,1.27-1l.56-1.32-2.73-7h1.24l1.9,5.39c0,.06.07.24.14.53h0c0-.11.07-.28.14-.52l2-5.4Z" fill="#2f2f2f"/>
-    </g>
-    <g>
-      <path d="M213.46,312.62a6.61,6.61,0,0,1-3.28.83,4.47,4.47,0,0,1-3.39-1.35,4.94,4.94,0,0,1-1.3-3.58,5.1,5.1,0,0,1,1.44-3.74,4.93,4.93,0,0,1,3.65-1.46,6.27,6.27,0,0,1,2.68.52v1.27a5.15,5.15,0,0,0-2.81-.75,3.51,3.51,0,0,0-2.7,1.14,4.72,4.72,0,0,0-.08,5.86,3.42,3.42,0,0,0,2.65,1.06,4,4,0,0,0,2-.46v-2.75h-2.14v-1h3.29Z" fill="#2f2f2f"/>
-      <path d="M220.55,313.29h-1.12v-1.1h0a2.35,2.35,0,0,1-2.15,1.26,2.29,2.29,0,0,1-1.64-.55,1.94,1.94,0,0,1-.59-1.47q0-2,2.31-2.28l2.1-.3c0-1.19-.48-1.78-1.44-1.78a3.47,3.47,0,0,0-2.29.86v-1.15a4.32,4.32,0,0,1,2.38-.66c1.65,0,2.47.88,2.47,2.62Zm-1.12-3.54-1.69.23a2.67,2.67,0,0,0-1.18.39,1.11,1.11,0,0,0-.39,1,1.05,1.05,0,0,0,.36.83,1.42,1.42,0,0,0,1,.33,1.79,1.79,0,0,0,1.37-.59,2,2,0,0,0,.55-1.48Z" fill="#2f2f2f"/>
-      <path d="M225.81,313.22a2.15,2.15,0,0,1-1.05.22c-1.22,0-1.84-.68-1.84-2.05v-4.14h-1.2v-1h1.2v-1.71l1.12-.36v2.07h1.77v1H224v3.94a1.61,1.61,0,0,0,.24,1,1,1,0,0,0,.8.31,1.16,1.16,0,0,0,.73-.24Z" fill="#2f2f2f"/>
-      <path d="M232.8,310.07h-4.94a2.61,2.61,0,0,0,.63,1.8,2.14,2.14,0,0,0,1.65.64,3.42,3.42,0,0,0,2.17-.78v1a4,4,0,0,1-2.44.67,3,3,0,0,1-2.33-.95,3.93,3.93,0,0,1-.84-2.68,3.84,3.84,0,0,1,.92-2.67,3,3,0,0,1,2.3-1,2.64,2.64,0,0,1,2.13.89,3.74,3.74,0,0,1,.75,2.47Zm-1.15-.95a2.24,2.24,0,0,0-.47-1.51,1.58,1.58,0,0,0-1.28-.54,1.81,1.81,0,0,0-1.35.57,2.62,2.62,0,0,0-.68,1.48Z" fill="#2f2f2f"/>
-      <path d="M243.27,306.29l-2.09,7H240l-1.44-5a3.82,3.82,0,0,1-.11-.65h0a2.93,2.93,0,0,1-.14.63l-1.56,5H235.6l-2.11-7h1.17l1.45,5.26a3,3,0,0,1,.1.63h0a3.24,3.24,0,0,1,.12-.64l1.62-5.25h1l1.45,5.28a3,3,0,0,1,.1.62h.06a2.9,2.9,0,0,1,.12-.62l1.42-5.28Z" fill="#2f2f2f"/>
-      <path d="M249.45,313.29h-1.12v-1.1h0a2.35,2.35,0,0,1-2.15,1.26,2.29,2.29,0,0,1-1.64-.55,1.94,1.94,0,0,1-.59-1.47q0-2,2.31-2.28l2.1-.3c0-1.19-.48-1.78-1.45-1.78a3.47,3.47,0,0,0-2.28.86v-1.15a4.32,4.32,0,0,1,2.38-.66c1.65,0,2.47.88,2.47,2.62Zm-1.12-3.54-1.69.23a2.67,2.67,0,0,0-1.18.39,1.11,1.11,0,0,0-.39,1,1.05,1.05,0,0,0,.36.83,1.42,1.42,0,0,0,1,.33,1.79,1.79,0,0,0,1.37-.59,2,2,0,0,0,.55-1.48Z" fill="#2f2f2f"/>
-      <path d="M257,306.29l-3.22,8.12c-.57,1.45-1.38,2.17-2.42,2.17a2.5,2.5,0,0,1-.73-.09v-1a2.1,2.1,0,0,0,.66.12,1.36,1.36,0,0,0,1.27-1l.56-1.33-2.73-7h1.24l1.9,5.39c0,.06.07.24.14.53h0c0-.11.07-.28.14-.52l2-5.4Z" fill="#2f2f2f"/>
-      <path d="M261.57,313v-1.21a3.34,3.34,0,0,0,2,.68c1,0,1.48-.33,1.48-1a.89.89,0,0,0-.13-.47,1.25,1.25,0,0,0-.34-.35,2.7,2.7,0,0,0-.51-.27l-.62-.24a8.07,8.07,0,0,1-.82-.38,2.4,2.4,0,0,1-.59-.42,1.73,1.73,0,0,1-.35-.54,1.86,1.86,0,0,1-.12-.7,1.66,1.66,0,0,1,.22-.87,1.93,1.93,0,0,1,.6-.64,3.06,3.06,0,0,1,.86-.39,4.09,4.09,0,0,1,1-.13,4,4,0,0,1,1.62.32v1.13a3.19,3.19,0,0,0-1.77-.5,2,2,0,0,0-.57.07,1.48,1.48,0,0,0-.44.2,1,1,0,0,0-.28.31.9.9,0,0,0-.09.4,1,1,0,0,0,.09.46,1.15,1.15,0,0,0,.3.33,2.43,2.43,0,0,0,.46.26l.62.25a8.42,8.42,0,0,1,.84.37,2.59,2.59,0,0,1,.62.42,1.76,1.76,0,0,1,.41.54,1.85,1.85,0,0,1,.13.74,1.77,1.77,0,0,1-.22.9,2,2,0,0,1-.62.63,2.61,2.61,0,0,1-.88.38,4.42,4.42,0,0,1-1,.12A4.1,4.1,0,0,1,261.57,313Z" fill="#2f2f2f"/>
-      <path d="M273.48,313.29h-1.12v-1.11h0a2.29,2.29,0,0,1-2.16,1.27c-1.67,0-2.5-1-2.5-3v-4.18h1.12v4c0,1.48.56,2.22,1.69,2.22a1.69,1.69,0,0,0,1.35-.61,2.32,2.32,0,0,0,.53-1.58v-4h1.12Z" fill="#2f2f2f"/>
-      <path d="M276.74,312.28h0v1h-1.12V302.93h1.12v4.59h0a2.66,2.66,0,0,1,2.42-1.4,2.6,2.6,0,0,1,2.11.94,3.94,3.94,0,0,1,.76,2.52,4.37,4.37,0,0,1-.86,2.82,2.84,2.84,0,0,1-2.33,1.05A2.3,2.3,0,0,1,276.74,312.28Zm0-2.83v1a2.09,2.09,0,0,0,.56,1.47,2,2,0,0,0,3-.17,3.54,3.54,0,0,0,.58-2.17,2.81,2.81,0,0,0-.54-1.83,1.79,1.79,0,0,0-1.46-.66,2,2,0,0,0-1.58.68A2.51,2.51,0,0,0,276.71,309.45Z" fill="#2f2f2f"/>
-      <path d="M289.56,313.29h-1.13v-4c0-1.49-.54-2.23-1.62-2.23a1.76,1.76,0,0,0-1.39.63,2.32,2.32,0,0,0-.55,1.6v4h-1.12v-7h1.12v1.16h0a2.55,2.55,0,0,1,2.3-1.33,2.14,2.14,0,0,1,1.76.75,3.33,3.33,0,0,1,.61,2.14Z" fill="#2f2f2f"/>
-      <path d="M297.26,310.07h-4.94a2.52,2.52,0,0,0,.63,1.8,2.14,2.14,0,0,0,1.65.64,3.42,3.42,0,0,0,2.17-.78v1a4,4,0,0,1-2.44.67,3,3,0,0,1-2.33-.95,3.93,3.93,0,0,1-.85-2.68,3.84,3.84,0,0,1,.93-2.67,3,3,0,0,1,2.3-1,2.64,2.64,0,0,1,2.13.89,3.74,3.74,0,0,1,.75,2.47Zm-1.15-.95a2.24,2.24,0,0,0-.47-1.51,1.59,1.59,0,0,0-1.28-.54,1.81,1.81,0,0,0-1.35.57,2.55,2.55,0,0,0-.68,1.48Z" fill="#2f2f2f"/>
-      <path d="M302.18,313.22a2.09,2.09,0,0,1-1,.22c-1.23,0-1.84-.68-1.84-2.05v-4.14h-1.2v-1h1.2v-1.71l1.12-.36v2.07h1.76v1h-1.76v3.94a1.61,1.61,0,0,0,.24,1,.92.92,0,0,0,.79.31,1.14,1.14,0,0,0,.73-.24Z" fill="#2f2f2f"/>
-    </g>
-    <g>
-      <path d="M366.76,312.88a5.79,5.79,0,0,1-2.71.57,4.36,4.36,0,0,1-3.34-1.34,5,5,0,0,1-1.26-3.54,5.22,5.22,0,0,1,1.41-3.8,4.8,4.8,0,0,1,3.59-1.45,5.72,5.72,0,0,1,2.31.41V305a4.68,4.68,0,0,0-2.32-.59,3.57,3.57,0,0,0-2.74,1.13,4.25,4.25,0,0,0-1.05,3,4.07,4.07,0,0,0,1,2.86,3.34,3.34,0,0,0,2.58,1.06,4.79,4.79,0,0,0,2.55-.66Z" fill="#2f2f2f"/>
-      <path d="M374,310.07h-4.94a2.61,2.61,0,0,0,.63,1.8,2.14,2.14,0,0,0,1.65.64,3.45,3.45,0,0,0,2.18-.78v1a4.05,4.05,0,0,1-2.44.67,3,3,0,0,1-2.33-.95,4.49,4.49,0,0,1,.07-5.35,3,3,0,0,1,2.3-1,2.64,2.64,0,0,1,2.13.89,3.74,3.74,0,0,1,.75,2.47Zm-1.15-.95a2.29,2.29,0,0,0-.46-1.51,1.61,1.61,0,0,0-1.29-.54,1.79,1.79,0,0,0-1.34.57,2.56,2.56,0,0,0-.69,1.48Z" fill="#2f2f2f"/>
-      <path d="M381.53,313.29H380.4v-4c0-1.49-.54-2.23-1.62-2.23a1.76,1.76,0,0,0-1.39.63,2.32,2.32,0,0,0-.55,1.6v4h-1.13v-7h1.13v1.16h0a2.55,2.55,0,0,1,2.3-1.33,2.14,2.14,0,0,1,1.76.75,3.33,3.33,0,0,1,.61,2.14Z" fill="#2f2f2f"/>
-      <path d="M386.75,313.22a2.09,2.09,0,0,1-1,.22c-1.23,0-1.84-.68-1.84-2.05v-4.14h-1.2v-1h1.2v-1.71l1.12-.36v2.07h1.76v1H385v3.94a1.61,1.61,0,0,0,.24,1,.92.92,0,0,0,.79.31,1.13,1.13,0,0,0,.73-.24Z" fill="#2f2f2f"/>
-      <path d="M391.79,307.42a1.39,1.39,0,0,0-.85-.22,1.42,1.42,0,0,0-1.2.67,3.17,3.17,0,0,0-.48,1.85v3.57h-1.12v-7h1.12v1.44h0a2.47,2.47,0,0,1,.74-1.15,1.62,1.62,0,0,1,1.1-.41,2,2,0,0,1,.67.09Z" fill="#2f2f2f"/>
-      <path d="M398,313.29h-1.12v-1.1h0a2.33,2.33,0,0,1-2.15,1.26,2.31,2.31,0,0,1-1.64-.55,1.94,1.94,0,0,1-.59-1.47q0-2,2.31-2.28l2.1-.3c0-1.19-.48-1.78-1.44-1.78a3.47,3.47,0,0,0-2.29.86v-1.15a4.35,4.35,0,0,1,2.38-.66c1.65,0,2.47.88,2.47,2.62Zm-1.12-3.54-1.69.23a2.58,2.58,0,0,0-1.17.39,1.09,1.09,0,0,0-.4,1,1.05,1.05,0,0,0,.36.83,1.42,1.42,0,0,0,1,.33,1.83,1.83,0,0,0,1.38-.59,2.07,2.07,0,0,0,.54-1.48Z" fill="#2f2f2f"/>
-      <path d="M401.1,313.29H400V302.93h1.12Z" fill="#2f2f2f"/>
-      <path d="M403.79,304.51a.73.73,0,0,1-.51-.2.67.67,0,0,1-.22-.52.69.69,0,0,1,.22-.53.69.69,0,0,1,.51-.2.71.71,0,0,1,.52.2.69.69,0,0,1,.22.53.67.67,0,0,1-.22.51A.72.72,0,0,1,403.79,304.51Zm.55,8.78h-1.13v-7h1.13Z" fill="#2f2f2f"/>
-      <path d="M411.45,306.61l-4.15,5.72h4.11v1h-5.75v-.35l4.14-5.69h-3.75v-1h5.4Z" fill="#2f2f2f"/>
-      <path d="M418.35,310.07h-4.94a2.61,2.61,0,0,0,.63,1.8,2.14,2.14,0,0,0,1.65.64,3.45,3.45,0,0,0,2.18-.78v1a4.05,4.05,0,0,1-2.44.67,3,3,0,0,1-2.33-.95,4.49,4.49,0,0,1,.07-5.35,3,3,0,0,1,2.31-1,2.63,2.63,0,0,1,2.12.89,3.74,3.74,0,0,1,.75,2.47Zm-1.14-.95a2.35,2.35,0,0,0-.47-1.51,1.6,1.6,0,0,0-1.28-.54,1.81,1.81,0,0,0-1.35.57,2.56,2.56,0,0,0-.69,1.48Z" fill="#2f2f2f"/>
-      <path d="M426.08,313.29H425V312.1h0a2.83,2.83,0,0,1-4.52.41,3.88,3.88,0,0,1-.79-2.56,4.16,4.16,0,0,1,.88-2.78,2.88,2.88,0,0,1,2.33-1.05,2.25,2.25,0,0,1,2.1,1.14h0v-4.33h1.12ZM425,310.12v-1a2,2,0,0,0-.56-1.43,1.84,1.84,0,0,0-1.42-.59,1.93,1.93,0,0,0-1.61.75,3.3,3.3,0,0,0-.59,2.08,3,3,0,0,0,.56,1.91,1.84,1.84,0,0,0,1.52.7,1.93,1.93,0,0,0,1.52-.68A2.51,2.51,0,0,0,425,310.12Z" fill="#2f2f2f"/>
-      <path d="M346.87,329.84v-1.21a3.32,3.32,0,0,0,2,.68q1.47,0,1.47-1a.89.89,0,0,0-.12-.47,1.41,1.41,0,0,0-.34-.35,3.05,3.05,0,0,0-.51-.27l-.63-.25a6.23,6.23,0,0,1-.81-.37,2.22,2.22,0,0,1-.59-.42,1.6,1.6,0,0,1-.36-.54,1.86,1.86,0,0,1-.12-.7,1.66,1.66,0,0,1,.23-.87,1.93,1.93,0,0,1,.6-.64,2.94,2.94,0,0,1,.86-.39,4.07,4.07,0,0,1,1-.13,4,4,0,0,1,1.63.32v1.13a3.22,3.22,0,0,0-1.78-.5,1.91,1.91,0,0,0-.56.07,1.37,1.37,0,0,0-.44.2,1,1,0,0,0-.28.31.91.91,0,0,0-.1.4,1,1,0,0,0,.1.46,1.11,1.11,0,0,0,.29.33,2.92,2.92,0,0,0,.47.26l.62.25a7.3,7.3,0,0,1,.83.37,2.47,2.47,0,0,1,.63.42,1.58,1.58,0,0,1,.4.54,1.84,1.84,0,0,1,.14.74,1.68,1.68,0,0,1-.23.9,1.93,1.93,0,0,1-.61.63,2.7,2.7,0,0,1-.88.38,4.44,4.44,0,0,1-1.05.12A4.06,4.06,0,0,1,346.87,329.84Z" fill="#2f2f2f"/>
-      <path d="M358.83,326.87h-4.95a2.61,2.61,0,0,0,.63,1.8,2.15,2.15,0,0,0,1.66.64,3.42,3.42,0,0,0,2.17-.78v1.05a4.05,4.05,0,0,1-2.44.67,3,3,0,0,1-2.33-.95,3.88,3.88,0,0,1-.85-2.68,3.84,3.84,0,0,1,.93-2.67,3,3,0,0,1,2.3-1,2.63,2.63,0,0,1,2.12.89,3.69,3.69,0,0,1,.76,2.47Zm-1.15-.95a2.29,2.29,0,0,0-.47-1.51,1.6,1.6,0,0,0-1.28-.54,1.81,1.81,0,0,0-1.35.57,2.49,2.49,0,0,0-.68,1.48Z" fill="#2f2f2f"/>
-      <path d="M364.16,324.22a1.39,1.39,0,0,0-.85-.22,1.42,1.42,0,0,0-1.2.67,3.17,3.17,0,0,0-.48,1.85v3.57h-1.12v-7h1.12v1.44h0a2.41,2.41,0,0,1,.73-1.15,1.64,1.64,0,0,1,1.1-.41,2,2,0,0,1,.67.09Z" fill="#2f2f2f"/>
-      <path d="M371.43,323.09l-2.79,7h-1.1l-2.65-7h1.23l1.78,5.08a4.6,4.6,0,0,1,.24,1h0a4.92,4.92,0,0,1,.22-.95l1.86-5.11Z" fill="#2f2f2f"/>
-      <path d="M373.25,321.31a.77.77,0,0,1-.52-.2.7.7,0,0,1-.21-.52.7.7,0,0,1,.73-.73.71.71,0,0,1,.52.2.72.72,0,0,1,.21.53.69.69,0,0,1-.21.51A.72.72,0,0,1,373.25,321.31Zm.54,8.78h-1.12v-7h1.12Z" fill="#2f2f2f"/>
-      <path d="M380.71,329.77a3.7,3.7,0,0,1-1.92.48,3.14,3.14,0,0,1-2.41-1,3.5,3.5,0,0,1-.92-2.53,3.89,3.89,0,0,1,1-2.78,3.46,3.46,0,0,1,2.64-1.05,3.66,3.66,0,0,1,1.63.35v1.14a2.89,2.89,0,0,0-1.67-.54,2.24,2.24,0,0,0-1.76.77,2.9,2.9,0,0,0-.69,2,2.79,2.79,0,0,0,.65,1.94,2.24,2.24,0,0,0,1.73.71,2.81,2.81,0,0,0,1.73-.61Z" fill="#2f2f2f"/>
-      <path d="M387.88,326.87h-4.95a2.61,2.61,0,0,0,.63,1.8,2.15,2.15,0,0,0,1.66.64,3.44,3.44,0,0,0,2.17-.78v1.05a4,4,0,0,1-2.44.67,3,3,0,0,1-2.33-.95,3.88,3.88,0,0,1-.85-2.68,3.84,3.84,0,0,1,.93-2.67,3,3,0,0,1,2.3-1,2.63,2.63,0,0,1,2.12.89,3.69,3.69,0,0,1,.76,2.47Zm-1.15-.95a2.29,2.29,0,0,0-.47-1.51,1.6,1.6,0,0,0-1.28-.54,1.81,1.81,0,0,0-1.35.57,2.49,2.49,0,0,0-.68,1.48Z" fill="#2f2f2f"/>
-      <path d="M389.12,329.84v-1.21a3.32,3.32,0,0,0,2,.68c1,0,1.48-.33,1.48-1a.89.89,0,0,0-.12-.47,1.29,1.29,0,0,0-.35-.35,2.61,2.61,0,0,0-.5-.27L391,327a7.11,7.11,0,0,1-.82-.37,2.17,2.17,0,0,1-.58-.42,1.6,1.6,0,0,1-.36-.54,1.86,1.86,0,0,1-.12-.7,1.66,1.66,0,0,1,.23-.87,1.93,1.93,0,0,1,.6-.64,2.94,2.94,0,0,1,.86-.39,4.07,4.07,0,0,1,1-.13,4,4,0,0,1,1.63.32v1.13a3.25,3.25,0,0,0-1.78-.5,2,2,0,0,0-.57.07,1.32,1.32,0,0,0-.43.2,1,1,0,0,0-.28.31.79.79,0,0,0-.1.4.92.92,0,0,0,.1.46,1.11,1.11,0,0,0,.29.33,2.79,2.79,0,0,0,.46.26l.63.25a8.19,8.19,0,0,1,.83.37,2.47,2.47,0,0,1,.63.42,1.72,1.72,0,0,1,.4.54,1.84,1.84,0,0,1,.14.74,1.77,1.77,0,0,1-.23.9,2,2,0,0,1-.61.63,2.79,2.79,0,0,1-.88.38,4.51,4.51,0,0,1-1.05.12A4.06,4.06,0,0,1,389.12,329.84Z" fill="#2f2f2f"/>
-      <path d="M398.89,329.84v-1.21a3.34,3.34,0,0,0,2,.68c1,0,1.48-.33,1.48-1a.89.89,0,0,0-.13-.47,1.41,1.41,0,0,0-.34-.35,2.7,2.7,0,0,0-.51-.27l-.62-.25a6.41,6.41,0,0,1-.82-.37,2.22,2.22,0,0,1-.59-.42,1.57,1.57,0,0,1-.35-.54,1.86,1.86,0,0,1-.12-.7,1.66,1.66,0,0,1,.22-.87,1.93,1.93,0,0,1,.6-.64,2.94,2.94,0,0,1,.86-.39,4.09,4.09,0,0,1,1-.13,4,4,0,0,1,1.62.32v1.13a3.19,3.19,0,0,0-1.77-.5,2,2,0,0,0-.57.07,1.37,1.37,0,0,0-.44.2,1,1,0,0,0-.28.31.91.91,0,0,0-.1.4,1,1,0,0,0,.1.46,1.28,1.28,0,0,0,.29.33,2.92,2.92,0,0,0,.47.26l.62.25a8.42,8.42,0,0,1,.84.37,2.59,2.59,0,0,1,.62.42,1.58,1.58,0,0,1,.4.54,1.94,1.94,0,0,1-.09,1.64,1.93,1.93,0,0,1-.61.63,2.7,2.7,0,0,1-.88.38,4.42,4.42,0,0,1-1,.12A4.1,4.1,0,0,1,398.89,329.84Z" fill="#2f2f2f"/>
-      <path d="M410.8,330.09h-1.12V329h0a2.29,2.29,0,0,1-2.16,1.27c-1.67,0-2.5-1-2.5-3v-4.18h1.11v4c0,1.48.57,2.22,1.7,2.22a1.69,1.69,0,0,0,1.35-.61,2.32,2.32,0,0,0,.53-1.58v-4h1.12Z" fill="#2f2f2f"/>
-      <path d="M414.06,329.08h0v1h-1.12V319.73H414v4.59h0a2.66,2.66,0,0,1,2.42-1.4,2.6,2.6,0,0,1,2.11.94,3.94,3.94,0,0,1,.76,2.52,4.37,4.37,0,0,1-.86,2.82,2.85,2.85,0,0,1-2.33,1.05A2.3,2.3,0,0,1,414.06,329.08Zm0-2.83v1a2.09,2.09,0,0,0,.56,1.47,2,2,0,0,0,3-.17,3.54,3.54,0,0,0,.58-2.17,2.81,2.81,0,0,0-.54-1.83,1.79,1.79,0,0,0-1.46-.66,2,2,0,0,0-1.58.68A2.51,2.51,0,0,0,414,326.25Z" fill="#2f2f2f"/>
-      <path d="M426.88,330.09h-1.13v-4c0-1.49-.54-2.23-1.62-2.23a1.76,1.76,0,0,0-1.39.63,2.32,2.32,0,0,0-.55,1.6v4h-1.13v-7h1.13v1.16h0a2.55,2.55,0,0,1,2.3-1.33,2.14,2.14,0,0,1,1.76.75,3.33,3.33,0,0,1,.61,2.14Z" fill="#2f2f2f"/>
-      <path d="M434.58,326.87h-4.94a2.56,2.56,0,0,0,.62,1.8,2.18,2.18,0,0,0,1.66.64,3.42,3.42,0,0,0,2.17-.78v1.05a4,4,0,0,1-2.44.67,3,3,0,0,1-2.33-.95,3.93,3.93,0,0,1-.85-2.68,3.84,3.84,0,0,1,.93-2.67,3,3,0,0,1,2.3-1,2.64,2.64,0,0,1,2.13.89,3.74,3.74,0,0,1,.75,2.47Zm-1.15-.95a2.29,2.29,0,0,0-.47-1.51,1.59,1.59,0,0,0-1.28-.54,1.81,1.81,0,0,0-1.35.57,2.55,2.55,0,0,0-.68,1.48Z" fill="#2f2f2f"/>
-      <path d="M439.5,330a2.09,2.09,0,0,1-1,.22c-1.23,0-1.84-.68-1.84-2.05v-4.14h-1.2v-1h1.2v-1.71l1.12-.36v2.07h1.76v1h-1.76V328a1.61,1.61,0,0,0,.24,1,.92.92,0,0,0,.79.31,1.14,1.14,0,0,0,.73-.24Z" fill="#2f2f2f"/>
-    </g>
-    <g>
-      <path d="M354.51,396.89v-9.8h2.71q5.17,0,5.18,4.77a4.81,4.81,0,0,1-1.44,3.65,5.33,5.33,0,0,1-3.85,1.38Zm1.15-8.76v7.72h1.46a4.17,4.17,0,0,0,3-1,3.91,3.91,0,0,0,1.07-2.93q0-3.76-4-3.76Z" fill="#2f2f2f"/>
-      <path d="M372.15,396.89h-1.4l-5.05-7.81a3.26,3.26,0,0,1-.31-.62h0a11.85,11.85,0,0,1,0,1.35v7.08h-1.15v-9.8h1.49l4.91,7.69c.21.32.34.53.4.65h0A11.72,11.72,0,0,1,371,394v-6.9h1.14Z" fill="#2f2f2f"/>
-      <path d="M374.17,396.49v-1.35a2.52,2.52,0,0,0,.55.37,4.12,4.12,0,0,0,.69.27,4.74,4.74,0,0,0,.72.18,4.06,4.06,0,0,0,.67.06,2.65,2.65,0,0,0,1.58-.39,1.32,1.32,0,0,0,.52-1.13,1.36,1.36,0,0,0-.17-.69,2,2,0,0,0-.48-.54,5.42,5.42,0,0,0-.73-.47l-.91-.46c-.34-.18-.66-.35-.95-.53a4,4,0,0,1-.78-.59,2.46,2.46,0,0,1-.51-.73,2.18,2.18,0,0,1-.19-.95,2.33,2.33,0,0,1,.29-1.17,2.52,2.52,0,0,1,.78-.81,3.26,3.26,0,0,1,1.09-.48,4.69,4.69,0,0,1,1.24-.16,4.86,4.86,0,0,1,2.12.35v1.29a4.19,4.19,0,0,0-3-.52,2,2,0,0,0-.67.26,1.38,1.38,0,0,0-.48.45,1.19,1.19,0,0,0-.19.69,1.48,1.48,0,0,0,.14.65,1.63,1.63,0,0,0,.42.5,4,4,0,0,0,.66.43l.91.47a10.66,10.66,0,0,1,1,.55,4.44,4.44,0,0,1,.82.63,2.8,2.8,0,0,1,.57.77,2.19,2.19,0,0,1,.21,1,2.43,2.43,0,0,1-.29,1.23,2.3,2.3,0,0,1-.76.82,3.24,3.24,0,0,1-1.11.45,5.77,5.77,0,0,1-1.33.14l-.57,0-.7-.11a6.75,6.75,0,0,1-.68-.18A1.79,1.79,0,0,1,374.17,396.49Z" fill="#2f2f2f"/>
-      <path d="M385.32,396.64v-1.21a3.32,3.32,0,0,0,2,.68c1,0,1.48-.33,1.48-1a.9.9,0,0,0-.13-.48,1.41,1.41,0,0,0-.34-.35,2.7,2.7,0,0,0-.51-.27l-.62-.24a8.07,8.07,0,0,1-.82-.38,2.22,2.22,0,0,1-.59-.42,1.57,1.57,0,0,1-.35-.54,1.86,1.86,0,0,1-.12-.7,1.66,1.66,0,0,1,.22-.87,1.93,1.93,0,0,1,.6-.64,2.94,2.94,0,0,1,.86-.39,4.09,4.09,0,0,1,1-.13,4,4,0,0,1,1.62.32v1.13a3.19,3.19,0,0,0-1.77-.5,2,2,0,0,0-.57.07,1.63,1.63,0,0,0-.44.2,1,1,0,0,0-.28.31.91.91,0,0,0-.1.4,1,1,0,0,0,.1.46,1.28,1.28,0,0,0,.29.33,2.92,2.92,0,0,0,.47.26l.62.25a7.3,7.3,0,0,1,.83.37,2.47,2.47,0,0,1,.63.42,1.58,1.58,0,0,1,.4.54,1.69,1.69,0,0,1,.14.74,1.77,1.77,0,0,1-.22.9,2,2,0,0,1-.62.63,2.7,2.7,0,0,1-.88.38,4.42,4.42,0,0,1-1,.12A4.1,4.1,0,0,1,385.32,396.64Z" fill="#2f2f2f"/>
-      <path d="M397.28,393.67h-4.95a2.61,2.61,0,0,0,.63,1.8,2.16,2.16,0,0,0,1.66.64,3.42,3.42,0,0,0,2.17-.78v1.05a4,4,0,0,1-2.44.67,3,3,0,0,1-2.33-.95,3.93,3.93,0,0,1-.85-2.68,3.84,3.84,0,0,1,.93-2.67,3,3,0,0,1,2.3-1,2.62,2.62,0,0,1,2.12.89,3.69,3.69,0,0,1,.76,2.47Zm-1.15-.95a2.29,2.29,0,0,0-.47-1.51,1.6,1.6,0,0,0-1.28-.54,1.81,1.81,0,0,0-1.35.57,2.49,2.49,0,0,0-.68,1.48Z" fill="#2f2f2f"/>
-      <path d="M402.61,391a1.37,1.37,0,0,0-.85-.22,1.42,1.42,0,0,0-1.2.67,3.17,3.17,0,0,0-.48,1.85v3.57H399v-7h1.12v1.44h0a2.46,2.46,0,0,1,.73-1.15,1.65,1.65,0,0,1,1.1-.41,1.92,1.92,0,0,1,.67.09Z" fill="#2f2f2f"/>
-      <path d="M409.88,389.89l-2.79,7H406l-2.65-7h1.23l1.78,5.08a4.6,4.6,0,0,1,.24,1h0a4.92,4.92,0,0,1,.22-.95l1.86-5.11Z" fill="#2f2f2f"/>
-      <path d="M411.7,388.11a.73.73,0,0,1-.51-.2.67.67,0,0,1-.22-.52.69.69,0,0,1,.22-.53.69.69,0,0,1,.51-.2.71.71,0,0,1,.52.2.73.73,0,0,1,.22.53.7.7,0,0,1-.22.51A.72.72,0,0,1,411.7,388.11Zm.55,8.78h-1.13v-7h1.13Z" fill="#2f2f2f"/>
-      <path d="M419.16,396.57a3.7,3.7,0,0,1-1.92.48,3.16,3.16,0,0,1-2.41-1,3.5,3.5,0,0,1-.92-2.53,3.89,3.89,0,0,1,1-2.78,3.46,3.46,0,0,1,2.64-1,3.66,3.66,0,0,1,1.63.35v1.14a2.87,2.87,0,0,0-1.67-.54,2.24,2.24,0,0,0-1.76.77,2.89,2.89,0,0,0-.68,2,2.79,2.79,0,0,0,.64,1.94,2.24,2.24,0,0,0,1.73.71,2.79,2.79,0,0,0,1.73-.61Z" fill="#2f2f2f"/>
-      <path d="M426.33,393.67h-4.94a2.56,2.56,0,0,0,.62,1.8,2.18,2.18,0,0,0,1.66.64,3.42,3.42,0,0,0,2.17-.78v1.05a4,4,0,0,1-2.44.67,3,3,0,0,1-2.33-.95,3.88,3.88,0,0,1-.85-2.68,3.84,3.84,0,0,1,.93-2.67,3,3,0,0,1,2.3-1,2.64,2.64,0,0,1,2.13.89,3.74,3.74,0,0,1,.75,2.47Zm-1.15-.95a2.29,2.29,0,0,0-.47-1.51,1.59,1.59,0,0,0-1.28-.54,1.81,1.81,0,0,0-1.35.57,2.55,2.55,0,0,0-.68,1.48Z" fill="#2f2f2f"/>
-      <path d="M427.57,396.64v-1.21a3.32,3.32,0,0,0,2,.68c1,0,1.47-.33,1.47-1a.9.9,0,0,0-.12-.48,1.29,1.29,0,0,0-.35-.35,2.61,2.61,0,0,0-.5-.27l-.63-.24a7.83,7.83,0,0,1-.81-.38,2.22,2.22,0,0,1-.59-.42,1.6,1.6,0,0,1-.36-.54,1.86,1.86,0,0,1-.12-.7,1.66,1.66,0,0,1,.23-.87,1.93,1.93,0,0,1,.6-.64,2.94,2.94,0,0,1,.86-.39,4.07,4.07,0,0,1,1-.13,4,4,0,0,1,1.63.32v1.13a3.22,3.22,0,0,0-1.78-.5,1.91,1.91,0,0,0-.56.07,1.63,1.63,0,0,0-.44.2,1,1,0,0,0-.28.31.79.79,0,0,0-.1.4.92.92,0,0,0,.1.46,1.11,1.11,0,0,0,.29.33,2.54,2.54,0,0,0,.47.26l.62.25a7.3,7.3,0,0,1,.83.37,2.47,2.47,0,0,1,.63.42,1.72,1.72,0,0,1,.4.54,1.94,1.94,0,0,1-.09,1.64,1.84,1.84,0,0,1-.61.63,2.7,2.7,0,0,1-.88.38,4.44,4.44,0,0,1-1.05.12A4.06,4.06,0,0,1,427.57,396.64Z" fill="#2f2f2f"/>
-    </g>
-    <g>
-      <path d="M465.72,27.49h-1.27l-1-2.74h-4.15l-1,2.74H457l3.76-9.8H462ZM463,23.71l-1.54-4.17a4.18,4.18,0,0,1-.15-.66h0a4,4,0,0,1-.16.66l-1.52,4.17Z" fill="#2f2f2f"/>
-      <path d="M472.33,20.82l-4.14,5.72h4.1v.95h-5.75v-.34l4.15-5.7h-3.76v-1h5.4Z" fill="#2f2f2f"/>
-      <path d="M479.43,27.49h-1.12v-1.1h0a2.3,2.3,0,0,1-2.16,1.27c-1.67,0-2.5-1-2.5-3V20.49h1.11v4c0,1.48.57,2.22,1.7,2.22a1.72,1.72,0,0,0,1.35-.61,2.32,2.32,0,0,0,.53-1.58v-4h1.12Z" fill="#2f2f2f"/>
-      <path d="M485.19,21.63a1.39,1.39,0,0,0-.85-.23,1.43,1.43,0,0,0-1.2.68,3.15,3.15,0,0,0-.48,1.85v3.56h-1.12v-7h1.12v1.45h0a2.36,2.36,0,0,1,.73-1.15,1.65,1.65,0,0,1,1.1-.42,1.72,1.72,0,0,1,.67.1Z" fill="#2f2f2f"/>
-      <path d="M492,24.27h-4.94a2.64,2.64,0,0,0,.63,1.81,2.18,2.18,0,0,0,1.65.64,3.47,3.47,0,0,0,2.18-.78v1a4.05,4.05,0,0,1-2.44.67,3,3,0,0,1-2.34-.95,4,4,0,0,1-.84-2.69,3.86,3.86,0,0,1,.92-2.66,3,3,0,0,1,2.3-1,2.64,2.64,0,0,1,2.13.89,3.7,3.7,0,0,1,.75,2.47Zm-1.15-.95a2.31,2.31,0,0,0-.46-1.51,1.61,1.61,0,0,0-1.29-.54,1.79,1.79,0,0,0-1.34.57,2.59,2.59,0,0,0-.69,1.48Z" fill="#2f2f2f"/>
-      <path d="M497.25,27.1V25.74a2.59,2.59,0,0,0,.56.37,3.83,3.83,0,0,0,.69.28,4.2,4.2,0,0,0,.72.17,3.25,3.25,0,0,0,.67.07,2.57,2.57,0,0,0,1.58-.4A1.32,1.32,0,0,0,502,25.1a1.41,1.41,0,0,0-.17-.69,2,2,0,0,0-.49-.53,4.08,4.08,0,0,0-.72-.47l-.91-.47c-.34-.17-.66-.35-1-.52a4.73,4.73,0,0,1-.77-.59,2.41,2.41,0,0,1-.51-.73,2.18,2.18,0,0,1-.19-1,2.31,2.31,0,0,1,.29-1.17,2.62,2.62,0,0,1,.77-.82,3.56,3.56,0,0,1,1.09-.47,4.82,4.82,0,0,1,1.25-.16,4.64,4.64,0,0,1,2.11.35v1.29a3.8,3.8,0,0,0-2.22-.6,3.22,3.22,0,0,0-.76.08,2.07,2.07,0,0,0-.67.25,1.47,1.47,0,0,0-.47.46,1.16,1.16,0,0,0-.19.68,1.45,1.45,0,0,0,.14.65,1.48,1.48,0,0,0,.41.5,4.58,4.58,0,0,0,.67.44c.26.14.56.3.91.46s.68.36,1,.55a4.15,4.15,0,0,1,.83.64,2.8,2.8,0,0,1,.57.77,2.16,2.16,0,0,1,.2,1,2.49,2.49,0,0,1-.28,1.23,2.36,2.36,0,0,1-.76.81,3.39,3.39,0,0,1-1.12.46,6.21,6.21,0,0,1-1.32.14,4.45,4.45,0,0,1-.58,0,5.81,5.81,0,0,1-.69-.11,6.75,6.75,0,0,1-.68-.18A2.47,2.47,0,0,1,497.25,27.1Z" fill="#2f2f2f"/>
-      <path d="M506,26.48h0v4.23h-1.12V20.49h1.12v1.24h0a2.66,2.66,0,0,1,2.42-1.4,2.54,2.54,0,0,1,2.11.94,3.88,3.88,0,0,1,.76,2.52,4.32,4.32,0,0,1-.85,2.81,2.83,2.83,0,0,1-2.34,1.06A2.33,2.33,0,0,1,506,26.48Zm0-2.82v1a2.05,2.05,0,0,0,.57,1.47,2,2,0,0,0,3-.17,3.56,3.56,0,0,0,.58-2.17,2.81,2.81,0,0,0-.54-1.83,1.8,1.8,0,0,0-1.46-.67,2,2,0,0,0-1.57.68A2.51,2.51,0,0,0,505.93,23.66Z" fill="#2f2f2f"/>
-      <path d="M516.62,21.63a1.39,1.39,0,0,0-.85-.23,1.43,1.43,0,0,0-1.2.68,3.15,3.15,0,0,0-.48,1.85v3.56H513v-7h1.12v1.45h0a2.36,2.36,0,0,1,.73-1.15,1.65,1.65,0,0,1,1.1-.42,1.72,1.72,0,0,1,.67.1Z" fill="#2f2f2f"/>
-      <path d="M518.44,18.72a.72.72,0,0,1-.52-.21.69.69,0,0,1-.21-.52.7.7,0,0,1,.21-.52.72.72,0,0,1,.52-.21.73.73,0,0,1,.52.21.7.7,0,0,1,.21.52.72.72,0,0,1-.73.73Zm.54,8.77h-1.12v-7H519Z" fill="#2f2f2f"/>
-      <path d="M526.91,27.49h-1.12v-4c0-1.48-.54-2.23-1.63-2.23a1.75,1.75,0,0,0-1.39.64,2.36,2.36,0,0,0-.55,1.59v4H521.1v-7h1.12v1.17h0a2.52,2.52,0,0,1,2.3-1.33,2.14,2.14,0,0,1,1.75.74,3.3,3.3,0,0,1,.61,2.15Z" fill="#2f2f2f"/>
-      <path d="M535,26.93c0,2.57-1.24,3.86-3.7,3.86A5,5,0,0,1,529,30.3V29.18a4.74,4.74,0,0,0,2.26.65c1.72,0,2.58-.91,2.58-2.75v-.76h0a2.84,2.84,0,0,1-4.51.41,3.76,3.76,0,0,1-.8-2.51,4.37,4.37,0,0,1,.86-2.84,2.87,2.87,0,0,1,2.35-1.05,2.29,2.29,0,0,1,2.1,1.14h0v-1H535Zm-1.13-2.6v-1a2,2,0,0,0-.56-1.43,1.85,1.85,0,0,0-1.4-.6,2,2,0,0,0-1.63.76,3.38,3.38,0,0,0-.59,2.12,2.85,2.85,0,0,0,.57,1.86,1.81,1.81,0,0,0,1.49.71,2,2,0,0,0,1.53-.67A2.48,2.48,0,0,0,533.86,24.33Z" fill="#2f2f2f"/>
-      <path d="M547.91,27.08a5.62,5.62,0,0,1-2.7.58,4.34,4.34,0,0,1-3.35-1.35,5,5,0,0,1-1.26-3.53A5.2,5.2,0,0,1,542,19a4.8,4.8,0,0,1,3.59-1.45,5.73,5.73,0,0,1,2.31.4v1.22a4.67,4.67,0,0,0-2.32-.58,3.57,3.57,0,0,0-2.74,1.12,4.27,4.27,0,0,0-1.05,3,4,4,0,0,0,1,2.85,3.35,3.35,0,0,0,2.58,1.07,4.79,4.79,0,0,0,2.55-.66Z" fill="#2f2f2f"/>
-      <path d="M550.58,27.49h-1.12V17.13h1.12Z" fill="#2f2f2f"/>
-      <path d="M555.7,27.66a3.28,3.28,0,0,1-2.48-1,3.67,3.67,0,0,1-.92-2.6,3.8,3.8,0,0,1,1-2.76,3.48,3.48,0,0,1,2.61-1,3.13,3.13,0,0,1,2.44,1,3.83,3.83,0,0,1,.88,2.68,3.77,3.77,0,0,1-1,2.68A3.33,3.33,0,0,1,555.7,27.66Zm.09-6.39a2.14,2.14,0,0,0-1.71.74,3,3,0,0,0-.63,2,2.87,2.87,0,0,0,.63,2,2.17,2.17,0,0,0,1.71.72,2.06,2.06,0,0,0,1.67-.71,3.06,3.06,0,0,0,.58-2,3.13,3.13,0,0,0-.58-2A2.06,2.06,0,0,0,555.79,21.27Z" fill="#2f2f2f"/>
-      <path d="M566.6,27.49h-1.12v-1.1h0a2.3,2.3,0,0,1-2.16,1.27c-1.67,0-2.5-1-2.5-3V20.49h1.11v4c0,1.48.57,2.22,1.7,2.22a1.75,1.75,0,0,0,1.35-.61,2.32,2.32,0,0,0,.53-1.58v-4h1.12Z" fill="#2f2f2f"/>
-      <path d="M574.77,27.49h-1.12V26.31h0a2.83,2.83,0,0,1-4.52.41,3.9,3.9,0,0,1-.79-2.56,4.19,4.19,0,0,1,.88-2.78,2.88,2.88,0,0,1,2.33-1.05,2.25,2.25,0,0,1,2.1,1.14h0V17.13h1.12Zm-1.12-3.16v-1a2,2,0,0,0-.56-1.44,2.06,2.06,0,0,0-3,.17,3.29,3.29,0,0,0-.59,2.07A2.92,2.92,0,0,0,570,26a1.83,1.83,0,0,0,1.51.71,1.91,1.91,0,0,0,1.52-.68A2.52,2.52,0,0,0,573.65,24.33Z" fill="#2f2f2f"/>
-      <path d="M465.3,43.28h0v4.23h-1.12V37.29h1.12v1.23h0a2.67,2.67,0,0,1,2.42-1.39,2.56,2.56,0,0,1,2.11.94,3.88,3.88,0,0,1,.76,2.52,4.32,4.32,0,0,1-.86,2.81,2.8,2.8,0,0,1-2.33,1.06A2.33,2.33,0,0,1,465.3,43.28Zm0-2.82v1a2.09,2.09,0,0,0,.56,1.47,1.91,1.91,0,0,0,1.44.61,1.86,1.86,0,0,0,1.59-.78,3.56,3.56,0,0,0,.58-2.17,2.81,2.81,0,0,0-.54-1.83,1.77,1.77,0,0,0-1.46-.67,2,2,0,0,0-1.57.68A2.51,2.51,0,0,0,465.27,40.46Z" fill="#2f2f2f"/>
-      <path d="M476,38.43a1.39,1.39,0,0,0-.85-.23,1.43,1.43,0,0,0-1.2.68,3.15,3.15,0,0,0-.48,1.85v3.56h-1.12v-7h1.12v1.45h0a2.45,2.45,0,0,1,.74-1.16,1.67,1.67,0,0,1,1.1-.41,1.72,1.72,0,0,1,.67.1Z" fill="#2f2f2f"/>
-      <path d="M477.77,35.52a.69.69,0,0,1-.51-.21.69.69,0,0,1-.21-.52.72.72,0,0,1,.72-.73.74.74,0,0,1,.53.21.7.7,0,0,1,.21.52.72.72,0,0,1-.74.73Zm.55,8.77H477.2v-7h1.12Z" fill="#2f2f2f"/>
-      <path d="M486.12,37.29l-2.79,7h-1.1l-2.65-7h1.23l1.77,5.09a4,4,0,0,1,.25,1h0a4.28,4.28,0,0,1,.22-1l1.86-5.12Z" fill="#2f2f2f"/>
-      <path d="M492.24,44.29h-1.12V43.2h0a2.35,2.35,0,0,1-2.15,1.26,2.3,2.3,0,0,1-1.64-.56,1.86,1.86,0,0,1-.59-1.46c0-1.31.77-2.07,2.31-2.29l2.1-.29c0-1.19-.48-1.79-1.45-1.79a3.43,3.43,0,0,0-2.28.87V37.79a4.32,4.32,0,0,1,2.38-.66c1.65,0,2.47.87,2.47,2.61Zm-1.12-3.54-1.69.24a2.82,2.82,0,0,0-1.18.38,1.13,1.13,0,0,0-.39,1,1.09,1.09,0,0,0,.36.84,1.4,1.4,0,0,0,1,.33,1.79,1.79,0,0,0,1.37-.59,2.06,2.06,0,0,0,.55-1.48Z" fill="#2f2f2f"/>
-      <path d="M497.5,44.23a2.22,2.22,0,0,1-1.05.21c-1.22,0-1.83-.68-1.83-2V38.25h-1.21v-1h1.21v-1.7l1.12-.37v2.07h1.76v1h-1.76v4a1.61,1.61,0,0,0,.24,1,.94.94,0,0,0,.79.3,1.22,1.22,0,0,0,.73-.23Z" fill="#2f2f2f"/>
-      <path d="M504.49,41.07h-4.94a2.64,2.64,0,0,0,.63,1.81,2.18,2.18,0,0,0,1.65.64,3.45,3.45,0,0,0,2.18-.78v1a4.05,4.05,0,0,1-2.44.67,2.94,2.94,0,0,1-2.33-1,4.47,4.47,0,0,1,.07-5.34,3,3,0,0,1,2.3-1,2.64,2.64,0,0,1,2.13.89,3.7,3.7,0,0,1,.75,2.47Zm-1.15-1a2.31,2.31,0,0,0-.46-1.51,1.61,1.61,0,0,0-1.29-.54,1.81,1.81,0,0,0-1.34.57,2.59,2.59,0,0,0-.69,1.48Z" fill="#2f2f2f"/>
-      <path d="M510.17,44.29v-9.8h2.71q5.18,0,5.18,4.78a4.83,4.83,0,0,1-1.44,3.65,5.32,5.32,0,0,1-3.85,1.37Zm1.15-8.76v7.73h1.46a4.17,4.17,0,0,0,3-1,3.87,3.87,0,0,0,1.07-2.92q0-3.77-4-3.77Z" fill="#2f2f2f"/>
-      <path d="M527.81,44.29h-1.4l-5-7.81a2.92,2.92,0,0,1-.31-.61h0a11.63,11.63,0,0,1,0,1.34v7.08h-1.15v-9.8h1.49l4.91,7.69a7.6,7.6,0,0,1,.4.66h0a11.72,11.72,0,0,1-.06-1.44V34.49h1.14Z" fill="#2f2f2f"/>
-      <path d="M529.83,43.9V42.54a2.52,2.52,0,0,0,.55.37,4.15,4.15,0,0,0,.69.28,4.69,4.69,0,0,0,.72.17,3.25,3.25,0,0,0,.67.07A2.57,2.57,0,0,0,534,43a1.32,1.32,0,0,0,.52-1.13,1.41,1.41,0,0,0-.17-.69,2.39,2.39,0,0,0-.48-.54,5.42,5.42,0,0,0-.73-.46l-.91-.47c-.34-.17-.66-.35-.95-.52a4.42,4.42,0,0,1-.78-.59,2.6,2.6,0,0,1-.51-.73,2.18,2.18,0,0,1-.19-.95,2.31,2.31,0,0,1,.29-1.17,2.65,2.65,0,0,1,.78-.82,3.72,3.72,0,0,1,1.09-.48,5.13,5.13,0,0,1,1.24-.15,4.72,4.72,0,0,1,2.12.35V36a3.84,3.84,0,0,0-2.23-.6,3.19,3.19,0,0,0-.75.08,2,2,0,0,0-.67.25,1.41,1.41,0,0,0-.48.46,1.16,1.16,0,0,0-.19.68,1.45,1.45,0,0,0,.14.65,1.63,1.63,0,0,0,.42.5,4,4,0,0,0,.66.44c.27.14.57.3.91.46s.68.36,1,.55a4.08,4.08,0,0,1,.82.64,2.8,2.8,0,0,1,.57.77,2.16,2.16,0,0,1,.21,1,2.49,2.49,0,0,1-.29,1.23,2.36,2.36,0,0,1-.76.81,3.25,3.25,0,0,1-1.11.46,6.31,6.31,0,0,1-1.33.14,4.31,4.31,0,0,1-.57,0,6,6,0,0,1-.7-.11,6.75,6.75,0,0,1-.68-.18A2.15,2.15,0,0,1,529.83,43.9Z" fill="#2f2f2f"/>
-      <path d="M546.29,37.62l-4.15,5.72h4.11v.95H540.5V44l4.14-5.7h-3.75v-1h5.4Z" fill="#2f2f2f"/>
-      <path d="M550.46,44.46a3.26,3.26,0,0,1-2.48-1,3.63,3.63,0,0,1-.93-2.6,3.8,3.8,0,0,1,1-2.76,3.46,3.46,0,0,1,2.6-1,3.16,3.16,0,0,1,2.45,1,3.88,3.88,0,0,1,.88,2.68,3.77,3.77,0,0,1-1,2.68A3.33,3.33,0,0,1,550.46,44.46Zm.08-6.39a2.14,2.14,0,0,0-1.71.74,3,3,0,0,0-.63,2,2.87,2.87,0,0,0,.64,2,2.15,2.15,0,0,0,1.7.72,2,2,0,0,0,1.67-.71,3.06,3.06,0,0,0,.59-2,3.13,3.13,0,0,0-.59-2A2,2,0,0,0,550.54,38.07Z" fill="#2f2f2f"/>
-      <path d="M561.47,44.29h-1.12v-4c0-1.48-.54-2.23-1.63-2.23a1.75,1.75,0,0,0-1.39.64,2.36,2.36,0,0,0-.55,1.59v4h-1.12v-7h1.12v1.17h0a2.52,2.52,0,0,1,2.3-1.33,2.14,2.14,0,0,1,1.75.74,3.3,3.3,0,0,1,.61,2.15Z" fill="#2f2f2f"/>
-      <path d="M569.17,41.07h-4.94a2.64,2.64,0,0,0,.63,1.81,2.18,2.18,0,0,0,1.66.64,3.44,3.44,0,0,0,2.17-.78v1a4.05,4.05,0,0,1-2.44.67,2.94,2.94,0,0,1-2.33-1,3.87,3.87,0,0,1-.85-2.68,3.82,3.82,0,0,1,.93-2.66,2.94,2.94,0,0,1,2.3-1,2.63,2.63,0,0,1,2.12.89,3.7,3.7,0,0,1,.75,2.47Zm-1.14-1a2.31,2.31,0,0,0-.47-1.51,1.6,1.6,0,0,0-1.28-.54,1.81,1.81,0,0,0-1.35.57,2.52,2.52,0,0,0-.68,1.48Z" fill="#2f2f2f"/>
-    </g>
-    <g>
-      <path d="M639.2,300.09h-2.58l-.75-2.34h-3.73l-.74,2.34h-2.57l3.83-10.51h2.8Zm-3.87-4.16-1.13-3.53a5.07,5.07,0,0,1-.18-.94h0a4.3,4.3,0,0,1-.19.92l-1.14,3.55Z" fill="#2f2f2f"/>
-      <path d="M646.59,300.09h-6.73v-1l3.77-4.84h-3.4v-1.7h6.33v1.14L643,298.38h3.59Z" fill="#2f2f2f"/>
-      <path d="M655,300.09h-2.3v-1.15h0a2.61,2.61,0,0,1-2.29,1.33c-1.74,0-2.61-1-2.61-3.16v-4.52h2.31v4.32q0,1.59,1.26,1.59a1.25,1.25,0,0,0,1-.44,1.74,1.74,0,0,0,.38-1.18v-4.29H655Z" fill="#2f2f2f"/>
-      <path d="M661.82,294.67a2.05,2.05,0,0,0-1-.22,1.41,1.41,0,0,0-1.18.55,2.44,2.44,0,0,0-.42,1.51v3.58h-2.32v-7.5h2.32V294h0a2,2,0,0,1,2-1.52,1.52,1.52,0,0,1,.58.08Z" fill="#2f2f2f"/>
-      <path d="M669.71,297h-4.89c.08,1.09.76,1.63,2.06,1.63a4,4,0,0,0,2.17-.59v1.67a5.7,5.7,0,0,1-2.7.56,3.49,3.49,0,0,1-3.82-3.82,4,4,0,0,1,1.08-2.95,3.61,3.61,0,0,1,2.67-1.1,3.25,3.25,0,0,1,2.53,1,3.74,3.74,0,0,1,.9,2.64Zm-2.14-1.42c0-1.08-.44-1.62-1.31-1.62a1.24,1.24,0,0,0-1,.47,2.09,2.09,0,0,0-.5,1.15Z" fill="#2f2f2f"/>
-      <path d="M675,299.68v-2.34a4.6,4.6,0,0,0,1.38.8,4.46,4.46,0,0,0,1.51.27,3.53,3.53,0,0,0,.78-.08,1.82,1.82,0,0,0,.56-.22,1,1,0,0,0,.33-.34.78.78,0,0,0,.11-.42.94.94,0,0,0-.17-.55,2.09,2.09,0,0,0-.48-.45,5.3,5.3,0,0,0-.72-.39l-.9-.39a4.61,4.61,0,0,1-1.84-1.25,2.76,2.76,0,0,1-.6-1.79,2.73,2.73,0,0,1,1.22-2.38,3.93,3.93,0,0,1,1.32-.56,6.71,6.71,0,0,1,1.58-.18,8.92,8.92,0,0,1,1.45.1,5,5,0,0,1,1.17.3V292a3.49,3.49,0,0,0-.57-.32,4.88,4.88,0,0,0-.64-.23,5.18,5.18,0,0,0-.66-.14,4.49,4.49,0,0,0-.62,0,2.77,2.77,0,0,0-.73.08,1.93,1.93,0,0,0-.56.21,1,1,0,0,0-.35.34.85.85,0,0,0,0,.9,1.62,1.62,0,0,0,.39.4,3.91,3.91,0,0,0,.62.36c.25.13.52.25.83.38a7.93,7.93,0,0,1,1.13.56,3.66,3.66,0,0,1,.86.67,2.4,2.4,0,0,1,.55.85,3,3,0,0,1,.19,1.12,3,3,0,0,1-.33,1.47,2.7,2.7,0,0,1-.9,1,4,4,0,0,1-1.33.53,7.55,7.55,0,0,1-1.6.16,8.73,8.73,0,0,1-1.65-.15A4.56,4.56,0,0,1,675,299.68Z" fill="#2f2f2f"/>
-      <path d="M686,299.22h0v4.32h-2.31v-11H686v1.13h0a2.94,2.94,0,0,1,4.66-.32,4.29,4.29,0,0,1,.8,2.73,4.61,4.61,0,0,1-.93,3,3,3,0,0,1-2.47,1.13A2.33,2.33,0,0,1,686,299.22Zm-.07-3.08v.6a1.94,1.94,0,0,0,.41,1.27,1.38,1.38,0,0,0,1.08.49,1.44,1.44,0,0,0,1.23-.61,3,3,0,0,0,.43-1.74c0-1.31-.51-2-1.54-2a1.45,1.45,0,0,0-1.16.54A2.12,2.12,0,0,0,685.91,296.14Z" fill="#2f2f2f"/>
-      <path d="M697.84,294.67a2,2,0,0,0-1-.22,1.39,1.39,0,0,0-1.18.55,2.38,2.38,0,0,0-.43,1.51v3.58H693v-7.5h2.31V294h0a2,2,0,0,1,2-1.52,1.5,1.5,0,0,1,.57.08Z" fill="#2f2f2f"/>
-      <path d="M700.07,291.4a1.32,1.32,0,0,1-1-.35,1.1,1.1,0,0,1-.37-.85,1.07,1.07,0,0,1,.37-.85,1.58,1.58,0,0,1,1.93,0,1.1,1.1,0,0,1,.37.85,1.13,1.13,0,0,1-.37.86A1.37,1.37,0,0,1,700.07,291.4Zm1.15,8.69H698.9v-7.5h2.32Z" fill="#2f2f2f"/>
-      <path d="M710.37,300.09h-2.31v-4.17c0-1.16-.42-1.74-1.25-1.74a1.23,1.23,0,0,0-1,.46,1.81,1.81,0,0,0-.38,1.17v4.28h-2.32v-7.5h2.32v1.18h0a2.65,2.65,0,0,1,2.41-1.37c1.66,0,2.49,1,2.49,3.1Z" fill="#2f2f2f"/>
-      <path d="M719.6,299.23a4.25,4.25,0,0,1-1.21,3.23,4.89,4.89,0,0,1-3.5,1.15,5.56,5.56,0,0,1-2.41-.43v-1.95a4.59,4.59,0,0,0,2.34.67,2.5,2.5,0,0,0,1.82-.62,2.21,2.21,0,0,0,.64-1.68V299h0a2.58,2.58,0,0,1-2.33,1.26,2.82,2.82,0,0,1-2.28-1,4.11,4.11,0,0,1-.85-2.71,4.61,4.61,0,0,1,.94-3,3.09,3.09,0,0,1,2.47-1.12,2.29,2.29,0,0,1,2,1.06h0v-.87h2.32Zm-2.29-2.75v-.59a1.82,1.82,0,0,0-.42-1.21,1.35,1.35,0,0,0-1.1-.5,1.4,1.4,0,0,0-1.2.6,2.76,2.76,0,0,0-.44,1.69,2.43,2.43,0,0,0,.41,1.48,1.36,1.36,0,0,0,1.15.55,1.43,1.43,0,0,0,1.16-.56A2.27,2.27,0,0,0,717.31,296.48Z" fill="#2f2f2f"/>
-      <path d="M733.42,299.71a6.89,6.89,0,0,1-3,.56,5,5,0,0,1-3.8-1.42,5.21,5.21,0,0,1-1.38-3.79,5.51,5.51,0,0,1,1.55-4.08,5.44,5.44,0,0,1,4-1.57,7.47,7.47,0,0,1,2.59.39v2.27a4.57,4.57,0,0,0-2.4-.63,3.18,3.18,0,0,0-2.39.94,3.45,3.45,0,0,0-.9,2.51,3.38,3.38,0,0,0,.85,2.43,3,3,0,0,0,2.31.91,4.89,4.89,0,0,0,2.53-.68Z" fill="#2f2f2f"/>
-      <path d="M737.29,300.09H735V289h2.32Z" fill="#2f2f2f"/>
-      <path d="M742.79,300.27a4,4,0,0,1-2.94-1,4.32,4.32,0,0,1,0-5.76,4.16,4.16,0,0,1,3-1.06,4,4,0,0,1,2.93,1.06,3.75,3.75,0,0,1,1.06,2.77,4,4,0,0,1-1.1,3A4.09,4.09,0,0,1,742.79,300.27Zm.06-6.09a1.53,1.53,0,0,0-1.27.56,2.52,2.52,0,0,0-.45,1.6q0,2.16,1.74,2.16c1.11,0,1.66-.74,1.66-2.22S744,294.18,742.85,294.18Z" fill="#2f2f2f"/>
-      <path d="M755.49,300.09h-2.31v-1.15h0a2.61,2.61,0,0,1-2.29,1.33c-1.74,0-2.61-1-2.61-3.16v-4.52h2.3v4.32q0,1.59,1.26,1.59a1.25,1.25,0,0,0,1-.44,1.74,1.74,0,0,0,.37-1.18v-4.29h2.31Z" fill="#2f2f2f"/>
-      <path d="M764.79,300.09h-2.31v-1h0a2.58,2.58,0,0,1-2.32,1.22,2.86,2.86,0,0,1-2.27-1,4.12,4.12,0,0,1-.85-2.77,4.5,4.5,0,0,1,.94-3,3.11,3.11,0,0,1,2.48-1.12,2.12,2.12,0,0,1,2,1h0V289h2.31Zm-2.27-3.65v-.56a1.79,1.79,0,0,0-.42-1.22,1.43,1.43,0,0,0-1.11-.48,1.4,1.4,0,0,0-1.2.6,2.8,2.8,0,0,0-.43,1.66,2.46,2.46,0,0,0,.41,1.52,1.48,1.48,0,0,0,2.31,0A2.36,2.36,0,0,0,762.52,296.44Z" fill="#2f2f2f"/>
-    </g>
-    <g>
-      <path d="M66.32,28.33H65.17v-9.8h1.15Z" fill="#2f2f2f"/>
-      <path d="M74.4,28.33H73.27v-4c0-1.49-.54-2.23-1.62-2.23a1.76,1.76,0,0,0-1.39.63,2.34,2.34,0,0,0-.55,1.6v4H68.58v-7h1.13v1.16h0A2.54,2.54,0,0,1,72,21.17a2.13,2.13,0,0,1,1.76.74,3.33,3.33,0,0,1,.61,2.14Z" fill="#2f2f2f"/>
-      <path d="M82.47,27.77q0,3.86-3.69,3.86a4.93,4.93,0,0,1-2.27-.5V30a4.64,4.64,0,0,0,2.25.66c1.73,0,2.59-.92,2.59-2.75v-.76h0a2.83,2.83,0,0,1-4.51.4,3.71,3.71,0,0,1-.79-2.5,4.37,4.37,0,0,1,.85-2.84,2.89,2.89,0,0,1,2.35-1,2.28,2.28,0,0,1,2.1,1.13h0v-1h1.12Zm-1.12-2.6v-1a2,2,0,0,0-.57-1.42,1.83,1.83,0,0,0-1.4-.6,1.94,1.94,0,0,0-1.63.76A3.37,3.37,0,0,0,77.17,25a2.88,2.88,0,0,0,.56,1.87,1.8,1.8,0,0,0,1.49.7,2,2,0,0,0,1.54-.67A2.5,2.5,0,0,0,81.35,25.17Z" fill="#2f2f2f"/>
-      <path d="M88.23,22.47a1.39,1.39,0,0,0-.85-.23,1.43,1.43,0,0,0-1.2.68,3.12,3.12,0,0,0-.48,1.84v3.57H84.58v-7H85.7v1.44h0a2.38,2.38,0,0,1,.73-1.15,1.69,1.69,0,0,1,1.1-.41,2,2,0,0,1,.67.09Z" fill="#2f2f2f"/>
-      <path d="M95.07,25.11H90.13a2.66,2.66,0,0,0,.63,1.81,2.17,2.17,0,0,0,1.65.63,3.42,3.42,0,0,0,2.17-.78v1.06a4.08,4.08,0,0,1-2.44.67,3,3,0,0,1-2.33-1A3.91,3.91,0,0,1,89,24.86a3.79,3.79,0,0,1,.92-2.66,3,3,0,0,1,2.3-1,2.61,2.61,0,0,1,2.13.89,3.69,3.69,0,0,1,.75,2.46Zm-1.15-.95a2.24,2.24,0,0,0-.47-1.51,1.58,1.58,0,0,0-1.28-.54,1.78,1.78,0,0,0-1.34.57,2.59,2.59,0,0,0-.69,1.48Z" fill="#2f2f2f"/>
-      <path d="M96.31,28.08v-1.2a3.31,3.31,0,0,0,2,.67c1,0,1.47-.33,1.47-1a.9.9,0,0,0-.12-.48,1.37,1.37,0,0,0-.34-.34,3.05,3.05,0,0,0-.51-.27l-.62-.25a8.17,8.17,0,0,1-.82-.37,2.5,2.5,0,0,1-.59-.43,1.56,1.56,0,0,1-.36-.53,2.2,2.2,0,0,1-.11-.71,1.66,1.66,0,0,1,.22-.87,2,2,0,0,1,.6-.64A2.68,2.68,0,0,1,98,21.3a3.64,3.64,0,0,1,1-.13,4,4,0,0,1,1.63.31v1.14a3.15,3.15,0,0,0-1.78-.51,2,2,0,0,0-.56.07,1.63,1.63,0,0,0-.44.2,1,1,0,0,0-.28.32.88.88,0,0,0-.1.4,1,1,0,0,0,.1.45,1,1,0,0,0,.29.33,2.31,2.31,0,0,0,.47.26l.62.25a7.3,7.3,0,0,1,.83.37,3.13,3.13,0,0,1,.63.42,1.53,1.53,0,0,1,.4.55,1.92,1.92,0,0,1-.09,1.63,1.87,1.87,0,0,1-.61.64,2.68,2.68,0,0,1-.88.37,4.44,4.44,0,0,1-1,.13A3.94,3.94,0,0,1,96.31,28.08Z" fill="#2f2f2f"/>
-      <path d="M102.24,28.08v-1.2a3.31,3.31,0,0,0,2,.67c1,0,1.48-.33,1.48-1a.9.9,0,0,0-.12-.48,1.26,1.26,0,0,0-.35-.34,2.61,2.61,0,0,0-.5-.27c-.2-.08-.4-.17-.63-.25s-.58-.25-.82-.37a2.43,2.43,0,0,1-.58-.43,1.56,1.56,0,0,1-.36-.53,2,2,0,0,1-.12-.71,1.66,1.66,0,0,1,.23-.87,2,2,0,0,1,.6-.64,2.68,2.68,0,0,1,.86-.38,3.64,3.64,0,0,1,1-.13,4,4,0,0,1,1.63.31v1.14a3.17,3.17,0,0,0-1.78-.51,2,2,0,0,0-.57.07,1.56,1.56,0,0,0-.43.2,1,1,0,0,0-.28.32.77.77,0,0,0-.1.4.88.88,0,0,0,.1.45.91.91,0,0,0,.29.33,2.22,2.22,0,0,0,.46.26l.63.25a8.19,8.19,0,0,1,.83.37,3.13,3.13,0,0,1,.63.42,1.66,1.66,0,0,1,.4.55,1.79,1.79,0,0,1,.14.73,1.74,1.74,0,0,1-.23.9A2,2,0,0,1,106,28a2.78,2.78,0,0,1-.88.37,4.51,4.51,0,0,1-1,.13A3.94,3.94,0,0,1,102.24,28.08Z" fill="#2f2f2f"/>
-      <path d="M70.37,47.33h-5.2v-9.8h5v1H66.32v3.26h3.54v1H66.32v3.43h4.05Z" fill="#2f2f2f"/>
-      <path d="M77.85,46.77q0,3.85-3.69,3.86a4.93,4.93,0,0,1-2.27-.5V49a4.64,4.64,0,0,0,2.25.66c1.73,0,2.59-.92,2.59-2.75v-.76h0a2.83,2.83,0,0,1-4.51.4,3.71,3.71,0,0,1-.79-2.5,4.37,4.37,0,0,1,.85-2.84,2.89,2.89,0,0,1,2.35-1,2.28,2.28,0,0,1,2.1,1.13h0v-1h1.12Zm-1.12-2.6v-1a2,2,0,0,0-.57-1.42,1.83,1.83,0,0,0-1.4-.6,1.94,1.94,0,0,0-1.63.76A3.37,3.37,0,0,0,72.54,44a2.88,2.88,0,0,0,.57,1.87,1.8,1.8,0,0,0,1.49.7,2,2,0,0,0,1.54-.67A2.5,2.5,0,0,0,76.73,44.17Z" fill="#2f2f2f"/>
-      <path d="M83.61,41.47a1.39,1.39,0,0,0-.85-.23,1.43,1.43,0,0,0-1.2.68,3.12,3.12,0,0,0-.48,1.84v3.57H80v-7h1.12v1.44h0a2.38,2.38,0,0,1,.73-1.15,1.69,1.69,0,0,1,1.1-.41,2,2,0,0,1,.67.09Z" fill="#2f2f2f"/>
-      <path d="M90.45,44.11H85.51a2.66,2.66,0,0,0,.63,1.81,2.17,2.17,0,0,0,1.65.63A3.42,3.42,0,0,0,90,45.77v1.06a4.08,4.08,0,0,1-2.44.67,3,3,0,0,1-2.33-1,3.91,3.91,0,0,1-.84-2.68,3.79,3.79,0,0,1,.92-2.66,3,3,0,0,1,2.3-1,2.61,2.61,0,0,1,2.13.89,3.69,3.69,0,0,1,.75,2.46Zm-1.15-1a2.24,2.24,0,0,0-.47-1.51,1.58,1.58,0,0,0-1.28-.54,1.78,1.78,0,0,0-1.34.57,2.59,2.59,0,0,0-.69,1.48Z" fill="#2f2f2f"/>
-      <path d="M91.69,47.08v-1.2a3.33,3.33,0,0,0,2,.67c1,0,1.48-.33,1.48-1a.9.9,0,0,0-.13-.48,1.37,1.37,0,0,0-.34-.34,2.7,2.7,0,0,0-.51-.27l-.62-.25a8.17,8.17,0,0,1-.82-.37,2.5,2.5,0,0,1-.59-.43,1.53,1.53,0,0,1-.35-.53,2,2,0,0,1-.12-.71,1.66,1.66,0,0,1,.22-.87,2,2,0,0,1,.6-.64,2.68,2.68,0,0,1,.86-.38,3.66,3.66,0,0,1,1-.13,4,4,0,0,1,1.62.31v1.14a3.12,3.12,0,0,0-1.77-.51,2,2,0,0,0-.57.07,1.63,1.63,0,0,0-.44.2,1,1,0,0,0-.28.32.88.88,0,0,0-.1.4,1,1,0,0,0,.1.45,1,1,0,0,0,.29.33,2.31,2.31,0,0,0,.47.26l.62.25a8.42,8.42,0,0,1,.84.37,3.35,3.35,0,0,1,.62.42,1.53,1.53,0,0,1,.4.55,1.92,1.92,0,0,1-.09,1.63,1.87,1.87,0,0,1-.61.64,2.68,2.68,0,0,1-.88.37,4.42,4.42,0,0,1-1,.13A4,4,0,0,1,91.69,47.08Z" fill="#2f2f2f"/>
-      <path d="M97.62,47.08v-1.2a3.31,3.31,0,0,0,2,.67c1,0,1.47-.33,1.47-1a.9.9,0,0,0-.12-.48,1.26,1.26,0,0,0-.35-.34,2.61,2.61,0,0,0-.5-.27c-.2-.08-.4-.17-.63-.25a7.93,7.93,0,0,1-.81-.37,2.5,2.5,0,0,1-.59-.43,1.56,1.56,0,0,1-.36-.53,2,2,0,0,1-.12-.71,1.66,1.66,0,0,1,.23-.87,2,2,0,0,1,.6-.64,2.68,2.68,0,0,1,.86-.38,3.64,3.64,0,0,1,1-.13,4,4,0,0,1,1.63.31v1.14a3.17,3.17,0,0,0-1.78-.51,2,2,0,0,0-.57.07,1.71,1.71,0,0,0-.43.2,1,1,0,0,0-.28.32.77.77,0,0,0-.1.4.88.88,0,0,0,.1.45.91.91,0,0,0,.29.33,2.07,2.07,0,0,0,.47.26l.62.25a7.3,7.3,0,0,1,.83.37,3.13,3.13,0,0,1,.63.42,1.66,1.66,0,0,1,.4.55,1.79,1.79,0,0,1,.14.73,1.74,1.74,0,0,1-.23.9,2,2,0,0,1-.61.64,2.68,2.68,0,0,1-.88.37,4.44,4.44,0,0,1-1.05.13A3.94,3.94,0,0,1,97.62,47.08Z" fill="#2f2f2f"/>
-    </g>
-    <g>
-      <path d="M804,99.28h-1.25l-3-3.52a1.42,1.42,0,0,1-.2-.27h0v3.79h-.91v-7.7h.91V95.2h0a2,2,0,0,1,.2-.26l2.88-3.36h1.12l-3.3,3.7Z" fill="#2f2f2f"/>
-      <path d="M809.13,96.75h-3.88a2,2,0,0,0,.49,1.42,1.71,1.71,0,0,0,1.3.5,2.7,2.7,0,0,0,1.71-.61v.83a3.21,3.21,0,0,1-1.92.52,2.31,2.31,0,0,1-1.83-.75,3,3,0,0,1-.67-2.11,3,3,0,0,1,.73-2.09,2.33,2.33,0,0,1,1.81-.81,2.09,2.09,0,0,1,1.67.7,2.94,2.94,0,0,1,.59,1.94Zm-.9-.74a1.84,1.84,0,0,0-.37-1.19,1.26,1.26,0,0,0-1-.42,1.42,1.42,0,0,0-1.06.44,2,2,0,0,0-.53,1.17Z" fill="#2f2f2f"/>
-      <path d="M814.84,93.78l-2.53,6.38c-.45,1.14-1.09,1.71-1.9,1.71a2,2,0,0,1-.58-.07V101a1.53,1.53,0,0,0,.52.1,1.08,1.08,0,0,0,1-.8l.44-1-2.15-5.49h1L812.11,98s0,.19.11.41h0l.11-.4,1.56-4.25Z" fill="#2f2f2f"/>
-      <path d="M798.33,104.58l-2.85,7.7h-1l-2.8-7.7h1l2.13,6.11a3,3,0,0,1,.15.68h0a3.15,3.15,0,0,1,.17-.69l2.18-6.1Z" fill="#2f2f2f"/>
-      <path d="M802.81,112.28h-.88v-.86h0a1.84,1.84,0,0,1-1.69,1,1.81,1.81,0,0,1-1.29-.43,1.51,1.51,0,0,1-.46-1.16c0-1,.6-1.62,1.81-1.79l1.65-.23c0-.94-.38-1.4-1.13-1.4a2.72,2.72,0,0,0-1.8.67v-.9a3.46,3.46,0,0,1,1.87-.52c1.3,0,1.94.69,1.94,2.06Zm-.88-2.78-1.33.18a2.15,2.15,0,0,0-.92.31.86.86,0,0,0-.31.77.82.82,0,0,0,.29.66,1.09,1.09,0,0,0,.76.25,1.39,1.39,0,0,0,1.08-.46,1.62,1.62,0,0,0,.43-1.16Z" fill="#2f2f2f"/>
-      <path d="M808.93,112.28h-.88v-.87h0a1.8,1.8,0,0,1-1.7,1c-1.31,0-2-.78-2-2.34v-3.29h.87v3.15c0,1.16.45,1.74,1.34,1.74a1.34,1.34,0,0,0,1.06-.48,1.79,1.79,0,0,0,.41-1.24v-3.17h.88Z" fill="#2f2f2f"/>
-      <path d="M811.53,112.28h-.88v-8.14h.88Z" fill="#2f2f2f"/>
-      <path d="M815.86,112.23a1.75,1.75,0,0,1-.82.17c-1,0-1.45-.54-1.45-1.61v-3.26h-.94v-.75h.94v-1.34l.89-.28v1.62h1.38v.75h-1.38v3.1a1.31,1.31,0,0,0,.18.79.77.77,0,0,0,.63.24.92.92,0,0,0,.57-.18Z" fill="#2f2f2f"/>
-      <path d="M816.84,112.08v-.94a2.64,2.64,0,0,0,1.58.53c.78,0,1.16-.26,1.16-.77a.76.76,0,0,0-.09-.38,1.15,1.15,0,0,0-.27-.27,2.15,2.15,0,0,0-.4-.21l-.49-.2a4.32,4.32,0,0,1-.64-.29,2.17,2.17,0,0,1-.47-.33,1.47,1.47,0,0,1-.28-.42,1.57,1.57,0,0,1-.09-.56,1.3,1.3,0,0,1,.18-.68,1.5,1.5,0,0,1,.47-.5,2.15,2.15,0,0,1,.67-.3,3,3,0,0,1,.79-.11,3.2,3.2,0,0,1,1.27.25v.89a2.51,2.51,0,0,0-1.39-.39,1.55,1.55,0,0,0-.45,0,1.19,1.19,0,0,0-.34.16.83.83,0,0,0-.22.24.69.69,0,0,0-.08.32.72.72,0,0,0,.31.62,2,2,0,0,0,.36.2l.49.2a5.2,5.2,0,0,1,.66.29,2,2,0,0,1,.49.33,1.34,1.34,0,0,1,.32.43,1.41,1.41,0,0,1,.11.57,1.36,1.36,0,0,1-.18.71,1.53,1.53,0,0,1-.48.5,2.2,2.2,0,0,1-.7.29,3.43,3.43,0,0,1-2.29-.23Z" fill="#2f2f2f"/>
-    </g>
-    <g>
-      <path d="M850.65,99V97.91a2.4,2.4,0,0,0,.44.29,4.35,4.35,0,0,0,.54.22c.19,0,.38.1.57.13a3.26,3.26,0,0,0,.52,0,2,2,0,0,0,1.24-.31,1,1,0,0,0,.42-.89,1.06,1.06,0,0,0-.14-.54,1.65,1.65,0,0,0-.38-.42,3.75,3.75,0,0,0-.57-.37l-.71-.36-.76-.42a3.17,3.17,0,0,1-.6-.46,2.06,2.06,0,0,1-.41-.57,1.76,1.76,0,0,1-.15-.75,1.73,1.73,0,0,1,.24-.92,1.93,1.93,0,0,1,.6-.64,2.67,2.67,0,0,1,.86-.37,4.49,4.49,0,0,1,2.64.15v1a3.06,3.06,0,0,0-1.75-.47,2.88,2.88,0,0,0-.59.06,1.77,1.77,0,0,0-.53.2,1.19,1.19,0,0,0-.38.36,1,1,0,0,0-.14.54,1.13,1.13,0,0,0,.11.51,1.28,1.28,0,0,0,.32.39,3.24,3.24,0,0,0,.53.34c.2.12.44.24.71.37s.54.28.78.43a3.38,3.38,0,0,1,.65.5,2.05,2.05,0,0,1,.45.61,1.67,1.67,0,0,1,.16.76,1.89,1.89,0,0,1-.22,1,1.76,1.76,0,0,1-.6.64,2.55,2.55,0,0,1-.88.36,4.37,4.37,0,0,1-1,.11l-.45,0-.55-.08-.53-.14A1.87,1.87,0,0,1,850.65,99Z" fill="#2f2f2f"/>
-      <path d="M861.18,96.75h-3.89a2,2,0,0,0,.5,1.42,1.71,1.71,0,0,0,1.3.5,2.7,2.7,0,0,0,1.71-.61v.83a3.23,3.23,0,0,1-1.92.52,2.31,2.31,0,0,1-1.83-.75,3,3,0,0,1-.67-2.11,3,3,0,0,1,.73-2.09,2.33,2.33,0,0,1,1.81-.81,2.09,2.09,0,0,1,1.67.7,2.94,2.94,0,0,1,.59,1.94Zm-.9-.74a1.84,1.84,0,0,0-.37-1.19,1.26,1.26,0,0,0-1-.42,1.42,1.42,0,0,0-1.06.44,2,2,0,0,0-.53,1.17Z" fill="#2f2f2f"/>
-      <path d="M866.34,99a2.89,2.89,0,0,1-1.51.38,2.47,2.47,0,0,1-1.89-.76,2.8,2.8,0,0,1-.73-2,3,3,0,0,1,.78-2.18,2.74,2.74,0,0,1,2.08-.83,2.9,2.9,0,0,1,1.28.27v.9A2.29,2.29,0,0,0,865,94.4a1.77,1.77,0,0,0-1.38.6,2.29,2.29,0,0,0-.54,1.59,2.21,2.21,0,0,0,.5,1.52,1.78,1.78,0,0,0,1.37.56,2.21,2.21,0,0,0,1.35-.48Z" fill="#2f2f2f"/>
-      <path d="M872.07,99.28h-.88v-.87h0a1.8,1.8,0,0,1-1.7,1c-1.31,0-2-.78-2-2.34V93.78h.87v3.15c0,1.16.45,1.74,1.33,1.74a1.36,1.36,0,0,0,1.07-.48,1.84,1.84,0,0,0,.41-1.24V93.78h.88Z" fill="#2f2f2f"/>
-      <path d="M876.66,94.67a1.16,1.16,0,0,0-.67-.17,1.1,1.1,0,0,0-.94.53,2.4,2.4,0,0,0-.38,1.45v2.8h-.88v-5.5h.88v1.14h0a2,2,0,0,1,.58-.91,1.26,1.26,0,0,1,.86-.32,1.51,1.51,0,0,1,.53.07Z" fill="#2f2f2f"/>
-      <path d="M878.14,92.39a.58.58,0,0,1-.4-.16.57.57,0,0,1-.17-.41.55.55,0,0,1,.17-.41.54.54,0,0,1,.4-.17.57.57,0,0,1,.41.17.55.55,0,0,1,.17.41.56.56,0,0,1-.17.4A.57.57,0,0,1,878.14,92.39Zm.43,6.89h-.88v-5.5h.88Z" fill="#2f2f2f"/>
-      <path d="M882.9,99.23a1.73,1.73,0,0,1-.82.17c-1,0-1.44-.54-1.44-1.61V94.53h-.95v-.75h.95V92.44l.88-.28v1.62h1.38v.75h-1.38v3.1a1.24,1.24,0,0,0,.19.79.73.73,0,0,0,.62.24.92.92,0,0,0,.57-.18Z" fill="#2f2f2f"/>
-      <path d="M888.83,93.78l-2.53,6.38c-.45,1.14-1.09,1.71-1.9,1.71a2,2,0,0,1-.58-.07V101a1.53,1.53,0,0,0,.52.1,1.08,1.08,0,0,0,1-.8l.44-1-2.14-5.49h1L886.1,98a3.62,3.62,0,0,1,.11.41h0a3.75,3.75,0,0,1,.1-.4l1.57-4.25Z" fill="#2f2f2f"/>
-      <path d="M859.7,112a4.54,4.54,0,0,1-2.13.45,3.41,3.41,0,0,1-2.63-1.06,3.88,3.88,0,0,1-1-2.77,4.09,4.09,0,0,1,1.11-3,3.77,3.77,0,0,1,2.82-1.14,4.57,4.57,0,0,1,1.82.32v1a3.66,3.66,0,0,0-1.83-.46,2.8,2.8,0,0,0-2.15.88,3.35,3.35,0,0,0-.82,2.37,3.17,3.17,0,0,0,.77,2.25,2.62,2.62,0,0,0,2,.83,3.76,3.76,0,0,0,2-.52Z" fill="#2f2f2f"/>
-      <path d="M865.47,109.75h-3.89a2,2,0,0,0,.5,1.42,1.71,1.71,0,0,0,1.3.5,2.7,2.7,0,0,0,1.71-.61v.83a3.23,3.23,0,0,1-1.92.52,2.31,2.31,0,0,1-1.83-.75,3,3,0,0,1-.67-2.11,3,3,0,0,1,.73-2.09,2.33,2.33,0,0,1,1.81-.81,2.09,2.09,0,0,1,1.67.7,2.94,2.94,0,0,1,.59,1.94Zm-.9-.74a1.84,1.84,0,0,0-.37-1.19,1.26,1.26,0,0,0-1-.42,1.4,1.4,0,0,0-1.06.44,2.06,2.06,0,0,0-.54,1.17Z" fill="#2f2f2f"/>
-      <path d="M871.41,112.28h-.88v-3.13c0-1.17-.43-1.75-1.28-1.75a1.38,1.38,0,0,0-1.09.49,1.84,1.84,0,0,0-.43,1.26v3.13h-.88v-5.5h.88v.92h0a2,2,0,0,1,1.8-1,1.69,1.69,0,0,1,1.38.59,2.59,2.59,0,0,1,.48,1.68Z" fill="#2f2f2f"/>
-      <path d="M875.58,112.23a1.75,1.75,0,0,1-.82.17c-1,0-1.45-.54-1.45-1.61v-3.26h-.94v-.75h.94v-1.34l.88-.28v1.62h1.39v.75h-1.39v3.1a1.24,1.24,0,0,0,.19.79.73.73,0,0,0,.62.24,1,1,0,0,0,.58-.18Z" fill="#2f2f2f"/>
-      <path d="M881.13,109.75h-3.88a2,2,0,0,0,.49,1.42,1.72,1.72,0,0,0,1.3.5,2.7,2.7,0,0,0,1.71-.61v.83a3.19,3.19,0,0,1-1.92.52,2.31,2.31,0,0,1-1.83-.75,3.09,3.09,0,0,1-.67-2.11,3,3,0,0,1,.73-2.09,2.34,2.34,0,0,1,1.81-.81,2.08,2.08,0,0,1,1.67.7,2.94,2.94,0,0,1,.59,1.94Zm-.9-.74a1.84,1.84,0,0,0-.37-1.19,1.26,1.26,0,0,0-1-.42,1.42,1.42,0,0,0-1.06.44,2.05,2.05,0,0,0-.53,1.17Z" fill="#2f2f2f"/>
-      <path d="M885.38,107.67a1.16,1.16,0,0,0-.67-.17,1.1,1.1,0,0,0-.94.53,2.47,2.47,0,0,0-.38,1.45v2.8h-.88v-5.5h.88v1.14h0A2,2,0,0,1,884,107a1.26,1.26,0,0,1,.86-.32,1.51,1.51,0,0,1,.53.07Z" fill="#2f2f2f"/>
-    </g>
-    <g>
-      <path d="M638.21,99.28h-1l-.82-2.16h-3.27l-.76,2.16h-1l3-7.7h.93Zm-2.11-3L634.9,93a3.15,3.15,0,0,1-.12-.52h0a3,3,0,0,1-.13.52l-1.2,3.28Z" fill="#2f2f2f"/>
-      <path d="M640.17,98.49h0v3.32h-.88v-8h.88v1h0a2.1,2.1,0,0,1,1.91-1.1,2,2,0,0,1,1.66.74,3.09,3.09,0,0,1,.59,2,3.39,3.39,0,0,1-.67,2.21,2.25,2.25,0,0,1-1.84.83A1.86,1.86,0,0,1,640.17,98.49Zm0-2.22V97a1.6,1.6,0,0,0,.45,1.15,1.57,1.57,0,0,0,2.37-.13,2.77,2.77,0,0,0,.46-1.7,2.15,2.15,0,0,0-.43-1.44,1.39,1.39,0,0,0-1.15-.53,1.54,1.54,0,0,0-1.23.54A2,2,0,0,0,640.15,96.27Z" fill="#2f2f2f"/>
-      <path d="M646.64,98.49h0v3.32h-.88v-8h.88v1h0a2.09,2.09,0,0,1,1.9-1.1,2,2,0,0,1,1.66.74,3,3,0,0,1,.6,2,3.45,3.45,0,0,1-.67,2.21,2.25,2.25,0,0,1-1.84.83A1.86,1.86,0,0,1,646.64,98.49Zm0-2.22V97a1.63,1.63,0,0,0,.44,1.15,1.58,1.58,0,0,0,2.38-.13,2.84,2.84,0,0,0,.46-1.7,2.21,2.21,0,0,0-.43-1.44,1.39,1.39,0,0,0-1.15-.53,1.54,1.54,0,0,0-1.23.54A1.92,1.92,0,0,0,646.62,96.27Z" fill="#2f2f2f"/>
-      <path d="M653.1,99.28h-.89V91.14h.89Z" fill="#2f2f2f"/>
-      <path d="M655.26,92.39a.56.56,0,0,1-.4-.17.52.52,0,0,1-.16-.4.53.53,0,0,1,.16-.41.56.56,0,0,1,.4-.17.59.59,0,0,1,.42.17.53.53,0,0,1,.16.41.55.55,0,0,1-.16.4A.59.59,0,0,1,655.26,92.39Zm.43,6.89h-.88v-5.5h.88Z" fill="#2f2f2f"/>
-      <path d="M661.18,99a2.88,2.88,0,0,1-1.5.38,2.48,2.48,0,0,1-1.9-.76,2.8,2.8,0,0,1-.72-2,3,3,0,0,1,.78-2.18,2.73,2.73,0,0,1,2.08-.83,2.86,2.86,0,0,1,1.27.27v.9a2.25,2.25,0,0,0-1.31-.43,1.78,1.78,0,0,0-1.38.61,2.29,2.29,0,0,0-.54,1.59,2.17,2.17,0,0,0,.51,1.52,1.76,1.76,0,0,0,1.36.56,2.19,2.19,0,0,0,1.35-.48Z" fill="#2f2f2f"/>
-      <path d="M666.54,99.28h-.88v-.86h0a1.83,1.83,0,0,1-1.69,1,1.79,1.79,0,0,1-1.28-.43,1.52,1.52,0,0,1-.47-1.16c0-1,.61-1.62,1.82-1.79l1.65-.23q0-1.41-1.14-1.41a2.7,2.7,0,0,0-1.79.68v-.9a3.43,3.43,0,0,1,1.87-.52c1.29,0,1.94.69,1.94,2.06Zm-.88-2.78-1.33.18a2.06,2.06,0,0,0-.92.31,1,1,0,0,0,0,1.43,1.17,1.17,0,0,0,.77.25,1.41,1.41,0,0,0,1.08-.46,1.66,1.66,0,0,0,.43-1.16Z" fill="#2f2f2f"/>
-      <path d="M670.73,99.23a1.8,1.8,0,0,1-.83.17c-1,0-1.44-.54-1.44-1.61V94.53h-1v-.75h1V92.44l.88-.29v1.63h1.39v.75h-1.39v3.1a1.24,1.24,0,0,0,.19.79.73.73,0,0,0,.62.24,1,1,0,0,0,.58-.18Z" fill="#2f2f2f"/>
-      <path d="M672.32,92.39a.54.54,0,0,1-.4-.17.53.53,0,0,1-.17-.4.53.53,0,0,1,.17-.41.54.54,0,0,1,.4-.17.57.57,0,0,1,.41.17.53.53,0,0,1,.17.41.56.56,0,0,1-.17.4A.57.57,0,0,1,672.32,92.39Zm.43,6.89h-.88v-5.5h.88Z" fill="#2f2f2f"/>
-      <path d="M676.81,99.41a2.58,2.58,0,0,1-1.95-.77,2.86,2.86,0,0,1-.73-2,3,3,0,0,1,.76-2.17,2.74,2.74,0,0,1,2.05-.78,2.48,2.48,0,0,1,1.92.76,3,3,0,0,1,.69,2.1,2.94,2.94,0,0,1-.75,2.11A2.58,2.58,0,0,1,676.81,99.41Zm.06-5a1.7,1.7,0,0,0-1.34.58,2.38,2.38,0,0,0-.49,1.59,2.22,2.22,0,0,0,.5,1.55,1.71,1.71,0,0,0,1.33.56,1.62,1.62,0,0,0,1.32-.55,2.46,2.46,0,0,0,.46-1.58,2.51,2.51,0,0,0-.46-1.59A1.63,1.63,0,0,0,676.87,94.39Z" fill="#2f2f2f"/>
-      <path d="M685.52,99.28h-.88V96.15c0-1.17-.43-1.76-1.28-1.76a1.39,1.39,0,0,0-1.09.5,1.84,1.84,0,0,0-.43,1.26v3.13H681v-5.5h.88v.92h0a2,2,0,0,1,1.8-1,1.69,1.69,0,0,1,1.38.59,2.57,2.57,0,0,1,.48,1.68Z" fill="#2f2f2f"/>
-      <path d="M641.94,112.28H641v-7.7h.9Z" fill="#2f2f2f"/>
-      <path d="M648.34,112.28h-.88v-3.13c0-1.17-.43-1.76-1.28-1.76a1.39,1.39,0,0,0-1.09.5,1.84,1.84,0,0,0-.43,1.26v3.13h-.89v-5.5h.89v.92h0a2,2,0,0,1,1.8-1,1.69,1.69,0,0,1,1.38.59,2.57,2.57,0,0,1,.48,1.68Z" fill="#2f2f2f"/>
-      <path d="M649.69,112.08v-.94a2.64,2.64,0,0,0,1.58.53c.78,0,1.16-.26,1.16-.77a.76.76,0,0,0-.09-.38,1.15,1.15,0,0,0-.27-.27,2.15,2.15,0,0,0-.4-.21l-.49-.2a4.32,4.32,0,0,1-.64-.29,2.17,2.17,0,0,1-.47-.33,1.62,1.62,0,0,1-.28-.42,1.6,1.6,0,0,1-.09-.56,1.3,1.3,0,0,1,.18-.68,1.5,1.5,0,0,1,.47-.5,1.91,1.91,0,0,1,.68-.3,2.88,2.88,0,0,1,.78-.11,3.2,3.2,0,0,1,1.27.25v.89a2.52,2.52,0,0,0-1.39-.4,1.58,1.58,0,0,0-.45.06,1.19,1.19,0,0,0-.34.16.83.83,0,0,0-.22.24.69.69,0,0,0-.08.32.8.8,0,0,0,.08.36.92.92,0,0,0,.23.26,2,2,0,0,0,.36.2l.49.2a5.2,5.2,0,0,1,.66.29,2,2,0,0,1,.49.33,1.24,1.24,0,0,1,.32.43,1.41,1.41,0,0,1,.11.57,1.36,1.36,0,0,1-.18.71,1.53,1.53,0,0,1-.48.5,2.11,2.11,0,0,1-.7.29,3.43,3.43,0,0,1-2.29-.23Z" fill="#2f2f2f"/>
-      <path d="M655.08,105.39a.56.56,0,0,1-.4-.17.52.52,0,0,1-.16-.4.53.53,0,0,1,.16-.41.56.56,0,0,1,.4-.17.59.59,0,0,1,.42.17.53.53,0,0,1,.17.41.56.56,0,0,1-.17.4A.59.59,0,0,1,655.08,105.39Zm.43,6.89h-.88v-5.5h.88Z" fill="#2f2f2f"/>
-      <path d="M662,111.84c0,2-1,3-2.9,3a3.86,3.86,0,0,1-1.78-.39v-.88a3.6,3.6,0,0,0,1.77.52c1.35,0,2-.72,2-2.16v-.6h0a2.06,2.06,0,0,1-1.89,1,2,2,0,0,1-1.65-.73,2.93,2.93,0,0,1-.63-2,3.47,3.47,0,0,1,.67-2.23,2.27,2.27,0,0,1,1.85-.83,1.8,1.8,0,0,1,1.65.89h0v-.76H662Zm-.88-2V109a1.6,1.6,0,0,0-.44-1.12,1.49,1.49,0,0,0-1.11-.47,1.53,1.53,0,0,0-1.28.6,2.69,2.69,0,0,0-.46,1.66,2.26,2.26,0,0,0,.45,1.47,1.41,1.41,0,0,0,1.17.55,1.55,1.55,0,0,0,1.21-.53A2,2,0,0,0,661.09,109.8Z" fill="#2f2f2f"/>
-      <path d="M668.25,112.28h-.88v-3.17c0-1.14-.43-1.72-1.28-1.72a1.38,1.38,0,0,0-1.08.5,1.83,1.83,0,0,0-.44,1.28v3.11h-.89v-8.14h.89v3.56h0a2,2,0,0,1,1.8-1c1.24,0,1.86.75,1.86,2.24Z" fill="#2f2f2f"/>
-      <path d="M672.42,112.23a1.75,1.75,0,0,1-.82.17c-1,0-1.44-.54-1.44-1.61v-3.26h-.95v-.75h.95v-1.34l.88-.29v1.63h1.38v.75H671v3.1a1.31,1.31,0,0,0,.18.79.77.77,0,0,0,.63.24.92.92,0,0,0,.57-.18Z" fill="#2f2f2f"/>
-      <path d="M673.4,112.08v-.94a2.64,2.64,0,0,0,1.58.53c.78,0,1.16-.26,1.16-.77a.76.76,0,0,0-.09-.38,1.15,1.15,0,0,0-.27-.27,2.15,2.15,0,0,0-.4-.21l-.49-.2a4.32,4.32,0,0,1-.64-.29,2.17,2.17,0,0,1-.47-.33,1.62,1.62,0,0,1-.28-.42,1.6,1.6,0,0,1-.09-.56,1.3,1.3,0,0,1,.18-.68,1.5,1.5,0,0,1,.47-.5,1.91,1.91,0,0,1,.68-.3,2.88,2.88,0,0,1,.78-.11,3.2,3.2,0,0,1,1.27.25v.89a2.52,2.52,0,0,0-1.39-.4,1.53,1.53,0,0,0-.45.06,1.19,1.19,0,0,0-.34.16.83.83,0,0,0-.22.24.69.69,0,0,0-.08.32.8.8,0,0,0,.08.36.92.92,0,0,0,.23.26,2,2,0,0,0,.36.2l.49.2a5.2,5.2,0,0,1,.66.29,2,2,0,0,1,.49.33,1.24,1.24,0,0,1,.32.43,1.41,1.41,0,0,1,.11.57,1.36,1.36,0,0,1-.18.71,1.53,1.53,0,0,1-.48.5,2.11,2.11,0,0,1-.7.29,3.43,3.43,0,0,1-2.29-.23Z" fill="#2f2f2f"/>
-    </g>
-    <g>
-      <path d="M717.5,98.78h-1l-.82-2.16h-3.27l-.76,2.16h-1l3-7.7h.94Zm-2.12-3-1.21-3.28c0-.11-.07-.28-.11-.51h0a2.86,2.86,0,0,1-.13.51l-1.2,3.28Z" fill="#2f2f2f"/>
-      <path d="M722.74,93.54,719.48,98h3.23v.75h-4.52v-.27L721.44,94H718.5v-.75h4.24Z" fill="#2f2f2f"/>
-      <path d="M728.37,98.78h-.88v-.87h0a1.81,1.81,0,0,1-1.7,1c-1.31,0-2-.78-2-2.34V93.28h.88v3.15c0,1.16.44,1.74,1.33,1.74a1.33,1.33,0,0,0,1.06-.48,1.79,1.79,0,0,0,.42-1.24V93.28h.88Z" fill="#2f2f2f"/>
-      <path d="M733,94.17a1.11,1.11,0,0,0-.66-.17,1.13,1.13,0,0,0-.95.53A2.47,2.47,0,0,0,731,96v2.8h-.89v-5.5H731v1.14h0a1.87,1.87,0,0,1,.57-.91,1.3,1.3,0,0,1,.87-.32,1.41,1.41,0,0,1,.52.07Z" fill="#2f2f2f"/>
-      <path d="M738.39,96.25H734.5a2,2,0,0,0,.5,1.42,1.72,1.72,0,0,0,1.3.5,2.7,2.7,0,0,0,1.71-.61v.83a3.21,3.21,0,0,1-1.92.52,2.31,2.31,0,0,1-1.83-.75,3,3,0,0,1-.67-2.11,3,3,0,0,1,.73-2.09,2.34,2.34,0,0,1,1.81-.81,2.09,2.09,0,0,1,1.67.7,2.94,2.94,0,0,1,.59,1.94Zm-.9-.74a1.84,1.84,0,0,0-.37-1.19,1.26,1.26,0,0,0-1-.42,1.42,1.42,0,0,0-1.06.44,2,2,0,0,0-.53,1.17Z" fill="#2f2f2f"/>
-      <path d="M714,111.78h-.9v-5.16c0-.41,0-.91.08-1.5h0a7,7,0,0,1-.23.74l-2.64,5.92h-.44l-2.62-5.87a4.65,4.65,0,0,1-.23-.79h0c0,.31,0,.81,0,1.51v5.15h-.87v-7.7h1.19l2.36,5.37a6.56,6.56,0,0,1,.36.93h0c.15-.43.28-.74.37-.95l2.41-5.35H714Z" fill="#2f2f2f"/>
-      <path d="M718.18,111.91a2.58,2.58,0,0,1-1.95-.77,2.86,2.86,0,0,1-.73-2,3,3,0,0,1,.76-2.17,2.72,2.72,0,0,1,2-.78,2.48,2.48,0,0,1,1.92.76,3,3,0,0,1,.69,2.1,2.94,2.94,0,0,1-.75,2.11A2.58,2.58,0,0,1,718.18,111.91Zm.06-5a1.69,1.69,0,0,0-1.34.57,2.38,2.38,0,0,0-.49,1.59,2.22,2.22,0,0,0,.5,1.55,1.69,1.69,0,0,0,1.33.56,1.62,1.62,0,0,0,1.32-.55A2.46,2.46,0,0,0,720,109a2.51,2.51,0,0,0-.45-1.59A1.62,1.62,0,0,0,718.24,106.9Z" fill="#2f2f2f"/>
-      <path d="M726.89,111.78H726v-3.13c0-1.17-.43-1.75-1.28-1.75a1.38,1.38,0,0,0-1.09.49,1.84,1.84,0,0,0-.43,1.26v3.13h-.88v-5.5h.88v.92h0a2,2,0,0,1,1.8-1,1.69,1.69,0,0,1,1.38.59,2.59,2.59,0,0,1,.48,1.68Z" fill="#2f2f2f"/>
-      <path d="M729,104.89a.6.6,0,0,1-.41-.16.56.56,0,0,1-.16-.41.54.54,0,0,1,.16-.41.57.57,0,0,1,.41-.17.58.58,0,0,1,.41.17.55.55,0,0,1,.17.41.56.56,0,0,1-.17.4A.58.58,0,0,1,729,104.89Zm.43,6.89h-.88v-5.5h.88Z" fill="#2f2f2f"/>
-      <path d="M733.74,111.73a1.75,1.75,0,0,1-.82.17c-1,0-1.45-.54-1.45-1.61V107h-.94v-.75h.94v-1.34l.88-.28v1.62h1.39V107h-1.39v3.1a1.3,1.3,0,0,0,.19.79.77.77,0,0,0,.63.24.92.92,0,0,0,.57-.18Z" fill="#2f2f2f"/>
-      <path d="M737.15,111.91a2.55,2.55,0,0,1-1.95-.77,2.82,2.82,0,0,1-.73-2,3,3,0,0,1,.76-2.17,2.71,2.71,0,0,1,2-.78,2.48,2.48,0,0,1,1.92.76,3,3,0,0,1,.69,2.1,2.94,2.94,0,0,1-.74,2.11A2.6,2.6,0,0,1,737.15,111.91Zm.06-5a1.67,1.67,0,0,0-1.34.57,2.38,2.38,0,0,0-.5,1.59,2.27,2.27,0,0,0,.5,1.55,1.71,1.71,0,0,0,1.34.56,1.59,1.59,0,0,0,1.31-.55A2.4,2.4,0,0,0,739,109a2.45,2.45,0,0,0-.46-1.59A1.59,1.59,0,0,0,737.21,106.9Z" fill="#2f2f2f"/>
-      <path d="M744.16,107.17a1.16,1.16,0,0,0-.67-.17,1.11,1.11,0,0,0-.94.53,2.47,2.47,0,0,0-.38,1.45v2.8h-.88v-5.5h.88v1.14h0a2,2,0,0,1,.58-.91,1.3,1.3,0,0,1,.86-.32,1.47,1.47,0,0,1,.53.07Z" fill="#2f2f2f"/>
-    </g>
-    <g>
-      <path d="M950.86,99.28h-1L949,97.12h-3.26L945,99.28h-1l3-7.7h.93Zm-2.11-3L947.54,93a3.24,3.24,0,0,1-.12-.51h0a4.37,4.37,0,0,1-.12.51l-1.2,3.28Z" fill="#2f2f2f"/>
-      <path d="M956.1,94l-3.25,4.49h3.22v.75h-4.52V99l3.26-4.48h-2.95v-.75h4.24Z" fill="#2f2f2f"/>
-      <path d="M961.73,99.28h-.88v-.87h0a1.81,1.81,0,0,1-1.7,1c-1.31,0-2-.78-2-2.34V93.78H958v3.15c0,1.16.45,1.74,1.34,1.74a1.36,1.36,0,0,0,1.06-.48,1.84,1.84,0,0,0,.41-1.24V93.78h.88Z" fill="#2f2f2f"/>
-      <path d="M966.31,94.67a1.18,1.18,0,0,0-1.6.36,2.4,2.4,0,0,0-.38,1.45v2.8h-.88v-5.5h.88v1.14h0a2,2,0,0,1,.57-.91,1.3,1.3,0,0,1,.87-.32,1.41,1.41,0,0,1,.52.07Z" fill="#2f2f2f"/>
-      <path d="M971.75,96.75h-3.88a2,2,0,0,0,.49,1.42,1.72,1.72,0,0,0,1.3.5,2.7,2.7,0,0,0,1.71-.61v.83a3.19,3.19,0,0,1-1.92.52,2.31,2.31,0,0,1-1.83-.75,3.09,3.09,0,0,1-.67-2.11,3,3,0,0,1,.73-2.09,2.34,2.34,0,0,1,1.81-.81,2.08,2.08,0,0,1,1.67.7,2.94,2.94,0,0,1,.59,1.94Zm-.9-.74a1.84,1.84,0,0,0-.37-1.19,1.26,1.26,0,0,0-1-.42,1.4,1.4,0,0,0-1.05.44,2.06,2.06,0,0,0-.54,1.17Z" fill="#2f2f2f"/>
-      <path d="M939.84,112.28v-7.7H942q4.06,0,4.07,3.75a3.8,3.8,0,0,1-1.13,2.87,4.19,4.19,0,0,1-3,1.08Zm.9-6.88v6.07h1.15a3.27,3.27,0,0,0,2.36-.81,3.07,3.07,0,0,0,.84-2.3c0-2-1.05-3-3.14-3Z" fill="#2f2f2f"/>
-      <path d="M951.89,109.75H948a2,2,0,0,0,.49,1.42,1.72,1.72,0,0,0,1.3.5,2.7,2.7,0,0,0,1.71-.61v.83a3.19,3.19,0,0,1-1.92.52,2.34,2.34,0,0,1-1.83-.75,3.08,3.08,0,0,1-.66-2.11,3,3,0,0,1,.72-2.09,2.34,2.34,0,0,1,1.81-.81,2.08,2.08,0,0,1,1.67.7,2.88,2.88,0,0,1,.59,1.94ZM951,109a1.78,1.78,0,0,0-.37-1.19,1.26,1.26,0,0,0-1-.42,1.4,1.4,0,0,0-1.05.44A2.06,2.06,0,0,0,948,109Z" fill="#2f2f2f"/>
-      <path d="M957.56,106.78l-2.19,5.5h-.87l-2.08-5.5h1l1.4,4a3.43,3.43,0,0,1,.19.77h0a3.75,3.75,0,0,1,.18-.75l1.46-4Z" fill="#2f2f2f"/>
-      <path d="M961.9,112.41a3.39,3.39,0,0,1-2.63-1.08,4,4,0,0,1-1-2.81,4.23,4.23,0,0,1,1-3,3.51,3.51,0,0,1,2.74-1.11,3.3,3.3,0,0,1,2.57,1.08,4,4,0,0,1,1,2.8,4.26,4.26,0,0,1-1,3A3.43,3.43,0,0,1,961.9,112.41Zm.06-7.14a2.48,2.48,0,0,0-2,.87,3.38,3.38,0,0,0-.76,2.3,3.42,3.42,0,0,0,.74,2.29,2.4,2.4,0,0,0,1.93.87,2.52,2.52,0,0,0,2-.83,3.36,3.36,0,0,0,.74-2.31,3.56,3.56,0,0,0-.71-2.36A2.47,2.47,0,0,0,962,105.27Z" fill="#2f2f2f"/>
-      <path d="M967.92,111.49h0v3.32H967v-8h.88v1h0a2.08,2.08,0,0,1,1.9-1.1,2,2,0,0,1,1.66.74,3.09,3.09,0,0,1,.59,2,3.39,3.39,0,0,1-.67,2.21,2.22,2.22,0,0,1-1.84.83A1.83,1.83,0,0,1,967.92,111.49Zm0-2.22V110a1.6,1.6,0,0,0,.45,1.15,1.45,1.45,0,0,0,1.12.48,1.48,1.48,0,0,0,1.26-.61,2.84,2.84,0,0,0,.45-1.7,2.21,2.21,0,0,0-.42-1.44,1.41,1.41,0,0,0-1.15-.52,1.54,1.54,0,0,0-1.24.53A2,2,0,0,0,967.89,109.27Z" fill="#2f2f2f"/>
-      <path d="M973.14,112.08v-.94a2.61,2.61,0,0,0,1.58.53c.77,0,1.16-.26,1.16-.77a.67.67,0,0,0-.1-.38.87.87,0,0,0-.27-.27,1.79,1.79,0,0,0-.39-.21l-.5-.2a5.53,5.53,0,0,1-.64-.29,2.09,2.09,0,0,1-.46-.33,1.29,1.29,0,0,1-.28-.42,1.57,1.57,0,0,1-.09-.56,1.4,1.4,0,0,1,.17-.68,1.53,1.53,0,0,1,.48-.5,2,2,0,0,1,.67-.3,2.88,2.88,0,0,1,.78-.11,3.21,3.21,0,0,1,1.28.25v.89a2.52,2.52,0,0,0-1.4-.39,1.52,1.52,0,0,0-.44,0,1.07,1.07,0,0,0-.34.16.71.71,0,0,0-.22.24.69.69,0,0,0-.08.32.72.72,0,0,0,.31.62,2,2,0,0,0,.36.2l.49.2a6.86,6.86,0,0,1,.66.29,2.21,2.21,0,0,1,.49.33,1.18,1.18,0,0,1,.31.43,1.26,1.26,0,0,1,.11.57,1.36,1.36,0,0,1-.18.71,1.53,1.53,0,0,1-.48.5,2.14,2.14,0,0,1-.69.29,3.18,3.18,0,0,1-.82.1A3.07,3.07,0,0,1,973.14,112.08Z" fill="#2f2f2f"/>
-    </g>
-    <g>
-      <path d="M1067.67,98.76a5.23,5.23,0,0,1-2.58.65,3.53,3.53,0,0,1-2.67-1.06,4.4,4.4,0,0,1,.12-5.75,3.83,3.83,0,0,1,2.86-1.15,4.9,4.9,0,0,1,2.11.41v1a4,4,0,0,0-2.21-.59,2.78,2.78,0,0,0-2.12.89,3.25,3.25,0,0,0-.83,2.31,3.3,3.3,0,0,0,.77,2.3,2.71,2.71,0,0,0,2.08.83,3.25,3.25,0,0,0,1.57-.36V96.08h-1.69v-.81h2.59Z" fill="#2f2f2f"/>
-      <path d="M1069.78,92.39a.58.58,0,0,1-.4-.16.53.53,0,0,1-.17-.41.52.52,0,0,1,.17-.41.54.54,0,0,1,.4-.17.57.57,0,0,1,.41.17.55.55,0,0,1,.17.41.56.56,0,0,1-.17.4A.57.57,0,0,1,1069.78,92.39Zm.43,6.89h-.88v-5.5h.88Z" fill="#2f2f2f"/>
-      <path d="M1074.54,99.23a1.75,1.75,0,0,1-.82.17c-1,0-1.44-.54-1.44-1.61V94.53h-1v-.75h1V92.44l.88-.28v1.62h1.38v.75h-1.38v3.1a1.31,1.31,0,0,0,.18.79.77.77,0,0,0,.63.24.92.92,0,0,0,.57-.18Z" fill="#2f2f2f"/>
-      <path d="M1081.58,99.28h-.91V95.77h-4v3.51h-.9v-7.7h.9V95h4V91.58h.91Z" fill="#2f2f2f"/>
-      <path d="M1087.91,99.28H1087v-.87h0a1.82,1.82,0,0,1-1.7,1c-1.31,0-2-.78-2-2.34V93.78h.88v3.15c0,1.16.44,1.74,1.33,1.74a1.34,1.34,0,0,0,1.06-.48A1.79,1.79,0,0,0,1087,97V93.78h.88Z" fill="#2f2f2f"/>
-      <path d="M1090.52,98.49h0v.79h-.88V91.14h.88v3.61h0a2.1,2.1,0,0,1,1.91-1.1,2,2,0,0,1,1.65.74,3,3,0,0,1,.6,2,3.39,3.39,0,0,1-.67,2.21,2.22,2.22,0,0,1-1.84.83A1.83,1.83,0,0,1,1090.52,98.49Zm0-2.22V97a1.6,1.6,0,0,0,.45,1.15,1.45,1.45,0,0,0,1.12.48,1.49,1.49,0,0,0,1.26-.61,2.84,2.84,0,0,0,.45-1.7,2.15,2.15,0,0,0-.43-1.44,1.38,1.38,0,0,0-1.14-.52,1.54,1.54,0,0,0-1.24.53A2,2,0,0,0,1090.5,96.27Z" fill="#2f2f2f"/>
-      <path d="M1067,112.28h-1l-.81-2.16h-3.27l-.76,2.16h-1l2.95-7.7h.94Zm-2.11-3-1.21-3.28c0-.11-.07-.28-.11-.51h0a2.26,2.26,0,0,1-.12.51l-1.2,3.28Z" fill="#2f2f2f"/>
-      <path d="M1071.7,112a2.88,2.88,0,0,1-1.5.38,2.48,2.48,0,0,1-1.9-.76,2.8,2.8,0,0,1-.72-2,3,3,0,0,1,.78-2.18,2.7,2.7,0,0,1,2.07-.83,2.87,2.87,0,0,1,1.28.27v.9a2.27,2.27,0,0,0-1.31-.42,1.77,1.77,0,0,0-1.38.6,2.29,2.29,0,0,0-.54,1.59,2.17,2.17,0,0,0,.51,1.52,1.74,1.74,0,0,0,1.36.56,2.19,2.19,0,0,0,1.35-.48Z" fill="#2f2f2f"/>
-      <path d="M1075.81,112.23a1.75,1.75,0,0,1-.82.17c-1,0-1.45-.54-1.45-1.61v-3.26h-.94v-.75h.94v-1.34l.88-.28v1.62h1.39v.75h-1.39v3.1a1.3,1.3,0,0,0,.19.79.77.77,0,0,0,.63.24.92.92,0,0,0,.57-.18Z" fill="#2f2f2f"/>
-      <path d="M1077.4,105.39a.59.59,0,0,1-.4-.16.57.57,0,0,1-.17-.41.55.55,0,0,1,.17-.41.56.56,0,0,1,.4-.17.59.59,0,0,1,.42.17.54.54,0,0,1,.16.41.55.55,0,0,1-.16.4A.59.59,0,0,1,1077.4,105.39Zm.43,6.89H1077v-5.5h.88Z" fill="#2f2f2f"/>
-      <path d="M1081.89,112.41a2.55,2.55,0,0,1-1.94-.77,2.82,2.82,0,0,1-.73-2,3,3,0,0,1,.76-2.17,2.7,2.7,0,0,1,2-.78,2.48,2.48,0,0,1,1.92.76,3,3,0,0,1,.69,2.1,2.94,2.94,0,0,1-.74,2.11A2.61,2.61,0,0,1,1081.89,112.41Zm.07-5a1.67,1.67,0,0,0-1.34.57,2.38,2.38,0,0,0-.5,1.59,2.27,2.27,0,0,0,.5,1.55,1.71,1.71,0,0,0,1.34.56,1.59,1.59,0,0,0,1.31-.55,2.4,2.4,0,0,0,.46-1.58,2.45,2.45,0,0,0-.46-1.59A1.59,1.59,0,0,0,1082,107.4Z" fill="#2f2f2f"/>
-      <path d="M1090.61,112.28h-.88v-3.13c0-1.17-.43-1.75-1.28-1.75a1.4,1.4,0,0,0-1.1.49,1.89,1.89,0,0,0-.43,1.26v3.13H1086v-5.5h.88v.92h0a2,2,0,0,1,1.81-1,1.69,1.69,0,0,1,1.38.59,2.59,2.59,0,0,1,.48,1.68Z" fill="#2f2f2f"/>
-      <path d="M1092,112.08v-.94a2.61,2.61,0,0,0,1.58.53c.77,0,1.16-.26,1.16-.77a.67.67,0,0,0-.1-.38.87.87,0,0,0-.27-.27,1.79,1.79,0,0,0-.39-.21l-.5-.2a5.53,5.53,0,0,1-.64-.29,2.09,2.09,0,0,1-.46-.33,1.29,1.29,0,0,1-.28-.42,1.57,1.57,0,0,1-.09-.56,1.4,1.4,0,0,1,.17-.68,1.53,1.53,0,0,1,.48-.5,2,2,0,0,1,.67-.3,2.88,2.88,0,0,1,.78-.11,3.21,3.21,0,0,1,1.28.25v.89a2.51,2.51,0,0,0-1.39-.39,1.55,1.55,0,0,0-.45,0,1.07,1.07,0,0,0-.34.16.71.71,0,0,0-.22.24.69.69,0,0,0-.08.32.72.72,0,0,0,.31.62,2,2,0,0,0,.36.2l.49.2a6.86,6.86,0,0,1,.66.29,2.21,2.21,0,0,1,.49.33,1.18,1.18,0,0,1,.31.43,1.26,1.26,0,0,1,.11.57,1.36,1.36,0,0,1-.18.71,1.53,1.53,0,0,1-.48.5,2.14,2.14,0,0,1-.69.29,3.18,3.18,0,0,1-.82.1A3.07,3.07,0,0,1,1092,112.08Z" fill="#2f2f2f"/>
-    </g>
-    <g>
-      <path d="M1005.72,100.37a3.44,3.44,0,0,1-.58,2.13,1.84,1.84,0,0,1-1.55.76,1.75,1.75,0,0,1-.74-.13v-.89a1.23,1.23,0,0,0,.75.21c.81,0,1.22-.69,1.22-2.07V95.43h.9Z" fill="#2f2f2f"/>
-      <path d="M1012,100.6h-3.89a2.07,2.07,0,0,0,.5,1.42,1.69,1.69,0,0,0,1.3.5,2.67,2.67,0,0,0,1.7-.61v.82a3.11,3.11,0,0,1-1.91.53,2.35,2.35,0,0,1-1.84-.75,3.08,3.08,0,0,1-.66-2.11,3,3,0,0,1,.73-2.09,2.31,2.31,0,0,1,1.8-.81,2.08,2.08,0,0,1,1.67.7,2.89,2.89,0,0,1,.6,1.94Zm-.91-.74a1.73,1.73,0,0,0-.37-1.19,1.25,1.25,0,0,0-1-.43,1.41,1.41,0,0,0-1.06.45,2.06,2.06,0,0,0-.54,1.17Z" fill="#2f2f2f"/>
-      <path d="M1017.9,103.13H1017V100c0-1.17-.43-1.76-1.28-1.76a1.38,1.38,0,0,0-1.09.5,1.84,1.84,0,0,0-.44,1.26v3.13h-.88v-5.5h.88v.91h0a2,2,0,0,1,1.8-1,1.69,1.69,0,0,1,1.38.59,2.57,2.57,0,0,1,.48,1.68Z" fill="#2f2f2f"/>
-      <path d="M1024.11,103.13h-1.23l-2.43-2.64h0v2.64h-.89V95h.89v5.16h0l2.31-2.52h1.15l-2.55,2.66Z" fill="#2f2f2f"/>
-      <path d="M1025.57,96.24a.54.54,0,0,1-.4-.17.53.53,0,0,1-.17-.4.56.56,0,0,1,.57-.58.6.6,0,0,1,.41.16.57.57,0,0,1,.17.42.56.56,0,0,1-.17.4A.57.57,0,0,1,1025.57,96.24Zm.43,6.89h-.88v-5.5h.88Z" fill="#2f2f2f"/>
-      <path d="M1032.29,103.13h-.88V100c0-1.17-.43-1.76-1.28-1.76a1.38,1.38,0,0,0-1.09.5,1.84,1.84,0,0,0-.44,1.26v3.13h-.88v-5.5h.88v.91h0a2,2,0,0,1,1.8-1,1.69,1.69,0,0,1,1.38.59,2.57,2.57,0,0,1,.48,1.68Z" fill="#2f2f2f"/>
-      <path d="M1033.64,102.93V102a2.64,2.64,0,0,0,1.58.53c.78,0,1.16-.26,1.16-.77a.74.74,0,0,0-.09-.38,1.15,1.15,0,0,0-.27-.27,2.15,2.15,0,0,0-.4-.21l-.49-.2a4.32,4.32,0,0,1-.64-.29,2.17,2.17,0,0,1-.47-.33,1.62,1.62,0,0,1-.28-.42,1.6,1.6,0,0,1-.09-.56,1.28,1.28,0,0,1,.18-.68,1.5,1.5,0,0,1,.47-.5,1.94,1.94,0,0,1,.67-.3,3,3,0,0,1,.79-.11,3.2,3.2,0,0,1,1.27.25v.89a2.52,2.52,0,0,0-1.39-.4,1.53,1.53,0,0,0-.45.06,1.19,1.19,0,0,0-.34.16.83.83,0,0,0-.22.24.69.69,0,0,0-.08.32.8.8,0,0,0,.08.36.92.92,0,0,0,.23.26,2,2,0,0,0,.36.2l.49.2a5.91,5.91,0,0,1,.66.29,2,2,0,0,1,.49.33,1.24,1.24,0,0,1,.32.43,1.41,1.41,0,0,1,.11.57,1.36,1.36,0,0,1-.18.71,1.53,1.53,0,0,1-.48.5,2.3,2.3,0,0,1-.7.29,3.12,3.12,0,0,1-.82.1A3.07,3.07,0,0,1,1033.64,102.93Z" fill="#2f2f2f"/>
-    </g>
-    <g>
-      <path d="M8.13,490.05a4.29,4.29,0,0,1-3.34-1.37,5.13,5.13,0,0,1-1.25-3.57,5.42,5.42,0,0,1,1.28-3.78,4.46,4.46,0,0,1,3.48-1.41,4.22,4.22,0,0,1,3.27,1.37,5.1,5.1,0,0,1,1.24,3.58,5.4,5.4,0,0,1-1.27,3.79A4.38,4.38,0,0,1,8.13,490.05ZM8.22,481a3.14,3.14,0,0,0-2.51,1.12,4.26,4.26,0,0,0-1,2.92,4.39,4.39,0,0,0,.94,2.92A3.09,3.09,0,0,0,8.13,489a3.23,3.23,0,0,0,2.55-1,4.3,4.3,0,0,0,.93-3,4.46,4.46,0,0,0-.91-3A3.1,3.1,0,0,0,8.22,481Z" fill="#2f2f2f"/>
-      <path d="M20.39,489.89H19.27v-4c0-1.49-.55-2.23-1.63-2.23a1.76,1.76,0,0,0-1.39.63,2.34,2.34,0,0,0-.55,1.6v4H14.58v-7H15.7v1.16h0a2.54,2.54,0,0,1,2.3-1.32,2.13,2.13,0,0,1,1.76.74,3.33,3.33,0,0,1,.61,2.14Z" fill="#2f2f2f"/>
-      <path d="M26,486.43H22.26v-.88H26Z" fill="#2f2f2f"/>
-      <path d="M29.05,488.88h0v4.23H27.9V482.89H29v1.23h0a2.65,2.65,0,0,1,2.42-1.39,2.53,2.53,0,0,1,2.11.94,3.85,3.85,0,0,1,.76,2.52,4.34,4.34,0,0,1-.85,2.81,2.86,2.86,0,0,1-2.34,1.05A2.34,2.34,0,0,1,29.05,488.88Zm0-2.82v1a2.09,2.09,0,0,0,.56,1.48,2,2,0,0,0,3-.18,3.6,3.6,0,0,0,.58-2.16,2.84,2.84,0,0,0-.54-1.84,1.8,1.8,0,0,0-1.47-.66,2,2,0,0,0-1.57.68A2.47,2.47,0,0,0,29,486.06Z" fill="#2f2f2f"/>
-      <path d="M39.71,484a1.37,1.37,0,0,0-.85-.23,1.43,1.43,0,0,0-1.2.68,3.12,3.12,0,0,0-.48,1.84v3.57H36.06v-7h1.12v1.44h0a2.46,2.46,0,0,1,.73-1.15,1.71,1.71,0,0,1,1.1-.41,1.92,1.92,0,0,1,.67.09Z" fill="#2f2f2f"/>
-      <path d="M46.55,486.67H41.61a2.66,2.66,0,0,0,.63,1.81,2.17,2.17,0,0,0,1.65.63,3.45,3.45,0,0,0,2.18-.78v1.05a4.05,4.05,0,0,1-2.44.67,2.93,2.93,0,0,1-2.33-.95,3.88,3.88,0,0,1-.85-2.68,3.84,3.84,0,0,1,.93-2.67,3,3,0,0,1,2.3-1,2.6,2.6,0,0,1,2.12.89,3.69,3.69,0,0,1,.75,2.46Zm-1.14-.95a2.35,2.35,0,0,0-.47-1.51,1.6,1.6,0,0,0-1.28-.54,1.81,1.81,0,0,0-1.35.57,2.52,2.52,0,0,0-.68,1.48Z" fill="#2f2f2f"/>
-      <path d="M58.18,489.89H57.06v-4a3,3,0,0,0-.36-1.68,1.37,1.37,0,0,0-1.21-.52,1.48,1.48,0,0,0-1.22.66,2.46,2.46,0,0,0-.5,1.57v4H52.65v-4.16c0-1.37-.53-2.06-1.6-2.06a1.48,1.48,0,0,0-1.21.62,2.55,2.55,0,0,0-.48,1.61v4H48.24v-7h1.12V484h0a2.36,2.36,0,0,1,2.17-1.27,2,2,0,0,1,1.25.4,1.92,1.92,0,0,1,.73,1.05,2.5,2.5,0,0,1,2.33-1.45q2.31,0,2.31,2.85Z" fill="#2f2f2f"/>
-      <path d="M60.76,481.11a.73.73,0,0,1-.51-.2.7.7,0,0,1-.21-.52.69.69,0,0,1,.21-.52.69.69,0,0,1,.51-.21.74.74,0,0,1,.53.21.69.69,0,0,1,.21.52.69.69,0,0,1-.21.51A.74.74,0,0,1,60.76,481.11Zm.55,8.78H60.19v-7h1.12Z" fill="#2f2f2f"/>
-      <path d="M63,489.64v-1.21a3.25,3.25,0,0,0,2,.68c1,0,1.48-.33,1.48-1a.9.9,0,0,0-.12-.48,1.26,1.26,0,0,0-.35-.34,2.61,2.61,0,0,0-.5-.27c-.2-.08-.4-.17-.63-.25s-.58-.25-.82-.38a2.17,2.17,0,0,1-.58-.42,1.6,1.6,0,0,1-.36-.54,1.86,1.86,0,0,1-.12-.7,1.66,1.66,0,0,1,.23-.87,2,2,0,0,1,.6-.64,2.68,2.68,0,0,1,.86-.38,3.64,3.64,0,0,1,1-.13,4,4,0,0,1,1.63.31v1.14a3.17,3.17,0,0,0-1.78-.51,2,2,0,0,0-.57.07,1.71,1.71,0,0,0-.43.2,1,1,0,0,0-.28.31.82.82,0,0,0-.1.4.9.9,0,0,0,.1.46,1,1,0,0,0,.29.33,2.22,2.22,0,0,0,.46.26l.63.25a8.19,8.19,0,0,1,.83.37,2.47,2.47,0,0,1,.63.42,1.66,1.66,0,0,1,.4.55,1.92,1.92,0,0,1-.09,1.63,2.07,2.07,0,0,1-.61.64,3,3,0,0,1-.88.37,4.51,4.51,0,0,1-1,.12A3.94,3.94,0,0,1,63,489.64Z" fill="#2f2f2f"/>
-      <path d="M75,486.67H70a2.66,2.66,0,0,0,.63,1.81,2.17,2.17,0,0,0,1.65.63,3.45,3.45,0,0,0,2.18-.78v1.05a4.05,4.05,0,0,1-2.44.67,2.93,2.93,0,0,1-2.33-.95,3.88,3.88,0,0,1-.85-2.68,3.84,3.84,0,0,1,.93-2.67,3,3,0,0,1,2.3-1,2.6,2.6,0,0,1,2.12.89,3.69,3.69,0,0,1,.75,2.46Zm-1.15-.95a2.29,2.29,0,0,0-.46-1.51,1.61,1.61,0,0,0-1.29-.54,1.81,1.81,0,0,0-1.34.57,2.59,2.59,0,0,0-.69,1.48Z" fill="#2f2f2f"/>
-      <path d="M76.23,489.64v-1.21a3.25,3.25,0,0,0,2,.68c1,0,1.48-.33,1.48-1a.82.82,0,0,0-.13-.48,1.22,1.22,0,0,0-.34-.34,2.43,2.43,0,0,0-.51-.27l-.62-.25c-.31-.13-.58-.25-.82-.38a2.4,2.4,0,0,1-.59-.42,1.73,1.73,0,0,1-.35-.54,1.86,1.86,0,0,1-.12-.7,1.66,1.66,0,0,1,.22-.87,2.19,2.19,0,0,1,.61-.64,2.63,2.63,0,0,1,.85-.38,3.76,3.76,0,0,1,1-.13,4.05,4.05,0,0,1,1.63.31v1.14a3.17,3.17,0,0,0-1.78-.51,2,2,0,0,0-.57.07,1.56,1.56,0,0,0-.43.2.91.91,0,0,0-.28.31.82.82,0,0,0-.1.4.91.91,0,0,0,.39.79,2,2,0,0,0,.46.26l.62.25a8.42,8.42,0,0,1,.84.37,2.88,2.88,0,0,1,.63.42,1.81,1.81,0,0,1,.4.55,1.92,1.92,0,0,1-.09,1.63,2.07,2.07,0,0,1-.61.64,3,3,0,0,1-.89.37,4.42,4.42,0,0,1-1,.12A3.91,3.91,0,0,1,76.23,489.64Z" fill="#2f2f2f"/>
-      <path d="M92.24,489.89H91.11v-4c0-1.49-.54-2.23-1.62-2.23a1.76,1.76,0,0,0-1.39.63,2.34,2.34,0,0,0-.55,1.6v4H86.42v-7h1.13v1.16h0a2.54,2.54,0,0,1,2.3-1.32,2.13,2.13,0,0,1,1.76.74,3.33,3.33,0,0,1,.61,2.14Z" fill="#2f2f2f"/>
-      <path d="M99.94,486.67H95a2.56,2.56,0,0,0,.63,1.81,2.17,2.17,0,0,0,1.65.63,3.42,3.42,0,0,0,2.17-.78v1.05a4,4,0,0,1-2.44.67,3,3,0,0,1-2.33-.95,3.93,3.93,0,0,1-.85-2.68,3.84,3.84,0,0,1,.93-2.67,3,3,0,0,1,2.3-1,2.61,2.61,0,0,1,2.13.89,3.69,3.69,0,0,1,.75,2.46Zm-1.15-.95a2.24,2.24,0,0,0-.47-1.51,1.59,1.59,0,0,0-1.28-.54,1.81,1.81,0,0,0-1.35.57,2.58,2.58,0,0,0-.68,1.48Z" fill="#2f2f2f"/>
-      <path d="M104.86,489.82a2.09,2.09,0,0,1-1,.22c-1.23,0-1.84-.68-1.84-2.05v-4.14h-1.21v-1H102v-1.71l1.12-.36v2.07h1.76v1H103.1v3.94a1.65,1.65,0,0,0,.24,1,1,1,0,0,0,.79.3,1.2,1.2,0,0,0,.73-.23Z" fill="#2f2f2f"/>
-      <path d="M115.55,482.89l-2.1,7h-1.16l-1.44-5a3.82,3.82,0,0,1-.11-.65h0a3,3,0,0,1-.14.64l-1.57,5h-1.12l-2.12-7h1.18l1.45,5.26a3,3,0,0,1,.09.63h.06a2.65,2.65,0,0,1,.12-.64l1.62-5.25h1l1.45,5.28a3.2,3.2,0,0,1,.1.63h.06a3.49,3.49,0,0,1,.11-.63l1.43-5.28Z" fill="#2f2f2f"/>
-      <path d="M119.63,490.05a3.22,3.22,0,0,1-2.48-1,3.62,3.62,0,0,1-.93-2.6,3.79,3.79,0,0,1,1-2.75,3.46,3.46,0,0,1,2.6-1,3.16,3.16,0,0,1,2.45,1,3.83,3.83,0,0,1,.87,2.67,3.79,3.79,0,0,1-.94,2.69A3.32,3.32,0,0,1,119.63,490.05Zm.08-6.38a2.16,2.16,0,0,0-1.71.73,3,3,0,0,0-.63,2,2.81,2.81,0,0,0,.64,2,2.15,2.15,0,0,0,1.7.72,2,2,0,0,0,1.67-.7,3.74,3.74,0,0,0,0-4A2,2,0,0,0,119.71,483.67Z" fill="#2f2f2f"/>
-      <path d="M128.48,484a1.39,1.39,0,0,0-.85-.23,1.43,1.43,0,0,0-1.2.68,3.12,3.12,0,0,0-.48,1.84v3.57h-1.12v-7H126v1.44h0a2.46,2.46,0,0,1,.73-1.15,1.69,1.69,0,0,1,1.1-.41,1.92,1.92,0,0,1,.67.09Z" fill="#2f2f2f"/>
-      <path d="M135.53,489.89H134l-3.09-3.36h0v3.36h-1.12V479.53h1.12v6.57h0l2.94-3.21h1.47L132,486.27Z" fill="#2f2f2f"/>
-    </g>
-    <g>
-      <path d="M35.35,254.32a6.63,6.63,0,0,1-3.28.83,4.51,4.51,0,0,1-3.4-1.35,5,5,0,0,1-1.29-3.59,5.09,5.09,0,0,1,1.44-3.73A4.87,4.87,0,0,1,32.46,245a6.14,6.14,0,0,1,2.69.52v1.27a5.16,5.16,0,0,0-2.82-.75,3.55,3.55,0,0,0-2.7,1.13,4.74,4.74,0,0,0-.07,5.86,3.41,3.41,0,0,0,2.65,1.07,4.15,4.15,0,0,0,2-.46v-2.75H32.05v-1h3.3Z" fill="#2f2f2f"/>
-      <path d="M42.43,255H41.31v-1.1h0a2.36,2.36,0,0,1-2.16,1.26,2.33,2.33,0,0,1-1.63-.55,1.91,1.91,0,0,1-.6-1.47c0-1.31.77-2.07,2.31-2.29l2.1-.29c0-1.19-.48-1.79-1.44-1.79a3.43,3.43,0,0,0-2.28.87v-1.15a4.32,4.32,0,0,1,2.38-.66q2.46,0,2.46,2.61Zm-1.12-3.55-1.68.24a2.77,2.77,0,0,0-1.18.38,1.13,1.13,0,0,0-.4,1,1,1,0,0,0,.37.84,1.39,1.39,0,0,0,1,.33,1.8,1.8,0,0,0,1.38-.59,2.09,2.09,0,0,0,.54-1.48Z" fill="#2f2f2f"/>
-      <path d="M47.69,254.92a2.2,2.2,0,0,1-1,.22c-1.23,0-1.84-.69-1.84-2.06v-4.14H43.6V248h1.21v-1.71l1.12-.37V248h1.76v.95H45.93v3.95a1.61,1.61,0,0,0,.24,1,1,1,0,0,0,.79.3,1.2,1.2,0,0,0,.73-.23Z" fill="#2f2f2f"/>
-      <path d="M54.69,251.77H49.74a2.63,2.63,0,0,0,.63,1.8,2.2,2.2,0,0,0,1.66.64,3.42,3.42,0,0,0,2.17-.78v1a4,4,0,0,1-2.44.67,3,3,0,0,1-2.33-1,3.89,3.89,0,0,1-.85-2.69,3.82,3.82,0,0,1,.93-2.66,3,3,0,0,1,2.3-1,2.63,2.63,0,0,1,2.12.89,3.67,3.67,0,0,1,.76,2.47Zm-1.15-1a2.32,2.32,0,0,0-.47-1.52,1.6,1.6,0,0,0-1.28-.54,1.81,1.81,0,0,0-1.35.57,2.52,2.52,0,0,0-.68,1.49Z" fill="#2f2f2f"/>
-      <path d="M65.16,248l-2.1,7H61.9l-1.44-5a2.94,2.94,0,0,1-.11-.64h0a2.93,2.93,0,0,1-.14.63l-1.57,5H57.49l-2.12-7h1.18L58,253.25a3.93,3.93,0,0,1,.09.63h.06a2.56,2.56,0,0,1,.12-.64L59.88,248h1l1.45,5.27a4.17,4.17,0,0,1,.1.63h0a2.86,2.86,0,0,1,.12-.63L64.05,248Z" fill="#2f2f2f"/>
-      <path d="M71.33,255H70.21v-1.1h0A2.36,2.36,0,0,1,68,255.15a2.31,2.31,0,0,1-1.63-.55,1.91,1.91,0,0,1-.6-1.47c0-1.31.77-2.07,2.31-2.29l2.1-.29c0-1.19-.48-1.79-1.44-1.79a3.43,3.43,0,0,0-2.28.87v-1.15a4.32,4.32,0,0,1,2.38-.66q2.46,0,2.46,2.61Zm-1.12-3.55-1.69.24a2.72,2.72,0,0,0-1.17.38,1.1,1.1,0,0,0-.4,1,1,1,0,0,0,.37.84,1.39,1.39,0,0,0,1,.33,1.8,1.8,0,0,0,1.38-.59,2.09,2.09,0,0,0,.54-1.48Z" fill="#2f2f2f"/>
-      <path d="M78.85,248l-3.22,8.12c-.58,1.45-1.38,2.17-2.42,2.17a2.58,2.58,0,0,1-.74-.09v-1a2.21,2.21,0,0,0,.67.12,1.38,1.38,0,0,0,1.27-1L75,255l-2.73-7h1.24l1.89,5.38c0,.07.07.25.15.54h0c0-.11.07-.29.13-.52l2-5.4Z" fill="#2f2f2f"/>
-    </g>
-    <g>
-      <path d="M269.13,27.49h-1.27l-1-2.74h-4.15l-1,2.74h-1.28l3.76-9.8h1.19Zm-2.68-3.78-1.54-4.17a4.18,4.18,0,0,1-.15-.66h0a3.18,3.18,0,0,1-.16.66l-1.52,4.17Z" fill="#2f2f2f"/>
-      <path d="M275.75,20.82l-4.15,5.72h4.1v.95H270v-.34l4.14-5.7h-3.76v-1h5.41Z" fill="#2f2f2f"/>
-      <path d="M282.84,27.49h-1.12v-1.1h0a2.3,2.3,0,0,1-2.16,1.27c-1.66,0-2.5-1-2.5-3V20.49h1.12v4c0,1.48.56,2.22,1.69,2.22a1.72,1.72,0,0,0,1.35-.61,2.32,2.32,0,0,0,.53-1.58v-4h1.12Z" fill="#2f2f2f"/>
-      <path d="M288.6,21.63a1.39,1.39,0,0,0-.85-.23,1.43,1.43,0,0,0-1.2.68,3.15,3.15,0,0,0-.48,1.85v3.56H285v-7h1.12v1.45h0a2.36,2.36,0,0,1,.73-1.15,1.65,1.65,0,0,1,1.1-.42,1.72,1.72,0,0,1,.67.1Z" fill="#2f2f2f"/>
-      <path d="M295.44,24.27H290.5a2.64,2.64,0,0,0,.63,1.81,2.18,2.18,0,0,0,1.65.64,3.45,3.45,0,0,0,2.18-.78v1a4.05,4.05,0,0,1-2.44.67,3,3,0,0,1-2.33-.95,3.91,3.91,0,0,1-.85-2.69,3.86,3.86,0,0,1,.92-2.66,3,3,0,0,1,2.3-1,2.64,2.64,0,0,1,2.13.89,3.7,3.7,0,0,1,.75,2.47Zm-1.15-.95a2.31,2.31,0,0,0-.46-1.51,1.61,1.61,0,0,0-1.29-.54,1.81,1.81,0,0,0-1.34.57,2.59,2.59,0,0,0-.69,1.48Z" fill="#2f2f2f"/>
-      <path d="M300.67,27.1V25.74a2.52,2.52,0,0,0,.55.37,4.15,4.15,0,0,0,.69.28,4.43,4.43,0,0,0,.72.17,3.25,3.25,0,0,0,.67.07,2.57,2.57,0,0,0,1.58-.4,1.32,1.32,0,0,0,.52-1.13,1.41,1.41,0,0,0-.17-.69,2.16,2.16,0,0,0-.48-.53,4.6,4.6,0,0,0-.73-.47l-.91-.47c-.34-.17-.66-.35-.95-.52a4.42,4.42,0,0,1-.78-.59,2.41,2.41,0,0,1-.51-.73,2.18,2.18,0,0,1-.19-1A2.31,2.31,0,0,1,301,19a2.65,2.65,0,0,1,.78-.82,3.36,3.36,0,0,1,1.09-.47,5.85,5.85,0,0,1,3.36.19v1.29a3.86,3.86,0,0,0-2.23-.6,3.33,3.33,0,0,0-.76.08,2.07,2.07,0,0,0-.67.25,1.47,1.47,0,0,0-.47.46,1.16,1.16,0,0,0-.19.68,1.45,1.45,0,0,0,.14.65,1.52,1.52,0,0,0,.42.5,4,4,0,0,0,.66.44c.26.14.57.3.91.46s.68.36,1,.55a4.08,4.08,0,0,1,.82.64,2.8,2.8,0,0,1,.57.77,2.16,2.16,0,0,1,.21,1,2.49,2.49,0,0,1-.29,1.23,2.36,2.36,0,0,1-.76.81,3.43,3.43,0,0,1-1.11.46,6.38,6.38,0,0,1-1.33.14,4.45,4.45,0,0,1-.58,0,5.81,5.81,0,0,1-.69-.11,6.75,6.75,0,0,1-.68-.18A2.15,2.15,0,0,1,300.67,27.1Z" fill="#2f2f2f"/>
-      <path d="M309.37,26.48h0v4.23h-1.12V20.49h1.12v1.24h0a2.66,2.66,0,0,1,2.42-1.4,2.54,2.54,0,0,1,2.11.94,3.88,3.88,0,0,1,.76,2.52,4.32,4.32,0,0,1-.85,2.81,2.83,2.83,0,0,1-2.34,1.06A2.33,2.33,0,0,1,309.37,26.48Zm0-2.82v1a2.05,2.05,0,0,0,.57,1.47,2,2,0,0,0,3-.17,3.63,3.63,0,0,0,.57-2.17,2.81,2.81,0,0,0-.54-1.83,1.79,1.79,0,0,0-1.46-.67,2,2,0,0,0-1.57.68A2.51,2.51,0,0,0,309.34,23.66Z" fill="#2f2f2f"/>
-      <path d="M320,21.63a1.39,1.39,0,0,0-.85-.23,1.43,1.43,0,0,0-1.2.68,3.15,3.15,0,0,0-.48,1.85v3.56h-1.12v-7h1.12v1.45h0a2.36,2.36,0,0,1,.73-1.15,1.65,1.65,0,0,1,1.1-.42,1.72,1.72,0,0,1,.67.1Z" fill="#2f2f2f"/>
-      <path d="M321.85,18.72a.73.73,0,0,1-.52-.21.69.69,0,0,1-.21-.52.7.7,0,0,1,.21-.52.73.73,0,0,1,.52-.21.72.72,0,0,1,.52.21.7.7,0,0,1,.21.52.73.73,0,0,1-.21.52A.72.72,0,0,1,321.85,18.72Zm.54,8.77h-1.12v-7h1.12Z" fill="#2f2f2f"/>
-      <path d="M330.32,27.49H329.2v-4c0-1.48-.54-2.23-1.63-2.23a1.75,1.75,0,0,0-1.39.64,2.36,2.36,0,0,0-.55,1.59v4h-1.12v-7h1.12v1.17h0a2.52,2.52,0,0,1,2.3-1.33,2.14,2.14,0,0,1,1.75.74,3.3,3.3,0,0,1,.61,2.15Z" fill="#2f2f2f"/>
-      <path d="M338.4,26.93q0,3.86-3.69,3.86a4.9,4.9,0,0,1-2.27-.49V29.18a4.7,4.7,0,0,0,2.25.65c1.72,0,2.59-.91,2.59-2.75v-.76h0a2.84,2.84,0,0,1-4.51.41,3.76,3.76,0,0,1-.8-2.51,4.37,4.37,0,0,1,.86-2.84,2.87,2.87,0,0,1,2.35-1.05,2.29,2.29,0,0,1,2.1,1.14h0v-1h1.12Zm-1.12-2.6v-1a2,2,0,0,0-.57-1.43,1.83,1.83,0,0,0-1.4-.6,2,2,0,0,0-1.63.76,3.38,3.38,0,0,0-.59,2.12,2.85,2.85,0,0,0,.57,1.86,1.81,1.81,0,0,0,1.49.71,2,2,0,0,0,1.53-.67A2.49,2.49,0,0,0,337.28,24.33Z" fill="#2f2f2f"/>
-      <path d="M351.32,27.08a5.62,5.62,0,0,1-2.7.58,4.36,4.36,0,0,1-3.35-1.35A5,5,0,0,1,344,22.78a5.2,5.2,0,0,1,1.41-3.8A4.8,4.8,0,0,1,349,17.53a5.73,5.73,0,0,1,2.31.4v1.22a4.67,4.67,0,0,0-2.32-.58,3.57,3.57,0,0,0-2.74,1.12,4.27,4.27,0,0,0-1.05,3,4,4,0,0,0,1,2.85,3.36,3.36,0,0,0,2.58,1.07,4.79,4.79,0,0,0,2.55-.66Z" fill="#2f2f2f"/>
-      <path d="M354,27.49h-1.12V17.13H354Z" fill="#2f2f2f"/>
-      <path d="M359.11,27.66a3.24,3.24,0,0,1-2.47-1,3.63,3.63,0,0,1-.93-2.6,3.8,3.8,0,0,1,1-2.76,3.48,3.48,0,0,1,2.61-1,3.13,3.13,0,0,1,2.44,1A3.83,3.83,0,0,1,362.6,24a3.72,3.72,0,0,1-1,2.68A3.31,3.31,0,0,1,359.11,27.66Zm.09-6.39a2.14,2.14,0,0,0-1.71.74,3,3,0,0,0-.63,2,2.87,2.87,0,0,0,.63,2,2.18,2.18,0,0,0,1.71.72,2.06,2.06,0,0,0,1.67-.71,3.06,3.06,0,0,0,.58-2,3.13,3.13,0,0,0-.58-2A2.06,2.06,0,0,0,359.2,21.27Z" fill="#2f2f2f"/>
-      <path d="M370,27.49h-1.12v-1.1h0a2.3,2.3,0,0,1-2.16,1.27c-1.67,0-2.5-1-2.5-3V20.49h1.11v4c0,1.48.57,2.22,1.7,2.22a1.72,1.72,0,0,0,1.35-.61,2.32,2.32,0,0,0,.53-1.58v-4H370Z" fill="#2f2f2f"/>
-      <path d="M378.18,27.49h-1.12V26.31h0a2.83,2.83,0,0,1-4.52.41,3.89,3.89,0,0,1-.78-2.56,4.19,4.19,0,0,1,.87-2.78,2.88,2.88,0,0,1,2.33-1.05,2.25,2.25,0,0,1,2.1,1.14h0V17.13h1.12Zm-1.12-3.16v-1a2,2,0,0,0-.56-1.44,1.9,1.9,0,0,0-1.42-.59,1.92,1.92,0,0,0-1.62.76,3.29,3.29,0,0,0-.59,2.07,2.92,2.92,0,0,0,.57,1.91,1.83,1.83,0,0,0,1.51.71,1.91,1.91,0,0,0,1.52-.68A2.52,2.52,0,0,0,377.06,24.33Z" fill="#2f2f2f"/>
-      <path d="M290.19,46.49H289V39.92c0-.52,0-1.16.1-1.91h0a5.91,5.91,0,0,1-.29,1l-3.35,7.53h-.56L281.57,39a5.52,5.52,0,0,1-.3-1h0q.06.59.06,1.92v6.56h-1.11v-9.8h1.52l3,6.84a9.06,9.06,0,0,1,.45,1.17h0c.2-.53.35-.94.47-1.2l3.07-6.81h1.44Z" fill="#2f2f2f"/>
-      <path d="M297.5,46.49h-1.12V45.4h0a2.56,2.56,0,0,1-3.79.71,1.94,1.94,0,0,1-.59-1.47c0-1.31.77-2.07,2.31-2.29l2.1-.29c0-1.19-.48-1.79-1.44-1.79a3.43,3.43,0,0,0-2.29.87V40a4.32,4.32,0,0,1,2.38-.66c1.65,0,2.47.87,2.47,2.61ZM296.38,43l-1.69.24a2.82,2.82,0,0,0-1.18.38,1.13,1.13,0,0,0-.39,1,1.07,1.07,0,0,0,.36.84,1.42,1.42,0,0,0,1,.33,1.79,1.79,0,0,0,1.37-.59,2.06,2.06,0,0,0,.55-1.48Z" fill="#2f2f2f"/>
-      <path d="M305.33,46.49h-1.12v-4c0-1.48-.54-2.23-1.63-2.23a1.75,1.75,0,0,0-1.39.64,2.36,2.36,0,0,0-.55,1.59v4h-1.12v-7h1.12v1.17h0a2.52,2.52,0,0,1,2.3-1.33,2.14,2.14,0,0,1,1.75.74,3.3,3.3,0,0,1,.61,2.15Z" fill="#2f2f2f"/>
-      <path d="M312.36,46.49h-1.12V45.4h0a2.56,2.56,0,0,1-3.79.71,1.94,1.94,0,0,1-.59-1.47c0-1.31.77-2.07,2.31-2.29l2.1-.29c0-1.19-.48-1.79-1.44-1.79a3.43,3.43,0,0,0-2.28.87V40a4.32,4.32,0,0,1,2.38-.66q2.46,0,2.46,2.61ZM311.24,43l-1.69.24a2.72,2.72,0,0,0-1.17.38,1.1,1.1,0,0,0-.4,1,1.05,1.05,0,0,0,.37.84,1.39,1.39,0,0,0,1,.33,1.8,1.8,0,0,0,1.38-.59,2.09,2.09,0,0,0,.54-1.48Z" fill="#2f2f2f"/>
-      <path d="M320.43,45.93q0,3.85-3.69,3.86a5,5,0,0,1-2.27-.49V48.18a4.74,4.74,0,0,0,2.26.65c1.72,0,2.58-.91,2.58-2.75v-.76h0a2.83,2.83,0,0,1-4.5.41,3.76,3.76,0,0,1-.8-2.51,4.37,4.37,0,0,1,.86-2.84,2.86,2.86,0,0,1,2.35-1.05,2.26,2.26,0,0,1,2.09,1.14h0v-1h1.12Zm-1.12-2.6v-1a2,2,0,0,0-.56-1.43,1.87,1.87,0,0,0-1.41-.6,2,2,0,0,0-1.62.76,3.32,3.32,0,0,0-.59,2.12,2.9,2.9,0,0,0,.56,1.86,1.84,1.84,0,0,0,1.5.71,2,2,0,0,0,1.53-.67A2.53,2.53,0,0,0,319.31,43.33Z" fill="#2f2f2f"/>
-      <path d="M328.25,43.27h-4.94a2.64,2.64,0,0,0,.63,1.81,2.18,2.18,0,0,0,1.65.64,3.45,3.45,0,0,0,2.18-.78V46a4.05,4.05,0,0,1-2.44.67,3,3,0,0,1-2.33-.95,3.91,3.91,0,0,1-.85-2.69,3.82,3.82,0,0,1,.93-2.66,2.94,2.94,0,0,1,2.3-1,2.63,2.63,0,0,1,2.12.89,3.7,3.7,0,0,1,.75,2.47Zm-1.14-1a2.37,2.37,0,0,0-.47-1.51,1.6,1.6,0,0,0-1.28-.54,1.81,1.81,0,0,0-1.35.57,2.52,2.52,0,0,0-.68,1.48Z" fill="#2f2f2f"/>
-      <path d="M339.88,46.49h-1.13v-4a3.06,3.06,0,0,0-.35-1.69,1.39,1.39,0,0,0-1.21-.52,1.48,1.48,0,0,0-1.22.66,2.48,2.48,0,0,0-.5,1.57v4h-1.12V42.34c0-1.38-.54-2.07-1.6-2.07a1.48,1.48,0,0,0-1.21.62,2.57,2.57,0,0,0-.48,1.61v4h-1.12v-7h1.12V40.6h0a2.39,2.39,0,0,1,2.18-1.27,2,2,0,0,1,2,1.45,2.5,2.5,0,0,1,2.33-1.45q2.31,0,2.31,2.85Z" fill="#2f2f2f"/>
-      <path d="M347.58,43.27h-4.94a2.64,2.64,0,0,0,.63,1.81,2.18,2.18,0,0,0,1.65.64,3.45,3.45,0,0,0,2.18-.78V46a4.05,4.05,0,0,1-2.44.67,3,3,0,0,1-2.33-.95,3.91,3.91,0,0,1-.85-2.69,3.86,3.86,0,0,1,.92-2.66,3,3,0,0,1,2.31-1,2.63,2.63,0,0,1,2.12.89,3.7,3.7,0,0,1,.75,2.47Zm-1.15-1a2.31,2.31,0,0,0-.46-1.51,1.61,1.61,0,0,0-1.29-.54,1.81,1.81,0,0,0-1.34.57,2.59,2.59,0,0,0-.69,1.48Z" fill="#2f2f2f"/>
-      <path d="M355.08,46.49H354v-4c0-1.48-.55-2.23-1.63-2.23a1.73,1.73,0,0,0-1.39.64,2.31,2.31,0,0,0-.55,1.59v4h-1.12v-7h1.12v1.17h0a2.53,2.53,0,0,1,2.3-1.33,2.16,2.16,0,0,1,1.76.74,3.36,3.36,0,0,1,.61,2.15Z" fill="#2f2f2f"/>
-      <path d="M360.31,46.43a2.27,2.27,0,0,1-1.05.22c-1.23,0-1.84-.69-1.84-2.06V40.45h-1.2v-1h1.2v-1.7l1.12-.37v2.07h1.77v1h-1.77V44.4a1.61,1.61,0,0,0,.24,1,1,1,0,0,0,.79.3,1.23,1.23,0,0,0,.74-.23Z" fill="#2f2f2f"/>
-      <path d="M297.49,65.49h-1.27l-1-2.74H291l-1,2.74h-1.28l3.76-9.8h1.19Zm-2.69-3.78-1.54-4.17a4.18,4.18,0,0,1-.15-.66h0a3.27,3.27,0,0,1-.15.66l-1.53,4.17Z" fill="#2f2f2f"/>
-      <path d="M304.59,65.49h-1.12V64.31h0a2.83,2.83,0,0,1-4.52.41,3.9,3.9,0,0,1-.79-2.56,4.14,4.14,0,0,1,.88-2.78,2.88,2.88,0,0,1,2.33-1.05,2.25,2.25,0,0,1,2.1,1.14h0V55.13h1.12Zm-1.12-3.16v-1a2,2,0,0,0-.56-1.44,1.87,1.87,0,0,0-1.42-.59,1.92,1.92,0,0,0-1.61.76,3.29,3.29,0,0,0-.59,2.07,3,3,0,0,0,.56,1.91,1.85,1.85,0,0,0,1.52.71,1.93,1.93,0,0,0,1.52-.68A2.51,2.51,0,0,0,303.47,62.33Z" fill="#2f2f2f"/>
-      <path d="M312.76,65.49h-1.12V64.31h0a2.83,2.83,0,0,1-4.52.41,3.9,3.9,0,0,1-.79-2.56,4.14,4.14,0,0,1,.88-2.78,2.88,2.88,0,0,1,2.33-1.05,2.25,2.25,0,0,1,2.1,1.14h0V55.13h1.12Zm-1.12-3.16v-1a2,2,0,0,0-.56-1.44,1.87,1.87,0,0,0-1.42-.59,1.92,1.92,0,0,0-1.61.76,3.29,3.29,0,0,0-.59,2.07A3,3,0,0,0,308,64a1.85,1.85,0,0,0,1.52.71,1.93,1.93,0,0,0,1.52-.68A2.51,2.51,0,0,0,311.64,62.33Z" fill="#2f2f2f"/>
-      <path d="M318.52,59.63a1.37,1.37,0,0,0-.85-.23,1.45,1.45,0,0,0-1.2.68,3.15,3.15,0,0,0-.48,1.85v3.56h-1.12v-7H316v1.45h0a2.36,2.36,0,0,1,.73-1.15,1.67,1.67,0,0,1,1.1-.42,1.68,1.68,0,0,1,.67.1Z" fill="#2f2f2f"/>
-      <path d="M325.36,62.27h-4.94a2.64,2.64,0,0,0,.63,1.81,2.18,2.18,0,0,0,1.66.64,3.44,3.44,0,0,0,2.17-.78v1a4.05,4.05,0,0,1-2.44.67,3,3,0,0,1-2.33-1,3.91,3.91,0,0,1-.85-2.69,3.82,3.82,0,0,1,.93-2.66,2.94,2.94,0,0,1,2.3-1,2.63,2.63,0,0,1,2.12.89,3.7,3.7,0,0,1,.75,2.47Zm-1.14-1a2.37,2.37,0,0,0-.47-1.51,1.6,1.6,0,0,0-1.28-.54,1.81,1.81,0,0,0-1.35.57,2.52,2.52,0,0,0-.68,1.48Z" fill="#2f2f2f"/>
-      <path d="M326.61,65.24V64a3.32,3.32,0,0,0,2,.68c1,0,1.48-.33,1.48-1a.79.79,0,0,0-.13-.47,1.25,1.25,0,0,0-.34-.35,2.61,2.61,0,0,0-.5-.27l-.63-.25c-.31-.12-.58-.25-.82-.37a2.72,2.72,0,0,1-.59-.43,1.58,1.58,0,0,1-.35-.53,1.92,1.92,0,0,1-.12-.71,1.71,1.71,0,0,1,.23-.87,2,2,0,0,1,.6-.63,2.82,2.82,0,0,1,.86-.39,3.64,3.64,0,0,1,1-.13,4,4,0,0,1,1.63.32v1.13a3.17,3.17,0,0,0-1.78-.51,2,2,0,0,0-.57.08,1.14,1.14,0,0,0-.43.2.83.83,0,0,0-.28.31.77.77,0,0,0-.1.4,1,1,0,0,0,.1.46.88.88,0,0,0,.29.32,1.84,1.84,0,0,0,.46.26l.63.26c.3.12.58.24.83.36a2.78,2.78,0,0,1,.63.43,1.77,1.77,0,0,1,.4.54,1.83,1.83,0,0,1,.14.73,1.72,1.72,0,0,1-.23.9,2,2,0,0,1-.61.64,3,3,0,0,1-.88.38,4.57,4.57,0,0,1-1,.12A3.91,3.91,0,0,1,326.61,65.24Z" fill="#2f2f2f"/>
-      <path d="M332.53,65.24V64a3.34,3.34,0,0,0,2,.68c1,0,1.48-.33,1.48-1a.87.87,0,0,0-.13-.47,1.25,1.25,0,0,0-.34-.35,2.7,2.7,0,0,0-.51-.27l-.62-.25a8.17,8.17,0,0,1-.82-.37,2.72,2.72,0,0,1-.59-.43,1.58,1.58,0,0,1-.35-.53,1.92,1.92,0,0,1-.12-.71,1.71,1.71,0,0,1,.22-.87,2,2,0,0,1,.6-.63,3.06,3.06,0,0,1,.86-.39,3.66,3.66,0,0,1,1-.13,4,4,0,0,1,1.62.32v1.13a3.12,3.12,0,0,0-1.77-.51,2,2,0,0,0-.57.08,1.27,1.27,0,0,0-.44.2.92.92,0,0,0-.28.31.87.87,0,0,0-.09.4,1.08,1.08,0,0,0,.09.46,1.1,1.1,0,0,0,.29.32,1.91,1.91,0,0,0,.47.26l.62.26q.46.18.84.36a3,3,0,0,1,.62.43,1.65,1.65,0,0,1,.41.54,1.83,1.83,0,0,1,.13.73,1.72,1.72,0,0,1-.22.9,2,2,0,0,1-.62.64,2.82,2.82,0,0,1-.88.38,4.42,4.42,0,0,1-1,.12A4,4,0,0,1,332.53,65.24Z" fill="#2f2f2f"/>
-      <path d="M344.49,62.27h-4.94a2.59,2.59,0,0,0,.62,1.81,2.21,2.21,0,0,0,1.66.64,3.42,3.42,0,0,0,2.17-.78v1a4,4,0,0,1-2.44.67,3,3,0,0,1-2.33-1,4,4,0,0,1-.85-2.69,3.82,3.82,0,0,1,.93-2.66,3,3,0,0,1,2.3-1,2.64,2.64,0,0,1,2.13.89,3.7,3.7,0,0,1,.75,2.47Zm-1.15-1a2.31,2.31,0,0,0-.47-1.51,1.59,1.59,0,0,0-1.28-.54,1.81,1.81,0,0,0-1.35.57,2.58,2.58,0,0,0-.68,1.48Z" fill="#2f2f2f"/>
-      <path d="M345.73,65.24V64a3.32,3.32,0,0,0,2,.68q1.47,0,1.47-1a.86.86,0,0,0-.12-.47,1.41,1.41,0,0,0-.34-.35,3.05,3.05,0,0,0-.51-.27l-.63-.25a7.93,7.93,0,0,1-.81-.37,2.5,2.5,0,0,1-.59-.43,1.47,1.47,0,0,1-.36-.53,1.92,1.92,0,0,1-.12-.71,1.71,1.71,0,0,1,.23-.87,2,2,0,0,1,.6-.63,2.94,2.94,0,0,1,.86-.39,3.64,3.64,0,0,1,1-.13,4,4,0,0,1,1.63.32v1.13a3.15,3.15,0,0,0-1.78-.51,1.94,1.94,0,0,0-.56.08,1.19,1.19,0,0,0-.44.2.92.92,0,0,0-.28.31.88.88,0,0,0-.1.4,1.08,1.08,0,0,0,.1.46,1,1,0,0,0,.29.32,1.74,1.74,0,0,0,.47.26l.62.26c.31.12.59.24.83.36a2.78,2.78,0,0,1,.63.43,1.62,1.62,0,0,1,.4.54,1.67,1.67,0,0,1,.14.73,1.63,1.63,0,0,1-.23.9,1.87,1.87,0,0,1-.61.64,2.93,2.93,0,0,1-.88.38,4.44,4.44,0,0,1-1,.12A3.94,3.94,0,0,1,345.73,65.24Z" fill="#2f2f2f"/>
-    </g>
-    <g>
-      <path d="M614.61,401.77h-1.27l-1-2.74h-4.16l-1,2.74h-1.28l3.76-9.8h1.19ZM611.92,398l-1.54-4.17a4.18,4.18,0,0,1-.15-.66h0a4,4,0,0,1-.16.66L608.52,398Z" fill="#2f2f2f"/>
-      <path d="M621.22,395.1l-4.14,5.72h4.1v.95h-5.75v-.34l4.14-5.7h-3.75v-1h5.4Z" fill="#2f2f2f"/>
-      <path d="M628.32,401.77h-1.13v-1.1h0a2.32,2.32,0,0,1-2.16,1.27c-1.67,0-2.51-1-2.51-3v-4.19h1.12v4c0,1.48.56,2.21,1.69,2.21a1.75,1.75,0,0,0,1.36-.6,2.32,2.32,0,0,0,.52-1.58v-4h1.13Z" fill="#2f2f2f"/>
-      <path d="M634.07,395.91a1.35,1.35,0,0,0-.84-.23,1.43,1.43,0,0,0-1.2.68,3.08,3.08,0,0,0-.49,1.85v3.56h-1.12v-7h1.12v1.45h0a2.44,2.44,0,0,1,.73-1.16,1.71,1.71,0,0,1,1.1-.41,1.65,1.65,0,0,1,.67.1Z" fill="#2f2f2f"/>
-      <path d="M640.92,398.55H636a2.64,2.64,0,0,0,.63,1.81,2.18,2.18,0,0,0,1.66.63,3.49,3.49,0,0,0,2.17-.77v1a4.1,4.1,0,0,1-2.44.67,2.94,2.94,0,0,1-2.33-1,3.87,3.87,0,0,1-.85-2.68,3.8,3.8,0,0,1,.93-2.66,3,3,0,0,1,2.3-1,2.63,2.63,0,0,1,2.12.89,3.65,3.65,0,0,1,.76,2.47Zm-1.15-.95a2.31,2.31,0,0,0-.47-1.51,1.6,1.6,0,0,0-1.28-.54,1.81,1.81,0,0,0-1.35.57,2.52,2.52,0,0,0-.68,1.48Z" fill="#2f2f2f"/>
-      <path d="M587.22,418.57h-5.09v-9.8h1.15v8.76h3.94Z" fill="#2f2f2f"/>
-      <path d="M591.4,418.74a3.28,3.28,0,0,1-2.48-1,3.67,3.67,0,0,1-.92-2.6,3.8,3.8,0,0,1,1-2.76,3.47,3.47,0,0,1,2.61-1,3.15,3.15,0,0,1,2.44,1,3.83,3.83,0,0,1,.88,2.68,3.77,3.77,0,0,1-.95,2.68A3.33,3.33,0,0,1,591.4,418.74Zm.08-6.39a2.1,2.1,0,0,0-1.7.74,3,3,0,0,0-.63,2,2.89,2.89,0,0,0,.63,2,2.16,2.16,0,0,0,1.7.71,2.06,2.06,0,0,0,1.68-.7,3.11,3.11,0,0,0,.58-2,3.19,3.19,0,0,0-.58-2A2.06,2.06,0,0,0,591.48,412.35Z" fill="#2f2f2f"/>
-      <path d="M601.64,418.57h-1.12v-1.09h0a2.36,2.36,0,0,1-2.16,1.26,2.29,2.29,0,0,1-1.63-.56,1.89,1.89,0,0,1-.59-1.47q0-1.95,2.31-2.28l2.1-.29c0-1.19-.48-1.79-1.45-1.79a3.47,3.47,0,0,0-2.28.86v-1.14a4.32,4.32,0,0,1,2.38-.66c1.64,0,2.47.87,2.47,2.61ZM600.52,415l-1.69.24a2.82,2.82,0,0,0-1.18.38,1.13,1.13,0,0,0-.4,1,1.1,1.1,0,0,0,.37.84,1.39,1.39,0,0,0,1,.32,1.79,1.79,0,0,0,1.38-.58,2.1,2.1,0,0,0,.55-1.48Z" fill="#2f2f2f"/>
-      <path d="M609.71,418.57h-1.13v-1.19h0a2.58,2.58,0,0,1-2.41,1.36,2.64,2.64,0,0,1-2.11-.94,3.9,3.9,0,0,1-.79-2.56,4.14,4.14,0,0,1,.88-2.78,2.88,2.88,0,0,1,2.33-1,2.26,2.26,0,0,1,2.1,1.13h0v-4.33h1.13Zm-1.13-3.16v-1a2,2,0,0,0-.56-1.44,1.87,1.87,0,0,0-1.42-.59,1.92,1.92,0,0,0-1.61.76,3.29,3.29,0,0,0-.59,2.07,3,3,0,0,0,.56,1.91,1.86,1.86,0,0,0,1.52.7,1.92,1.92,0,0,0,1.52-.67A2.51,2.51,0,0,0,608.58,415.41Z" fill="#2f2f2f"/>
-      <path d="M616,418.57v-9.8h2.79a3.09,3.09,0,0,1,2,.62,2,2,0,0,1,.74,1.62,2.38,2.38,0,0,1-.45,1.45,2.51,2.51,0,0,1-1.24.88v0a2.49,2.49,0,0,1,1.58.75,2.29,2.29,0,0,1,.6,1.65,2.53,2.53,0,0,1-.91,2,3.35,3.35,0,0,1-2.27.78Zm1.15-8.76V413h1.18a2.26,2.26,0,0,0,1.48-.46,1.58,1.58,0,0,0,.54-1.28c0-.95-.63-1.43-1.88-1.43Zm0,4.2v3.52h1.56a2.34,2.34,0,0,0,1.57-.47,1.65,1.65,0,0,0,.55-1.32c0-1.15-.79-1.73-2.36-1.73Z" fill="#2f2f2f"/>
-      <path d="M628.8,418.57h-1.12v-1.09h0a2.36,2.36,0,0,1-2.16,1.26,2.29,2.29,0,0,1-1.63-.56,1.89,1.89,0,0,1-.6-1.47q0-1.95,2.31-2.28l2.1-.29c0-1.19-.48-1.79-1.44-1.79a3.47,3.47,0,0,0-2.28.86v-1.14a4.32,4.32,0,0,1,2.38-.66q2.46,0,2.46,2.61ZM627.68,415l-1.68.24a2.77,2.77,0,0,0-1.18.38,1.1,1.1,0,0,0-.4,1,1.07,1.07,0,0,0,.37.84,1.39,1.39,0,0,0,1,.32,1.79,1.79,0,0,0,1.38-.58,2.09,2.09,0,0,0,.54-1.48Z" fill="#2f2f2f"/>
-      <path d="M632,418.57h-1.13V408.21H632Z" fill="#2f2f2f"/>
-      <path d="M639.1,418.57H638v-1.09h0a2.34,2.34,0,0,1-2.15,1.26,2.3,2.3,0,0,1-1.64-.56,1.92,1.92,0,0,1-.59-1.47q0-1.95,2.31-2.28l2.1-.29c0-1.19-.48-1.79-1.44-1.79a3.47,3.47,0,0,0-2.29.86v-1.14a4.32,4.32,0,0,1,2.38-.66c1.65,0,2.47.87,2.47,2.61ZM638,415l-1.69.24a2.82,2.82,0,0,0-1.18.38,1.13,1.13,0,0,0-.39,1,1.09,1.09,0,0,0,.36.84,1.41,1.41,0,0,0,1,.32,1.78,1.78,0,0,0,1.37-.58,2.06,2.06,0,0,0,.55-1.48Z" fill="#2f2f2f"/>
-      <path d="M646.93,418.57h-1.12v-4c0-1.48-.54-2.23-1.63-2.23a1.75,1.75,0,0,0-1.39.64,2.36,2.36,0,0,0-.55,1.59v4h-1.12v-7h1.12v1.17h0a2.52,2.52,0,0,1,2.3-1.33,2.14,2.14,0,0,1,1.75.74,3.29,3.29,0,0,1,.61,2.14Z" fill="#2f2f2f"/>
-      <path d="M653.78,418.25a3.6,3.6,0,0,1-1.91.49,3.17,3.17,0,0,1-2.42-1,3.54,3.54,0,0,1-.92-2.52,3.88,3.88,0,0,1,1-2.78,3.46,3.46,0,0,1,2.65-1,3.64,3.64,0,0,1,1.62.34v1.15a2.87,2.87,0,0,0-1.66-.55,2.25,2.25,0,0,0-1.76.77,2.91,2.91,0,0,0-.69,2,2.73,2.73,0,0,0,.65,1.94,2.18,2.18,0,0,0,1.73.71,2.83,2.83,0,0,0,1.72-.6Z" fill="#2f2f2f"/>
-      <path d="M661,415.35H656a2.66,2.66,0,0,0,.63,1.81,2.17,2.17,0,0,0,1.65.63,3.47,3.47,0,0,0,2.17-.77v1.05a4.08,4.08,0,0,1-2.44.67,3,3,0,0,1-2.33-1,3.91,3.91,0,0,1-.84-2.68,3.79,3.79,0,0,1,.92-2.66,3,3,0,0,1,2.3-1,2.64,2.64,0,0,1,2.13.89,3.7,3.7,0,0,1,.75,2.47Zm-1.15-1a2.26,2.26,0,0,0-.47-1.51,1.58,1.58,0,0,0-1.28-.54,1.78,1.78,0,0,0-1.34.57,2.59,2.59,0,0,0-.69,1.48Z" fill="#2f2f2f"/>
-      <path d="M666.28,412.71a1.35,1.35,0,0,0-.84-.23,1.43,1.43,0,0,0-1.2.68,3.08,3.08,0,0,0-.49,1.85v3.56h-1.12v-7h1.12V413h0a2.44,2.44,0,0,1,.73-1.16,1.71,1.71,0,0,1,1.1-.41,1.65,1.65,0,0,1,.67.1Z" fill="#2f2f2f"/>
-    </g>
-  </g>
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 26.2.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" [
+	<!ENTITY ns_extend "http://ns.adobe.com/Extensibility/1.0/">
+	<!ENTITY ns_ai "http://ns.adobe.com/AdobeIllustrator/10.0/">
+	<!ENTITY ns_graphs "http://ns.adobe.com/Graphs/1.0/">
+	<!ENTITY ns_vars "http://ns.adobe.com/Variables/1.0/">
+	<!ENTITY ns_imrep "http://ns.adobe.com/ImageReplacement/1.0/">
+	<!ENTITY ns_sfw "http://ns.adobe.com/SaveForWeb/1.0/">
+	<!ENTITY ns_custom "http://ns.adobe.com/GenericCustomNamespace/1.0/">
+	<!ENTITY ns_adobe_xpath "http://ns.adobe.com/XPath/1.0/">
+]>
+<svg version="1.1" id="Layer_1" xmlns:x="&ns_extend;" xmlns:i="&ns_ai;" xmlns:graph="&ns_graphs;"
+	 xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 1124.7 498"
+	 style="enable-background:new 0 0 1124.7 498;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#FFFFFF;}
+	.st1{opacity:7.000000e-02;fill:#505150;enable-background:new    ;}
+	.st2{opacity:0.15;fill:#505150;enable-background:new    ;}
+	.st3{opacity:0.65;fill:#505150;enable-background:new    ;}
+	.st4{opacity:0.15;fill:#83B9F9;enable-background:new    ;}
+	.st5{fill:#83B9F9;}
+	.st6{fill:#A67AF4;}
+	.st7{fill:#773ADC;}
+	.st8{fill:url(#SVGID_1_);}
+	.st9{fill:url(#SVGID_00000155125091779556195380000018084145219770147245_);}
+	.st10{fill:url(#SVGID_00000068636563703996290090000000055110317031271076_);}
+	.st11{fill:#3C3C41;}
+	.st12{fill:#0078D4;}
+	.st13{fill:#6BB9F2;}
+	.st14{fill:url(#SVGID_00000129922111581494625910000015968105731954168229_);}
+	.st15{fill:#50E6FF;}
+	.st16{fill:url(#SVGID_00000141431367892459968410000015386914948308925598_);}
+	.st17{fill:url(#SVGID_00000115485307171571475850000014861054356914403773_);}
+	.st18{fill:url(#SVGID_00000064355945705288463620000002492552708635366041_);}
+	.st19{fill:#1490DF;}
+	.st20{fill:url(#SVGID_00000029737211945786944960000013806970548146371768_);}
+	.st21{fill:url(#SVGID_00000116210418702851879260000011636077498002521250_);}
+	.st22{fill:url(#SVGID_00000016058887973198928000000017324448260170258345_);}
+	.st23{fill:url(#SVGID_00000171000683048087410800000012445008331215133575_);}
+	.st24{fill:url(#SVGID_00000113323375592109350890000016103906792210524846_);}
+	.st25{fill:url(#SVGID_00000091711349935329777480000017734008648927363985_);}
+	.st26{opacity:0.7;fill:#CCCCCB;enable-background:new    ;}
+	.st27{fill:url(#SVGID_00000119088205423687846830000006782875458840157073_);}
+	.st28{fill:url(#f57e105d-6d2d-4ad7-b8c3-c10684c9f9b8_00000093888035420406952800000013187622463565294508_);}
+	.st29{fill:#699CD3;}
+	.st30{fill:#CFCFCE;}
+	.st31{fill:url(#SVGID_00000176014723125651538290000003619035664282207669_);}
+	.st32{fill:url(#SVGID_00000091729583645367594590000001538946060302093971_);}
+	.st33{fill:#999999;}
+	.st34{fill:url(#aacf8311-a317-400f-b613-74bd00da5ce3_00000102515667680695150700000003632993596837778870_);}
+	.st35{fill:url(#bd983c41-db73-40ec-a4f4-da1213fc9924_00000178190194588633371640000013322967028696883584_);}
+	.st36{opacity:0.75;fill:#F7921E;enable-background:new    ;}
+	.st37{fill:url(#SVGID_00000041990318020545661720000015236399281999962553_);}
+	.st38{fill:#A5DEF3;}
+	.st39{fill:#33BEDD;}
+	.st40{fill:#74CFEB;}
+	.st41{fill:#EF404A;}
+	.st42{fill:url(#SVGID_00000064349760965179021700000015975282242800605582_);}
+	.st43{fill:#2E76BC;}
+	.st44{fill:url(#SVGID_00000167380696996548075030000006235386766612660357_);}
+	.st45{fill:#FEBD11;}
+	.st46{fill:#FEE452;}
+	.st47{opacity:0.5;fill:#FED402;enable-background:new    ;}
+	.st48{fill:url(#f57e105d-6d2d-4ad7-b8c3-c10684c9f9b8_00000183231576259935705250000012737636966233755777_);}
+	.st49{opacity:0.3;fill:#FFFFFF;enable-background:new    ;}
+	.st50{fill:#75767A;}
+	.st51{fill:#207067;}
+	.st52{fill:#42E8CA;}
+	.st53{fill:#59285F;}
+	.st54{fill:#CE74B6;}
+	.st55{opacity:0.6;fill:#FFFFFF;enable-background:new    ;}
+	.st56{fill:url(#SVGID_00000162325683510749175360000007860402390157564583_);}
+	.st57{fill:url(#SVGID_00000124164038778729697470000015696544396935595699_);}
+	.st58{fill:url(#SVGID_00000153681053991995989180000006679639566921960096_);}
+	.st59{fill:url(#SVGID_00000167394652558197998400000008258534365857653686_);}
+	.st60{fill:url(#SVGID_00000150092266365647742340000011104370471749256861_);}
+	.st61{fill:url(#SVGID_00000033359829981292010940000013166408395378196110_);}
+	.st62{fill:url(#SVGID_00000011724603177624554520000010594602570952557995_);}
+	.st63{fill:url(#SVGID_00000011020950719539741620000003376730199294205105_);}
+	.st64{fill:url(#SVGID_00000073002211741893308740000001957672436356043141_);}
+	.st65{fill:url(#SVGID_00000127749360318023824460000008544690511692810664_);}
+	.st66{fill:#5FB832;}
+	.st67{fill:#D33833;}
+	.st68{fill:#EF3D3A;}
+	.st69{fill:#231F20;}
+	.st70{fill:#F0D6B7;}
+	.st71{fill:#335061;}
+	.st72{fill:#6D6B6D;}
+	.st73{fill:#DCD9D8;}
+	.st74{fill:#F7E4CD;}
+	.st75{fill:#49728B;}
+	.st76{fill:#81B0C4;}
+	.st77{fill:#1D1919;}
+	.st78{fill:url(#a91f0ca4-8fb7-4019-9c09-0a52e2c05754_00000039133237957242405030000015509983946469680021_);}
+	.st79{fill:url(#SVGID_00000098181168121309444340000002709786077681246609_);}
+	.st80{fill:url(#SVGID_00000120547171657874393530000018157416097341993137_);}
+	.st81{fill:#F2F2F2;}
+	.st82{fill:url(#SVGID_00000098179733332264356490000007614411152035585711_);}
+	.st83{fill:#53B0DE;}
+	.st84{fill:url(#SVGID_00000085972349692738182010000002783136735511315352_);}
+	.st85{fill:url(#SVGID_00000078745422513328759450000007872723889225855120_);}
+	.st86{fill:#1E3465;}
+	.st87{fill:url(#SVGID_00000121959747040948372890000015861439085458270126_);}
+	.st88{fill:#E8E8E8;}
+	.st89{fill:#1B8AB3;}
+	.st90{fill:url(#SVGID_00000178167485957627227360000004683960453264775588_);}
+	.st91{fill:url(#SVGID_00000121249110636014133070000005559102324381466045_);}
+	.st92{fill:none;}
+	.st93{opacity:0.7;}
+	.st94{opacity:0.9;fill:#CCCCCB;enable-background:new    ;}
+	.st95{fill:url(#SVGID_00000058577073392141436530000009044063490538077368_);}
+	.st96{fill:url(#SVGID_00000086672930564884666610000002423078978776691105_);}
+	.st97{fill:#821618;}
+	.st98{fill:#E52526;}
+	.st99{fill:#F27281;}
+	.st100{fill:url(#SVGID_00000023274200162204108470000004275790357177148585_);}
+	.st101{fill:#B6D43A;}
+	.st102{fill:url(#SVGID_00000056407272989605471360000001762480300350080896_);}
+	.st103{opacity:0.8;fill:#FFFFFF;enable-background:new    ;}
+	.st104{fill:url(#SVGID_00000140712486592005480860000003698217866064355979_);}
+	.st105{fill:url(#SVGID_00000078006731696349077690000011560388728664543896_);}
+	.st106{fill:url(#SVGID_00000129194556256004315680000018367682032975815562_);}
+	.st107{fill:url(#SVGID_00000024714911633232625260000009172037832395822731_);}
+	.st108{fill:url(#SVGID_00000014599919231880634480000005208838636596337329_);}
+	.st109{fill:#68BD45;}
+	.st110{fill:#2F2F2F;}
+	.st111{font-family:'SegoeUI';}
+	.st112{font-size:11px;}
+	.st113{fill:url(#SVGID_00000173859392784668506000000004558366005485655714_);}
+	.st114{font-size:14px;}
+	.st115{font-family:'SegoeUI-Bold';}
+	.st116{font-size:15px;}
+	.st117{fill:url(#SVGID_00000036231532751132364770000005465706936928015524_);}
+	.st118{fill-rule:evenodd;clip-rule:evenodd;fill:#8E714E;}
+	.st119{fill-rule:evenodd;clip-rule:evenodd;fill:#442D22;}
+	.st120{fill-rule:evenodd;clip-rule:evenodd;fill:#FFFFFF;}
+	.st121{fill-rule:evenodd;clip-rule:evenodd;fill:#A6A385;}
+	.st122{fill-rule:evenodd;clip-rule:evenodd;fill:#499D4A;}
+	.st123{fill-rule:evenodd;clip-rule:evenodd;fill:#58AA50;}
+	.st124{fill:url(#SVGID_00000183943241382949869160000008853919703321665975_);}
+	.st125{clip-path:url(#SVGID_00000159437043340246715520000003514955246188835245_);}
+	.st126{fill:#F2F2F3;}
+</style>
+<font horiz-adv-x="2048">
+<!-- Segoe is a trademark of the Microsoft group of companies. -->
+<!-- Copyright: Copyright 2022 Adobe System Incorporated. All rights reserved. -->
+<font-face font-family="SegoeUI" units-per-em="2048" underline-position="-178" underline-thickness="119"/>
+<missing-glyph horiz-adv-x="1322" d="M166,0l0,1398l990,0l0,-1398M314,148l694,0l0,1102l-694,0z"/>
+<glyph unicode=" " horiz-adv-x="561"/>
+<glyph unicode="-" horiz-adv-x="819" d="M690,506l-546,0l0,129l546,0z"/>
+<glyph unicode="/" horiz-adv-x="798" d="M813,1434l-688,-1672l-153,0l686,1672z"/>
+<glyph unicode="A" horiz-adv-x="1321" d="M1298,0l-186,0l-152,402l-608,0l-143,-402l-187,0l550,1434l174,0M905,553l-225,611C673,1184 665,1216 658,1260l-4,0C647,1219 640,1187 631,1164l-223,-611z"/>
+<glyph unicode="B" horiz-adv-x="1174" d="M188,0l0,1434l408,0C720,1434 818,1404 891,1343C964,1282 1000,1203 1000,1106C1000,1025 978,954 934,894C890,834 829,791 752,766l0,-4C849,751 926,714 984,653C1042,591 1071,511 1071,412C1071,289 1027,190 939,114C851,38 740,0 606,0M356,1282l0,-463l172,0C620,819 692,841 745,886C798,930 824,992 824,1073C824,1212 732,1282 549,1282M356,668l0,-516l228,0C683,152 759,175 814,222C868,269 895,333 895,414C895,583 780,668 549,668z"/>
+<glyph unicode="C" horiz-adv-x="1268" d="M1164,60C1058,4 926,-24 768,-24C564,-24 401,42 278,173C155,304 94,477 94,690C94,919 163,1105 301,1246C439,1387 614,1458 826,1458C962,1458 1075,1438 1164,1399l0,-179C1061,1277 948,1306 824,1306C659,1306 526,1251 424,1141C321,1031 270,884 270,700C270,525 318,386 414,283C509,179 635,127 790,127C934,127 1059,159 1164,223z"/>
+<glyph unicode="D" horiz-adv-x="1436" d="M188,0l0,1434l396,0C1089,1434 1342,1201 1342,735C1342,514 1272,336 1132,202C991,67 803,0 568,0M356,1282l0,-1130l214,0C758,152 904,202 1009,303C1114,404 1166,546 1166,731C1166,1098 971,1282 580,1282z"/>
+<glyph unicode="E" horiz-adv-x="1036" d="M948,0l-760,0l0,1434l728,0l0,-152l-560,0l0,-477l518,0l0,-151l-518,0l0,-502l592,0z"/>
+<glyph unicode="F" horiz-adv-x="1000" d="M916,1282l-560,0l0,-496l518,0l0,-151l-518,0l0,-635l-168,0l0,1434l728,0z"/>
+<glyph unicode="G" horiz-adv-x="1405" d="M1260,98C1116,17 956,-24 780,-24C575,-24 410,42 284,174C157,306 94,481 94,698C94,920 164,1102 305,1245C445,1387 623,1458 838,1458C994,1458 1125,1433 1231,1382l0,-186C1115,1269 978,1306 819,1306C658,1306 527,1251 424,1140C321,1029 270,886 270,710C270,529 318,386 413,283C508,179 638,127 801,127C913,127 1010,149 1092,194l0,402l-314,0l0,152l482,0z"/>
+<glyph unicode="H" horiz-adv-x="1454" d="M1266,0l-168,0l0,654l-742,0l0,-654l-168,0l0,1434l168,0l0,-629l742,0l0,629l168,0z"/>
+<glyph unicode="I" horiz-adv-x="545" d="M356,0l-168,0l0,1434l168,0z"/>
+<glyph unicode="J" horiz-adv-x="731" d="M555,514C555,344 519,212 447,118C375,23 279,-24 158,-24C102,-24 56,-16 20,0l0,166C56,140 103,127 160,127C311,127 387,255 387,512l0,922l168,0z"/>
+<glyph unicode="K" horiz-adv-x="1188" d="M1186,0l-234,0l-554,656C377,681 365,697 360,706l-4,0l0,-706l-168,0l0,1434l168,0l0,-674l4,0C369,775 382,791 398,809l536,625l209,0l-615,-688z"/>
+<glyph unicode="L" horiz-adv-x="964" d="M932,0l-744,0l0,1434l168,0l0,-1282l576,0z"/>
+<glyph unicode="M" horiz-adv-x="1839" d="M1650,0l-167,0l0,962C1483,1038 1488,1131 1497,1241l-4,0C1477,1176 1463,1130 1450,1102l-490,-1102l-82,0l-489,1094C375,1126 361,1175 346,1241l-4,0C347,1184 350,1090 350,960l0,-960l-162,0l0,1434l222,0l440,-1000C884,357 906,300 916,262l6,0C951,341 974,399 991,438l449,996l210,0z"/>
+<glyph unicode="N" horiz-adv-x="1532" d="M1344,0l-206,0l-738,1143C381,1172 366,1202 354,1233l-6,0C353,1202 356,1137 356,1036l0,-1036l-168,0l0,1434l218,0l718,-1125C1154,262 1173,230 1182,213l4,0C1179,254 1176,325 1176,424l0,1010l168,0z"/>
+<glyph unicode="O" horiz-adv-x="1544" d="M766,-24C563,-24 400,43 278,177C155,311 94,485 94,700C94,931 156,1115 281,1252C406,1389 575,1458 790,1458C988,1458 1148,1391 1269,1258C1390,1125 1450,950 1450,735C1450,501 1388,316 1264,180C1140,44 974,-24 766,-24M778,1306C627,1306 505,1252 411,1143C317,1034 270,892 270,715C270,538 316,396 408,289C499,181 619,127 766,127C923,127 1047,178 1138,281C1229,384 1274,527 1274,712C1274,901 1230,1048 1142,1151C1054,1254 933,1306 778,1306z"/>
+<glyph unicode="P" horiz-adv-x="1147" d="M356,542l0,-542l-168,0l0,1434l394,0C735,1434 854,1397 939,1322C1023,1247 1065,1142 1065,1006C1065,870 1018,759 925,672C831,585 704,542 545,542M356,1282l0,-588l176,0C648,694 737,721 798,774C859,827 889,901 889,998C889,1187 777,1282 553,1282z"/>
+<glyph unicode="Q" horiz-adv-x="1544" d="M766,-24C563,-24 400,43 277,177C155,311 94,485 94,700C94,931 156,1115 281,1252C406,1389 576,1458 790,1458C987,1458 1147,1391 1268,1258C1389,1125 1450,950 1450,735C1450,501 1388,316 1264,180C1235,147 1203,119 1170,96l403,-289l-305,0l-270,202C927,-13 850,-24 766,-24M778,1306C627,1306 505,1252 411,1143C317,1034 270,892 270,715C270,539 316,397 407,288C499,181 619,127 766,127C923,127 1047,178 1138,281C1229,384 1274,527 1274,712C1274,902 1230,1048 1142,1151C1054,1254 933,1306 778,1306z"/>
+<glyph unicode="R" horiz-adv-x="1225" d="M1216,0l-200,0l-240,402C754,439 733,471 712,498C691,524 670,545 649,562C627,579 604,591 579,599C554,606 525,610 494,610l-138,0l0,-610l-168,0l0,1434l428,0C679,1434 737,1426 790,1411C843,1395 889,1371 928,1339C967,1307 997,1267 1019,1220C1041,1172 1052,1116 1052,1052C1052,1002 1045,956 1030,915C1015,873 993,836 966,803C938,770 905,743 866,720C827,697 783,679 734,666l0,-4C758,651 779,639 797,626C814,612 831,596 847,577C863,558 879,537 895,514C910,490 928,462 947,431M356,1282l0,-520l228,0C626,762 665,768 701,781C736,794 767,812 793,836C819,859 839,888 854,923C869,957 876,995 876,1038C876,1115 851,1175 802,1218C752,1261 680,1282 586,1282z"/>
+<glyph unicode="S" horiz-adv-x="1088" d="M121,58l0,198C144,236 171,218 203,202C234,186 268,173 303,162C338,151 373,142 408,136C443,130 476,127 506,127C609,127 687,146 738,185C789,223 814,278 814,350C814,389 806,422 789,451C772,480 748,506 718,530C688,553 653,576 612,598C571,619 526,642 479,666C429,691 382,717 339,743C296,769 258,798 226,829C194,860 169,896 151,936C132,975 123,1022 123,1075C123,1140 137,1197 166,1246C195,1294 232,1334 279,1365C326,1396 379,1420 439,1435C498,1450 559,1458 621,1458C762,1458 865,1441 930,1407l0,-189C845,1277 737,1306 604,1306C567,1306 531,1302 494,1295C457,1287 425,1274 396,1257C367,1240 344,1217 326,1190C308,1163 299,1129 299,1090C299,1053 306,1022 320,995C333,968 353,944 380,922C407,900 439,879 478,858C516,837 560,815 610,790C661,765 710,738 756,710C802,682 842,651 877,617C912,583 939,545 960,504C980,463 990,415 990,362C990,291 976,232 949,183C921,134 884,94 837,63C790,32 735,10 674,-3C613,-17 548,-24 480,-24C457,-24 429,-22 396,-18C363,-15 329,-9 294,-2C259,5 227,13 196,24C165,34 140,45 121,58z"/>
+<glyph unicode="V" horiz-adv-x="1272" d="M1254,1434l-531,-1434l-185,0l-520,1434l187,0l397,-1137C615,260 624,218 631,170l4,0C640,210 651,253 668,299l405,1135z"/>
+<glyph unicode="a" horiz-adv-x="1042" d="M899,0l-164,0l0,160l-4,0C660,37 555,-24 416,-24C314,-24 234,3 177,57C119,111 90,183 90,272C90,463 203,575 428,606l307,43C735,823 665,910 524,910C401,910 289,868 190,784l0,168C291,1016 407,1048 538,1048C779,1048 899,921 899,666M735,518l-247,-34C412,473 355,455 316,428C277,401 258,353 258,284C258,234 276,193 312,162C347,130 395,114 454,114C535,114 603,143 656,200C709,257 735,329 735,416z"/>
+<glyph unicode="b" horiz-adv-x="1204" d="M334,148l-4,0l0,-148l-164,0l0,1516l164,0l0,-672l4,0C415,980 533,1048 688,1048C819,1048 922,1002 997,911C1071,819 1108,696 1108,542C1108,371 1066,234 983,131C900,28 786,-24 641,-24C506,-24 403,33 334,148M330,561l0,-143C330,333 358,262 413,203C468,144 537,114 622,114C721,114 799,152 856,228C912,304 940,410 940,545C940,659 914,748 861,813C808,878 737,910 647,910C552,910 475,877 417,811C359,744 330,661 330,561z"/>
+<glyph unicode="c" horiz-adv-x="946" d="M864,47C785,0 692,-24 584,-24C438,-24 320,24 231,119C141,214 96,337 96,488C96,657 144,792 241,895C338,997 467,1048 628,1048C718,1048 797,1031 866,998l0,-168C790,883 709,910 622,910C517,910 432,873 365,798C298,723 264,624 264,502C264,382 296,287 359,218C422,149 506,114 612,114C701,114 785,144 864,203z"/>
+<glyph unicode="d" horiz-adv-x="1206" d="M1040,0l-164,0l0,174l-4,0C796,42 679,-24 520,-24C391,-24 289,22 212,114C135,205 96,330 96,488C96,657 139,793 224,895C309,997 423,1048 565,1048C706,1048 808,993 872,882l4,0l0,634l164,0M876,463l0,151C876,697 849,767 794,824C739,881 670,910 586,910C486,910 407,873 350,800C293,727 264,625 264,496C264,378 292,285 347,217C402,148 475,114 568,114C659,114 734,147 791,213C848,279 876,362 876,463z"/>
+<glyph unicode="e" horiz-adv-x="1071" d="M989,471l-723,0C269,357 299,269 358,207C417,145 497,114 600,114C715,114 821,152 918,228l0,-154C828,9 709,-24 561,-24C416,-24 303,23 220,116C137,209 96,339 96,508C96,667 141,797 232,898C322,998 434,1048 568,1048C702,1048 806,1005 879,918C952,831 989,711 989,557M821,610C820,705 798,778 753,831C708,884 645,910 565,910C488,910 422,882 368,827C314,772 281,699 268,610z"/>
+<glyph unicode="f" horiz-adv-x="641" d="M672,1372C640,1390 604,1399 563,1399C448,1399 391,1327 391,1182l0,-158l240,0l0,-140l-240,0l0,-884l-163,0l0,884l-175,0l0,140l175,0l0,166C228,1297 259,1382 321,1445C383,1507 460,1538 553,1538C603,1538 643,1532 672,1520z"/>
+<glyph unicode="g" horiz-adv-x="1206" d="M1040,82C1040,-294 860,-482 500,-482C373,-482 263,-458 168,-410l0,164C283,-310 393,-342 498,-342C750,-342 876,-208 876,60l0,112l-4,0C794,41 677,-24 520,-24C393,-24 290,22 213,113C135,204 96,326 96,479C96,653 138,791 222,894C305,997 420,1048 565,1048C703,1048 805,993 872,882l4,0l0,142l164,0M876,463l0,151C876,695 849,765 794,823C739,881 670,910 588,910C487,910 407,873 350,800C293,726 264,623 264,490C264,376 292,285 347,217C402,148 474,114 565,114C657,114 732,147 790,212C847,277 876,361 876,463z"/>
+<glyph unicode="h" horiz-adv-x="1159" d="M1016,0l-164,0l0,590C852,803 773,910 614,910C534,910 467,879 412,818C357,756 330,677 330,580l0,-580l-164,0l0,1516l164,0l0,-662l4,0C413,983 525,1048 670,1048C901,1048 1016,909 1016,631z"/>
+<glyph unicode="i" horiz-adv-x="496" d="M250,1284C221,1284 196,1294 175,1314C154,1334 144,1359 144,1390C144,1421 154,1446 175,1467C196,1487 221,1497 250,1497C280,1497 306,1487 327,1467C348,1446 358,1421 358,1390C358,1361 348,1336 327,1315C306,1294 280,1284 250,1284M330,0l-164,0l0,1024l164,0z"/>
+<glyph unicode="k" horiz-adv-x="1018" d="M1016,0l-230,0l-452,492l-4,0l0,-492l-164,0l0,1516l164,0l0,-961l4,0l430,469l215,0l-475,-494z"/>
+<glyph unicode="l" horiz-adv-x="496" d="M330,0l-164,0l0,1516l164,0z"/>
+<glyph unicode="m" horiz-adv-x="1764" d="M1620,0l-164,0l0,588C1456,701 1439,783 1404,834C1369,885 1310,910 1227,910C1157,910 1098,878 1049,814C1000,750 975,673 975,584l0,-584l-164,0l0,608C811,809 733,910 578,910C506,910 447,880 400,820C353,759 330,681 330,584l0,-584l-164,0l0,1024l164,0l0,-162l4,0C407,986 513,1048 652,1048C722,1048 783,1029 835,990C887,951 923,899 942,836C1018,977 1131,1048 1282,1048C1507,1048 1620,909 1620,631z"/>
+<glyph unicode="n" horiz-adv-x="1159" d="M1016,0l-164,0l0,584C852,801 773,910 614,910C532,910 464,879 411,818C357,756 330,678 330,584l0,-584l-164,0l0,1024l164,0l0,-170l4,0C411,983 523,1048 670,1048C782,1048 868,1012 927,940C986,867 1016,763 1016,626z"/>
+<glyph unicode="o" horiz-adv-x="1200" d="M594,-24C443,-24 322,24 232,120C141,215 96,342 96,500C96,672 143,806 237,903C331,1000 458,1048 618,1048C771,1048 890,1001 976,907C1061,813 1104,683 1104,516C1104,353 1058,222 966,124C873,25 749,-24 594,-24M606,910C501,910 417,874 356,803C295,731 264,632 264,506C264,385 295,289 357,219C419,149 502,114 606,114C712,114 794,148 851,217C908,286 936,383 936,510C936,638 908,737 851,806C794,875 712,910 606,910z"/>
+<glyph unicode="p" horiz-adv-x="1204" d="M334,148l-4,0l0,-619l-164,0l0,1495l164,0l0,-180l4,0C415,980 533,1048 688,1048C820,1048 923,1002 997,911C1071,819 1108,696 1108,542C1108,371 1066,234 983,131C900,28 786,-24 641,-24C508,-24 406,33 334,148M330,561l0,-143C330,333 358,262 413,203C468,144 537,114 622,114C721,114 799,152 856,228C912,304 940,410 940,545C940,659 914,748 861,813C808,878 737,910 647,910C552,910 475,877 417,811C359,744 330,661 330,561z"/>
+<glyph unicode="r" horiz-adv-x="712" d="M700,858C671,880 630,891 576,891C506,891 448,858 401,792C354,726 330,636 330,522l0,-522l-164,0l0,1024l164,0l0,-211l4,0C357,885 393,941 441,982C489,1022 543,1042 602,1042C645,1042 677,1037 700,1028z"/>
+<glyph unicode="s" horiz-adv-x="869" d="M104,37l0,176C193,147 292,114 399,114C543,114 615,162 615,258C615,285 609,309 597,328C584,347 568,363 547,378C526,393 501,406 473,418C444,429 414,441 381,454C336,472 296,490 262,509C227,527 199,548 176,571C153,594 135,620 124,649C112,678 106,713 106,752C106,800 117,843 139,880C161,917 190,948 227,973C264,998 306,1016 353,1029C400,1042 448,1048 498,1048C587,1048 666,1033 736,1002l0,-166C661,885 574,910 476,910C445,910 418,907 393,900C368,893 347,883 330,870C312,857 298,842 289,825C279,807 274,787 274,766C274,739 279,717 289,699C298,681 312,665 331,651C350,637 372,624 399,613C426,602 456,589 490,576C535,559 576,541 612,523C648,504 679,484 704,461C729,438 749,411 763,381C776,351 783,315 783,274C783,223 772,179 750,142C727,105 697,74 660,49C623,24 580,6 531,-6C482,-18 431,-24 378,-24C273,-24 181,-4 104,37z"/>
+<glyph unicode="t" horiz-adv-x="694" d="M641,10C602,-11 551,-22 488,-22C309,-22 219,78 219,278l0,606l-176,0l0,140l176,0l0,250l164,53l0,-303l258,0l0,-140l-258,0l0,-577C383,238 395,189 418,160C441,131 480,116 534,116C575,116 611,127 641,150z"/>
+<glyph unicode="u" horiz-adv-x="1159" d="M994,0l-164,0l0,162l-4,0C758,38 653,-24 510,-24C266,-24 144,121 144,412l0,612l163,0l0,-586C307,222 390,114 555,114C635,114 701,144 753,203C804,262 830,339 830,434l0,590l164,0z"/>
+<glyph unicode="v" horiz-adv-x="981" d="M971,1024l-408,-1024l-161,0l-388,1024l180,0l260,-744C473,225 485,178 490,137l4,0C501,188 511,235 526,276l272,748z"/>
+<glyph unicode="w" horiz-adv-x="1480" d="M1456,1024l-307,-1024l-170,0l-211,733C760,761 755,793 752,828l-4,0C746,804 739,773 727,735l-229,-735l-164,0l-310,1024l172,0l212,-770C415,231 419,200 422,162l8,0C432,191 438,223 448,256l236,768l150,0l212,-772C1053,227 1058,197 1061,160l8,0C1070,186 1076,217 1086,252l208,772z"/>
+<glyph unicode="x" horiz-adv-x="940" d="M914,1024l-344,-518l338,-506l-191,0l-201,332C503,353 488,379 471,410l-4,0C464,404 448,378 420,332l-205,-332l-189,0l349,502l-334,522l191,0l198,-350C445,648 459,621 473,594l4,0l256,430z"/>
+<glyph unicode="y" horiz-adv-x="991" d="M981,1024l-471,-1188C426,-376 308,-482 156,-482C113,-482 78,-478 49,-469l0,147C84,-334 117,-340 146,-340C229,-340 291,-291 332,-192l82,194l-400,1022l182,0l277,-788C476,226 483,200 494,158l6,0C503,174 510,199 520,234l291,790z"/>
+<glyph unicode="z" horiz-adv-x="926" d="M880,977l-606,-837l600,0l0,-140l-841,0l0,51l606,833l-549,0l0,140l790,0z"/>
+</font>
+
+	<font horiz-adv-x="2048">
+<!-- Segoe is a trademark of the Microsoft group of companies. -->
+<!-- Copyright: Copyright 2022 Adobe System Incorporated. All rights reserved. -->
+<font-face font-family="SegoeUI-Bold" units-per-em="2048" underline-position="-178" underline-thickness="119"/>
+<missing-glyph horiz-adv-x="1322" d="M166,0l0,1398l990,0l0,-1398M314,148l694,0l0,1102l-694,0z"/>
+<glyph unicode=" " horiz-adv-x="565"/>
+<glyph unicode="A" horiz-adv-x="1440" d="M1425,0l-352,0l-102,319l-510,0l-101,-319l-350,0l522,1434l383,0M897,567l-154,482C732,1085 724,1128 719,1178l-8,0C708,1136 699,1094 686,1053l-156,-486z"/>
+<glyph unicode="S" horiz-adv-x="1148" d="M98,55l0,320C156,326 219,290 287,266C355,241 424,229 493,229C534,229 569,233 600,240C630,247 655,258 676,271C696,284 711,299 721,317C731,334 736,353 736,374C736,402 728,427 712,449C696,471 674,491 647,510C619,529 586,547 548,564C510,581 469,599 425,617C313,664 230,721 175,788C120,855 92,937 92,1032C92,1107 107,1171 137,1225C167,1278 208,1322 260,1357C311,1392 371,1417 439,1434C507,1450 579,1458 655,1458C730,1458 796,1454 854,1445C911,1436 964,1422 1013,1403l0,-299C989,1121 963,1135 935,1148C906,1161 877,1171 847,1180C817,1188 787,1194 758,1198C728,1202 700,1204 673,1204C636,1204 603,1201 573,1194C543,1187 518,1177 497,1164C476,1151 460,1136 449,1119C438,1101 432,1081 432,1059C432,1035 438,1014 451,995C464,976 482,958 505,941C528,924 557,907 590,891C623,874 661,857 703,840C760,816 812,791 858,764C903,737 942,706 975,672C1008,638 1033,599 1050,556C1067,512 1076,461 1076,403C1076,323 1061,256 1031,202C1000,147 959,103 907,70C855,36 795,12 726,-3C657,-18 584,-25 507,-25C428,-25 354,-18 283,-5C212,8 150,28 98,55z"/>
+<glyph unicode="e" horiz-adv-x="1108" d="M1053,422l-668,0C396,273 489,199 666,199C779,199 878,226 963,279l0,-228C868,0 745,-25 594,-25C429,-25 300,21 209,113C118,204 72,332 72,496C72,666 121,801 220,900C319,999 440,1049 584,1049C733,1049 849,1005 931,916C1012,827 1053,707 1053,555M760,616C760,763 701,836 582,836C531,836 488,815 451,773C414,731 391,679 383,616z"/>
+<glyph unicode="g" horiz-adv-x="1268" d="M1137,117C1137,-73 1082,-220 972,-324C862,-429 703,-481 494,-481C356,-481 247,-461 166,-422l0,266C271,-217 378,-248 485,-248C592,-248 674,-220 733,-163C792,-107 821,-31 821,66l0,81l-4,0C745,32 639,-25 498,-25C367,-25 264,21 187,113C110,205 72,328 72,483C72,656 115,794 200,896C285,998 398,1049 537,1049C662,1049 755,1001 817,905l4,0l0,119l316,0M825,492l0,81C825,638 806,693 768,739C729,784 679,807 618,807C548,807 493,780 453,725C413,670 393,593 393,494C393,409 412,341 450,292C488,242 540,217 606,217C671,217 724,242 765,293C805,343 825,409 825,492z"/>
+<glyph unicode="i" horiz-adv-x="582" d="M293,1186C240,1186 196,1202 162,1234C128,1265 111,1304 111,1350C111,1397 128,1436 162,1466C196,1496 240,1511 293,1511C347,1511 391,1496 425,1466C458,1436 475,1397 475,1350C475,1302 458,1263 425,1232C391,1201 347,1186 293,1186M449,0l-316,0l0,1024l316,0z"/>
+<glyph unicode="n" horiz-adv-x="1239" d="M1122,0l-315,0l0,569C807,728 750,807 637,807C582,807 537,786 502,744C467,702 449,649 449,584l0,-584l-316,0l0,1024l316,0l0,-162l4,0C528,987 638,1049 782,1049C1009,1049 1122,908 1122,627z"/>
+<glyph unicode="p" horiz-adv-x="1270" d="M453,119l-4,0l0,-590l-316,0l0,1495l316,0l0,-154l4,0C531,989 641,1049 782,1049C915,1049 1017,1004 1090,913C1162,822 1198,698 1198,541C1198,370 1156,233 1072,130C987,27 875,-25 735,-25C612,-25 518,23 453,119M444,539l0,-82C444,386 463,329 500,284C537,239 586,217 647,217C719,217 775,245 815,301C854,356 874,435 874,537C874,717 804,807 664,807C599,807 547,783 506,734C465,685 444,620 444,539z"/>
+<glyph unicode="r" horiz-adv-x="815" d="M801,739C763,760 719,770 668,770C599,770 546,745 507,695C468,644 449,576 449,489l0,-489l-316,0l0,1024l316,0l0,-190l4,0C503,973 593,1042 723,1042C756,1042 782,1038 801,1030z"/>
+<glyph unicode="s" horiz-adv-x="901" d="M66,27l0,256C118,252 170,228 222,213C273,198 322,190 368,190C424,190 468,198 501,213C533,228 549,252 549,283C549,303 542,320 527,333C512,346 494,358 471,368C448,378 422,387 395,395C368,403 341,412 316,422C275,437 240,454 209,472C178,489 152,510 131,533C110,556 94,583 83,614C72,645 66,681 66,723C66,780 79,830 104,871C129,912 162,946 204,973C245,999 293,1018 347,1031C400,1043 456,1049 514,1049C559,1049 605,1046 652,1039C699,1032 745,1021 790,1008l0,-244C750,787 707,805 662,817C616,828 571,834 527,834C506,834 487,832 469,829C450,825 434,820 420,813C406,806 395,797 387,786C379,775 375,762 375,748C375,729 381,713 393,700C405,687 421,675 440,666C459,656 481,647 505,640C528,632 552,624 575,616C617,601 655,585 689,568C723,551 752,530 777,507C801,484 820,456 833,425C846,394 852,356 852,313C852,252 839,201 813,158C786,115 751,80 708,53C664,26 614,6 557,-6C500,-19 440,-25 379,-25C266,-25 162,-8 66,27z"/>
+<glyph unicode="u" horiz-adv-x="1239" d="M1106,0l-315,0l0,156l-5,0C708,35 604,-25 473,-25C236,-25 117,119 117,406l0,618l315,0l0,-590C432,289 489,217 604,217C661,217 706,237 740,277C774,316 791,370 791,438l0,586l315,0z"/>
+<glyph unicode="z" horiz-adv-x="981" d="M944,0l-919,0l0,131l514,660l-463,0l0,233l864,0l0,-156l-487,-635l491,0z"/>
+</font>
+
+	<switch>
+	<foreignObject requiredExtensions="&ns_ai;" x="0" y="0" width="1" height="1">
+		<i:aipgfRef  xlink:href="#adobe_illustrator_pgf">
+		</i:aipgfRef>
+	</foreignObject>
+	<g i:extraneous="self">
+		<g>
+			<rect x="0.2" y="-2.4" class="st0" width="1124.2" height="497.5"/>
+			<path class="st0" d="M1124.7,495.3H0v-498h1124.7V495.3z M0.5,494.8h1123.7v-497H0.5V494.8z"/>
+		</g>
+		<g>
+			<path class="st0" d="M1118.7,462.6c0,2.2-1.8,4-4,4H559.5c-2.2,0-4-1.8-4-4V144.3c0-2.2,1.8-4,4-4h555.2c2.2,0,4,1.8,4,4V462.6z"
+				/>
+			<path class="st1" d="M1118.7,462.6c0,2.2-1.8,4-4,4H559.5c-2.2,0-4-1.8-4-4V144.3c0-2.2,1.8-4,4-4h555.2c2.2,0,4,1.8,4,4V462.6z"
+				/>
+			<path class="st2" d="M1114.7,467.1H559.5c-2.5,0-4.5-2-4.5-4.5V144.3c0-2.5,2-4.5,4.5-4.5h555.2c2.5,0,4.5,2,4.5,4.5v318.3
+				C1119.2,465.1,1117.2,467.1,1114.7,467.1z M559.5,140.8c-1.9,0-3.5,1.6-3.5,3.5v318.3c0,1.9,1.6,3.5,3.5,3.5h555.2
+				c1.9,0,3.5-1.6,3.5-3.5V144.3c0-1.9-1.6-3.5-3.5-3.5H559.5z"/>
+		</g>
+		<path class="st3" d="M1114.7,467.1L1114.7,467.1l-0.1-1h0.1c0.2,0,0.4,0,0.6-0.1l0.2,1C1115.3,467.1,1115,467.1,1114.7,467.1z
+			 M1112.6,467.1h-0.8v-1h0.8V467.1z M1109.8,467.1h-0.8v-1h0.8V467.1z M1107,467.1h-0.8v-1h0.8V467.1z M1104.2,467.1h-0.8v-1h0.8
+			V467.1z M1101.4,467.1h-0.8v-1h0.8V467.1z M1098.6,467.1h-0.8v-1h0.8V467.1z M1095.8,467.1h-0.8v-1h0.8V467.1z M1093,467.1h-0.8
+			v-1h0.8V467.1z M1090.2,467.1h-0.8v-1h0.8V467.1z M1087.4,467.1h-0.8v-1h0.8V467.1z M1084.6,467.1h-0.8v-1h0.8V467.1z
+			 M1081.8,467.1h-0.8v-1h0.8V467.1z M1079,467.1h-0.8v-1h0.8V467.1z M1076.2,467.1h-0.8v-1h0.8V467.1z M1073.4,467.1h-0.8v-1h0.8
+			V467.1z M1070.6,467.1h-0.8v-1h0.8V467.1z M1067.8,467.1h-0.8v-1h0.8V467.1z M1065,467.1h-0.8v-1h0.8V467.1z M1062.2,467.1h-0.8
+			v-1h0.8V467.1z M1059.4,467.1h-0.8v-1h0.8V467.1z M1056.6,467.1h-0.8v-1h0.8V467.1z M1053.8,467.1h-0.8v-1h0.8V467.1z M1051,467.1
+			h-0.8v-1h0.8V467.1z M1048.2,467.1h-0.8v-1h0.8V467.1z M1045.4,467.1h-0.8v-1h0.8V467.1z M1042.6,467.1h-0.8v-1h0.8V467.1z
+			 M1039.8,467.1h-0.8v-1h0.8V467.1z M1037,467.1h-0.8v-1h0.8V467.1z M1034.2,467.1h-0.8v-1h0.8V467.1z M1031.4,467.1h-0.8v-1h0.8
+			V467.1z M1028.6,467.1h-0.8v-1h0.8V467.1z M1025.8,467.1h-0.8v-1h0.8V467.1z M1023,467.1h-0.8v-1h0.8V467.1z M1020.2,467.1h-0.8
+			v-1h0.8V467.1z M1017.4,467.1h-0.8v-1h0.8V467.1z M1014.6,467.1h-0.8v-1h0.8V467.1z M1011.9,467.1h-0.8v-1h0.8V467.1z
+			 M1009.1,467.1h-0.8v-1h0.8V467.1z M1006.3,467.1h-0.8v-1h0.8V467.1z M1003.5,467.1h-0.8v-1h0.8V467.1z M1000.7,467.1h-0.8v-1h0.8
+			V467.1z M997.9,467.1h-0.8v-1h0.8V467.1z M995.1,467.1h-0.8v-1h0.8V467.1z M992.3,467.1h-0.8v-1h0.8V467.1z M989.5,467.1h-0.8v-1
+			h0.8V467.1z M986.7,467.1h-0.8v-1h0.8V467.1z M983.9,467.1h-0.8v-1h0.8V467.1z M981.1,467.1h-0.8v-1h0.8V467.1z M978.3,467.1h-0.8
+			v-1h0.8V467.1z M975.5,467.1h-0.8v-1h0.8V467.1z M972.7,467.1h-0.8v-1h0.8V467.1z M969.9,467.1h-0.8v-1h0.8V467.1z M967.1,467.1
+			h-0.8v-1h0.8V467.1z M964.3,467.1h-0.8v-1h0.8V467.1z M961.5,467.1h-0.8v-1h0.8V467.1z M958.7,467.1h-0.8v-1h0.8V467.1z
+			 M955.9,467.1h-0.8v-1h0.8V467.1z M953.1,467.1h-0.8v-1h0.8V467.1z M950.3,467.1h-0.8v-1h0.8V467.1z M947.5,467.1h-0.8v-1h0.8
+			V467.1z M944.7,467.1h-0.8v-1h0.8V467.1z M941.9,467.1h-0.8v-1h0.8V467.1z M939.1,467.1h-0.8v-1h0.8V467.1z M936.3,467.1h-0.8v-1
+			h0.8V467.1z M933.5,467.1h-0.8v-1h0.8V467.1z M930.7,467.1h-0.8v-1h0.8V467.1z M927.9,467.1h-0.8v-1h0.8V467.1z M925.1,467.1h-0.8
+			v-1h0.8V467.1z M922.3,467.1h-0.8v-1h0.8V467.1z M919.5,467.1h-0.8v-1h0.8V467.1z M916.7,467.1h-0.8v-1h0.8V467.1z M913.9,467.1
+			h-0.8v-1h0.8V467.1z M911.1,467.1h-0.8v-1h0.8V467.1z M908.3,467.1h-0.8v-1h0.8V467.1z M905.5,467.1h-0.8v-1h0.8V467.1z
+			 M902.7,467.1h-0.8v-1h0.8V467.1z M899.9,467.1h-0.8v-1h0.8V467.1z M897.1,467.1h-0.8v-1h0.8V467.1z M894.3,467.1h-0.8v-1h0.8
+			V467.1z M891.5,467.1h-0.8v-1h0.8V467.1z M888.7,467.1h-0.8v-1h0.8V467.1z M885.9,467.1h-0.8v-1h0.8V467.1z M883.1,467.1h-0.8v-1
+			h0.8V467.1z M880.3,467.1h-0.8v-1h0.8V467.1z M877.5,467.1h-0.8v-1h0.8V467.1z M874.7,467.1h-0.8v-1h0.8V467.1z M871.9,467.1h-0.8
+			v-1h0.8V467.1z M869.1,467.1h-0.8v-1h0.8V467.1z M866.3,467.1h-0.8v-1h0.8V467.1z M863.5,467.1h-0.8v-1h0.8V467.1z M860.7,467.1
+			h-0.8v-1h0.8V467.1z M857.9,467.1h-0.8v-1h0.8V467.1z M855.1,467.1h-0.8v-1h0.8V467.1z M852.3,467.1h-0.8v-1h0.8V467.1z
+			 M849.5,467.1h-0.8v-1h0.8V467.1z M846.7,467.1h-0.8v-1h0.8V467.1z M843.9,467.1h-0.8v-1h0.8V467.1z M841.1,467.1h-0.8v-1h0.8
+			V467.1z M838.3,467.1h-0.8v-1h0.8V467.1z M835.5,467.1h-0.8v-1h0.8V467.1z M832.7,467.1h-0.8v-1h0.8V467.1z M829.9,467.1h-0.8v-1
+			h0.8V467.1z M827.1,467.1h-0.8v-1h0.8V467.1z M824.3,467.1h-0.8v-1h0.8V467.1z M821.5,467.1h-0.8v-1h0.8V467.1z M818.7,467.1h-0.8
+			v-1h0.8V467.1z M815.9,467.1h-0.8v-1h0.8V467.1z M813.1,467.1h-0.8v-1h0.8V467.1z M810.3,467.1h-0.8v-1h0.8V467.1z M807.5,467.1
+			h-0.8v-1h0.8V467.1z M804.7,467.1h-0.8v-1h0.8V467.1z M801.9,467.1h-0.8v-1h0.8V467.1z M799.1,467.1h-0.8v-1h0.8V467.1z
+			 M796.3,467.1h-0.8v-1h0.8V467.1z M793.5,467.1h-0.8v-1h0.8V467.1z M790.7,467.1h-0.8v-1h0.8V467.1z M787.9,467.1h-0.8v-1h0.8
+			V467.1z M785.1,467.1h-0.8v-1h0.8V467.1z M782.3,467.1h-0.8v-1h0.8V467.1z M779.5,467.1h-0.8v-1h0.8V467.1z M776.7,467.1h-0.8v-1
+			h0.8V467.1z M773.9,467.1h-0.8v-1h0.8V467.1z M771.1,467.1h-0.8v-1h0.8V467.1z M768.3,467.1h-0.8v-1h0.8V467.1z M765.5,467.1h-0.8
+			v-1h0.8V467.1z M762.7,467.1h-0.8v-1h0.8V467.1z M759.9,467.1h-0.8v-1h0.8V467.1z M757.1,467.1h-0.8v-1h0.8V467.1z M754.3,467.1
+			h-0.8v-1h0.8V467.1z M751.5,467.1h-0.8v-1h0.8V467.1z M748.7,467.1h-0.8v-1h0.8V467.1z M745.9,467.1h-0.8v-1h0.8V467.1z
+			 M743.1,467.1h-0.8v-1h0.8V467.1z M740.3,467.1h-0.8v-1h0.8V467.1z M737.5,467.1h-0.8v-1h0.8V467.1z M734.7,467.1h-0.8v-1h0.8
+			V467.1z M731.9,467.1h-0.8v-1h0.8V467.1z M729.1,467.1h-0.8v-1h0.8V467.1z M726.3,467.1h-0.8v-1h0.8V467.1z M723.5,467.1h-0.8v-1
+			h0.8V467.1z M720.7,467.1h-0.8v-1h0.8V467.1z M717.9,467.1h-0.8v-1h0.8V467.1z M715.1,467.1h-0.8v-1h0.8V467.1z M712.3,467.1h-0.8
+			v-1h0.8V467.1z M709.5,467.1h-0.8v-1h0.8V467.1z M706.7,467.1h-0.8v-1h0.8V467.1z M703.9,467.1h-0.8v-1h0.8V467.1z M701.1,467.1
+			h-0.8v-1h0.8V467.1z M698.3,467.1h-0.8v-1h0.8V467.1z M695.5,467.1h-0.8v-1h0.8V467.1z M692.7,467.1h-0.8v-1h0.8V467.1z
+			 M689.9,467.1h-0.8v-1h0.8V467.1z M687.1,467.1h-0.8v-1h0.8V467.1z M684.3,467.1h-0.8v-1h0.8V467.1z M681.5,467.1h-0.8v-1h0.8
+			V467.1z M678.7,467.1h-0.8v-1h0.8V467.1z M675.9,467.1h-0.8v-1h0.8V467.1z M673.1,467.1h-0.8v-1h0.8V467.1z M670.3,467.1h-0.8v-1
+			h0.8V467.1z M667.5,467.1h-0.8v-1h0.8V467.1z M664.7,467.1h-0.8v-1h0.8V467.1z M661.9,467.1h-0.8v-1h0.8V467.1z M659.1,467.1h-0.8
+			v-1h0.8V467.1z M656.3,467.1h-0.8v-1h0.8V467.1z M653.5,467.1h-0.8v-1h0.8V467.1z M650.7,467.1h-0.8v-1h0.8V467.1z M647.9,467.1
+			h-0.8v-1h0.8V467.1z M645.1,467.1h-0.8v-1h0.8V467.1z M642.3,467.1h-0.8v-1h0.8V467.1z M639.5,467.1h-0.8v-1h0.8V467.1z
+			 M636.7,467.1h-0.8v-1h0.8V467.1z M633.9,467.1h-0.8v-1h0.8V467.1z M631.1,467.1h-0.8v-1h0.8V467.1z M628.3,467.1h-0.8v-1h0.8
+			V467.1z M625.5,467.1h-0.8v-1h0.8V467.1z M622.7,467.1h-0.8v-1h0.8V467.1z M619.9,467.1h-0.8v-1h0.8V467.1z M617.1,467.1h-0.8v-1
+			h0.8V467.1z M614.3,467.1h-0.8v-1h0.8V467.1z M611.5,467.1h-0.8v-1h0.8V467.1z M608.7,467.1h-0.8v-1h0.8V467.1z M605.9,467.1h-0.8
+			v-1h0.8V467.1z M603.1,467.1h-0.8v-1h0.8V467.1z M600.3,467.1h-0.8v-1h0.8V467.1z M597.5,467.1h-0.8v-1h0.8V467.1z M594.7,467.1
+			h-0.8v-1h0.8V467.1z M564,467.1h-0.8v-1h0.8V467.1z M561.2,467.1h-0.8v-1h0.8V467.1z M558.2,466.9c-0.3-0.1-0.6-0.2-0.8-0.4
+			l0.5-0.9c0.2,0.1,0.4,0.2,0.6,0.3L558.2,466.9z M1117.5,466.1l-0.6-0.8c0.2-0.1,0.4-0.3,0.5-0.5l0.8,0.6
+			C1118,465.7,1117.8,465.9,1117.5,466.1z M555.8,465c-0.2-0.3-0.3-0.5-0.4-0.8l0.9-0.4c0.1,0.2,0.2,0.4,0.3,0.6L555.8,465z
+			 M1119.2,463.5l-1-0.2c0-0.2,0.1-0.5,0.1-0.7h1l0,0C1119.2,462.9,1119.2,463.2,1119.2,463.5z M556,462.1h-1v-0.8h1V462.1z
+			 M1119.2,460.5h-1v-0.8h1V460.5z M556,459.3h-1v-0.8h1V459.3z M1119.2,457.7h-1v-0.8h1V457.7z M556,456.5h-1v-0.8h1V456.5z
+			 M1119.2,454.9h-1v-0.8h1V454.9z M556,453.7h-1v-0.8h1V453.7z M1119.2,452.1h-1v-0.8h1V452.1z M556,450.9h-1v-0.8h1V450.9z
+			 M1119.2,449.3h-1v-0.8h1V449.3z M556,448.1h-1v-0.8h1V448.1z M1119.2,446.5h-1v-0.8h1V446.5z M556,445.3h-1v-0.8h1V445.3z
+			 M1119.2,443.7h-1v-0.8h1V443.7z M556,442.5h-1v-0.8h1V442.5z M1119.2,440.9h-1v-0.8h1V440.9z M556,439.7h-1v-0.8h1V439.7z
+			 M1119.2,438.1h-1v-0.8h1V438.1z M556,436.9h-1v-0.8h1V436.9z M1119.2,435.3h-1v-0.8h1V435.3z M556,434.1h-1v-0.8h1V434.1z
+			 M1119.2,432.5h-1v-0.8h1V432.5z M556,431.3h-1v-0.8h1V431.3z M1119.2,429.7h-1v-0.8h1V429.7z M556,428.5h-1v-0.8h1V428.5z
+			 M1119.2,426.9h-1v-0.8h1V426.9z M556,425.7h-1v-0.8h1V425.7z M1119.2,424.1h-1v-0.8h1V424.1z M556,422.9h-1v-0.8h1V422.9z
+			 M1119.2,421.3h-1v-0.8h1V421.3z M556,420.1h-1v-0.8h1V420.1z M1119.2,418.5h-1v-0.8h1V418.5z M556,417.3h-1v-0.8h1V417.3z
+			 M1119.2,415.8h-1V415h1V415.8z M556,414.5h-1v-0.8h1V414.5z M1119.2,413h-1v-0.8h1V413z M556,411.7h-1v-0.8h1V411.7z
+			 M1119.2,410.2h-1v-0.8h1V410.2z M556,408.9h-1v-0.8h1V408.9z M1119.2,407.4h-1v-0.8h1V407.4z M556,406.1h-1v-0.8h1V406.1z
+			 M1119.2,404.6h-1v-0.8h1V404.6z M556,403.3h-1v-0.8h1V403.3z M1119.2,401.8h-1V401h1V401.8z M556,400.5h-1v-0.8h1V400.5z
+			 M1119.2,399h-1v-0.8h1V399z M556,397.7h-1v-0.8h1V397.7z M1119.2,396.2h-1v-0.8h1V396.2z M556,394.9h-1v-0.8h1V394.9z
+			 M1119.2,393.4h-1v-0.8h1V393.4z M556,392.1h-1v-0.8h1V392.1z M1119.2,390.6h-1v-0.8h1V390.6z M556,389.3h-1v-0.8h1V389.3z
+			 M1119.2,387.8h-1V387h1V387.8z M556,386.5h-1v-0.8h1V386.5z M1119.2,385h-1v-0.8h1V385z M556,383.7h-1v-0.8h1V383.7z
+			 M1119.2,382.2h-1v-0.8h1V382.2z M556,380.9h-1v-0.8h1V380.9z M1119.2,379.4h-1v-0.8h1V379.4z M556,378.1h-1v-0.8h1V378.1z
+			 M1119.2,376.6h-1v-0.8h1V376.6z M556,375.3h-1v-0.8h1V375.3z M1119.2,373.8h-1V373h1V373.8z M556,372.5h-1v-0.8h1V372.5z
+			 M1119.2,371h-1v-0.8h1V371z M556,369.7h-1v-0.8h1V369.7z M1119.2,368.2h-1v-0.8h1V368.2z M556,366.9h-1v-0.8h1V366.9z
+			 M1119.2,365.4h-1v-0.8h1V365.4z M556,364.1h-1v-0.8h1V364.1z M1119.2,362.6h-1v-0.8h1V362.6z M556,361.3h-1v-0.8h1V361.3z
+			 M1119.2,359.8h-1V359h1V359.8z M556,358.5h-1v-0.8h1V358.5z M1119.2,357h-1v-0.8h1V357z M556,355.7h-1v-0.8h1V355.7z
+			 M1119.2,354.2h-1v-0.8h1V354.2z M556,352.9h-1v-0.8h1V352.9z M1119.2,351.4h-1v-0.8h1V351.4z M556,350.1h-1v-0.8h1V350.1z
+			 M1119.2,348.6h-1v-0.8h1V348.6z M556,347.3h-1v-0.8h1V347.3z M1119.2,345.8h-1V345h1V345.8z M556,344.5h-1v-0.8h1V344.5z
+			 M1119.2,343h-1v-0.8h1V343z M556,341.7h-1v-0.8h1V341.7z M1119.2,340.2h-1v-0.8h1V340.2z M556,338.9h-1v-0.8h1V338.9z
+			 M1119.2,337.4h-1v-0.8h1V337.4z M556,336.1h-1v-0.8h1V336.1z M1119.2,334.6h-1v-0.8h1V334.6z M556,333.3h-1v-0.8h1V333.3z
+			 M1119.2,331.8h-1V331h1V331.8z M556,330.5h-1v-0.8h1V330.5z M1119.2,329h-1v-0.8h1V329z M556,327.7h-1v-0.8h1V327.7z
+			 M1119.2,326.2h-1v-0.8h1V326.2z M556,324.9h-1v-0.8h1V324.9z M1119.2,323.4h-1v-0.8h1V323.4z M556,322.1h-1v-0.8h1V322.1z
+			 M1119.2,320.6h-1v-0.8h1V320.6z M556,319.3h-1v-0.8h1V319.3z M1119.2,317.8h-1V317h1V317.8z M556,316.5h-1v-0.8h1V316.5z
+			 M1119.2,315h-1v-0.8h1V315z M556,313.7h-1v-0.8h1V313.7z M1119.2,312.2h-1v-0.8h1V312.2z M556,310.9h-1v-0.8h1V310.9z
+			 M1119.2,309.4h-1v-0.8h1V309.4z M556,308.1h-1v-0.8h1V308.1z M1119.2,306.6h-1v-0.8h1V306.6z M556,305.3h-1v-0.8h1V305.3z
+			 M1119.2,303.8h-1V303h1V303.8z M556,302.5h-1v-0.8h1V302.5z M1119.2,301h-1v-0.8h1V301z M556,299.7h-1v-0.8h1V299.7z
+			 M1119.2,298.2h-1v-0.8h1V298.2z M556,296.9h-1v-0.8h1V296.9z M1119.2,295.4h-1v-0.8h1V295.4z M556,294.1h-1v-0.8h1V294.1z
+			 M1119.2,292.6h-1v-0.8h1V292.6z M556,291.3h-1v-0.8h1V291.3z M1119.2,289.8h-1V289h1V289.8z M556,288.5h-1v-0.8h1V288.5z
+			 M1119.2,287h-1v-0.8h1V287z M556,285.7h-1v-0.8h1V285.7z M1119.2,284.2h-1v-0.8h1V284.2z M556,282.9h-1v-0.8h1V282.9z
+			 M1119.2,281.4h-1v-0.8h1V281.4z M556,280.1h-1v-0.8h1V280.1z M1119.2,278.6h-1v-0.8h1V278.6z M556,277.3h-1v-0.8h1V277.3z
+			 M1119.2,275.8h-1V275h1V275.8z M556,274.5h-1v-0.8h1V274.5z M1119.2,273h-1v-0.8h1V273z M556,271.7h-1v-0.8h1V271.7z
+			 M1119.2,270.2h-1v-0.8h1V270.2z M556,268.9h-1v-0.8h1V268.9z M1119.2,267.4h-1v-0.8h1V267.4z M556,266.1h-1v-0.8h1V266.1z
+			 M1119.2,264.6h-1v-0.8h1V264.6z M556,263.3h-1v-0.8h1V263.3z M1119.2,261.8h-1V261h1V261.8z M556,260.5h-1v-0.8h1V260.5z
+			 M1119.2,259h-1v-0.8h1V259z M556,257.7h-1v-0.8h1V257.7z M1119.2,256.2h-1v-0.8h1V256.2z M556,254.9h-1v-0.8h1V254.9z
+			 M1119.2,253.4h-1v-0.8h1V253.4z M556,252.1h-1v-0.8h1V252.1z M1119.2,250.6h-1v-0.8h1V250.6z M556,249.3h-1v-0.8h1V249.3z
+			 M1119.2,247.8h-1V247h1V247.8z M556,246.5h-1v-0.8h1V246.5z M1119.2,245h-1v-0.8h1V245z M556,243.7h-1v-0.8h1V243.7z
+			 M1119.2,242.2h-1v-0.8h1V242.2z M556,240.9h-1v-0.8h1V240.9z M1119.2,239.4h-1v-0.8h1V239.4z M556,238.1h-1v-0.8h1V238.1z
+			 M1119.2,236.6h-1v-0.8h1V236.6z M556,235.3h-1v-0.8h1V235.3z M1119.2,233.8h-1V233h1V233.8z M556,232.5h-1v-0.8h1V232.5z
+			 M1119.2,231h-1v-0.8h1V231z M556,229.7h-1v-0.8h1V229.7z M1119.2,228.2h-1v-0.8h1V228.2z M556,226.9h-1v-0.8h1V226.9z
+			 M1119.2,225.4h-1v-0.8h1V225.4z M556,224.1h-1v-0.8h1V224.1z M1119.2,222.6h-1v-0.8h1V222.6z M556,221.3h-1v-0.8h1V221.3z
+			 M1119.2,219.8h-1V219h1V219.8z M556,218.5h-1v-0.8h1V218.5z M1119.2,217h-1v-0.8h1V217z M556,215.7h-1v-0.8h1V215.7z
+			 M1119.2,214.2h-1v-0.8h1V214.2z M556,212.9h-1v-0.8h1V212.9z M1119.2,211.4h-1v-0.8h1V211.4z M556,210.1h-1v-0.8h1V210.1z
+			 M1119.2,208.6h-1v-0.8h1V208.6z M556,207.3h-1v-0.8h1V207.3z M1119.2,205.8h-1V205h1V205.8z M556,204.5h-1v-0.8h1V204.5z
+			 M1119.2,203h-1v-0.8h1V203z M556,201.7h-1v-0.8h1V201.7z M1119.2,200.2h-1v-0.8h1V200.2z M556,198.9h-1v-0.8h1V198.9z
+			 M1119.2,197.4h-1v-0.8h1V197.4z M556,196.1h-1v-0.8h1V196.1z M1119.2,194.6h-1v-0.8h1V194.6z M556,193.3h-1v-0.8h1V193.3z
+			 M1119.2,191.8h-1V191h1V191.8z M556,190.5h-1v-0.8h1V190.5z M1119.2,189h-1v-0.8h1V189z M556,187.7h-1v-0.8h1V187.7z
+			 M1119.2,186.2h-1v-0.8h1V186.2z M556,184.9h-1v-0.8h1V184.9z M1119.2,183.4h-1v-0.8h1V183.4z M556,182.1h-1v-0.8h1V182.1z
+			 M1119.2,180.6h-1v-0.8h1V180.6z M556,179.3h-1v-0.8h1V179.3z M1119.2,177.8h-1V177h1V177.8z M556,176.5h-1v-0.8h1V176.5z
+			 M1119.2,175h-1v-0.8h1V175z M556,173.7h-1v-0.8h1V173.7z M1119.2,172.2h-1v-0.8h1V172.2z M556,170.9h-1v-0.8h1V170.9z
+			 M1119.2,169.4h-1v-0.8h1V169.4z M556,168.1h-1v-0.8h1V168.1z M1119.2,166.6h-1v-0.8h1V166.6z M556,165.3h-1v-0.8h1V165.3z
+			 M1119.2,163.8h-1V163h1V163.8z M556,162.5h-1v-0.8h1V162.5z M1119.2,161h-1v-0.8h1V161z M556,159.7h-1v-0.8h1V159.7z
+			 M1119.2,158.2h-1v-0.8h1V158.2z M556,156.9h-1v-0.8h1V156.9z M1119.2,155.4h-1v-0.8h1V155.4z M556,154.1h-1v-0.8h1V154.1z
+			 M1119.2,152.6h-1v-0.8h1V152.6z M556,151.3h-1v-0.8h1V151.3z M1119.2,149.8h-1V149h1V149.8z M556,148.5h-1v-0.8h1V148.5z
+			 M1119.2,147h-1v-0.8h1V147z M556,145.8h-1V145h1V145.8z M1118.2,144.2c0-0.2,0-0.5-0.1-0.7l1-0.2c0.1,0.3,0.1,0.6,0.1,0.9H1118.2
+			z M556.2,143.1l-0.9-0.3c0.1-0.3,0.2-0.6,0.4-0.8l0.9,0.5C556.4,142.7,556.3,142.9,556.2,143.1z M1117.4,142
+			c-0.2-0.2-0.3-0.3-0.5-0.5l0.6-0.8c0.2,0.2,0.5,0.4,0.7,0.6L1117.4,142z M557.8,141.3l-0.5-0.9c0.3-0.2,0.5-0.3,0.8-0.4l0.3,0.9
+			C558.2,141.1,558,141.2,557.8,141.3z M1115.2,140.9c-0.2,0-0.3,0-0.5,0h-0.2v-1h0.2c0.2,0,0.4,0,0.6,0L1115.2,140.9z
+			 M1112.5,140.8h-0.8v-1h0.8V140.8z M1109.7,140.8h-0.8v-1h0.8V140.8z M1106.9,140.8h-0.8v-1h0.8V140.8z M1104.1,140.8h-0.8v-1h0.8
+			V140.8z M1101.3,140.8h-0.8v-1h0.8V140.8z M1098.5,140.8h-0.8v-1h0.8V140.8z M1095.7,140.8h-0.8v-1h0.8V140.8z M1092.9,140.8h-0.8
+			v-1h0.8V140.8z M1090.1,140.8h-0.8v-1h0.8V140.8z M1087.3,140.8h-0.8v-1h0.8V140.8z M1084.5,140.8h-0.8v-1h0.8V140.8z
+			 M1081.7,140.8h-0.8v-1h0.8V140.8z M1078.9,140.8h-0.8v-1h0.8V140.8z M1076.1,140.8h-0.8v-1h0.8V140.8z M1073.3,140.8h-0.8v-1h0.8
+			V140.8z M1070.5,140.8h-0.8v-1h0.8V140.8z M1067.7,140.8h-0.8v-1h0.8V140.8z M1064.9,140.8h-0.8v-1h0.8V140.8z M1062.1,140.8h-0.8
+			v-1h0.8V140.8z M1059.3,140.8h-0.8v-1h0.8V140.8z M1056.5,140.8h-0.8v-1h0.8V140.8z M1053.7,140.8h-0.8v-1h0.8V140.8z
+			 M1050.9,140.8h-0.8v-1h0.8V140.8z M1048.1,140.8h-0.8v-1h0.8V140.8z M1045.3,140.8h-0.8v-1h0.8V140.8z M1042.5,140.8h-0.8v-1h0.8
+			V140.8z M1039.7,140.8h-0.8v-1h0.8V140.8z M1036.9,140.8h-0.8v-1h0.8V140.8z M1034.1,140.8h-0.8v-1h0.8V140.8z M1031.3,140.8h-0.8
+			v-1h0.8V140.8z M1028.5,140.8h-0.8v-1h0.8V140.8z M1025.7,140.8h-0.8v-1h0.8V140.8z M1022.9,140.8h-0.8v-1h0.8V140.8z
+			 M1020.1,140.8h-0.8v-1h0.8V140.8z M1017.3,140.8h-0.8v-1h0.8V140.8z M1014.5,140.8h-0.8v-1h0.8V140.8z M1011.7,140.8h-0.8v-1h0.8
+			V140.8z M1008.9,140.8h-0.8v-1h0.8V140.8z M1006.1,140.8h-0.8v-1h0.8V140.8z M1003.3,140.8h-0.8v-1h0.8V140.8z M1000.5,140.8h-0.8
+			v-1h0.8V140.8z M997.7,140.8h-0.8v-1h0.8V140.8z M994.9,140.8h-0.8v-1h0.8V140.8z M992.1,140.8h-0.8v-1h0.8V140.8z M989.3,140.8
+			h-0.8v-1h0.8V140.8z M986.5,140.8h-0.8v-1h0.8V140.8z M983.7,140.8h-0.8v-1h0.8V140.8z M980.9,140.8h-0.8v-1h0.8V140.8z
+			 M978.1,140.8h-0.8v-1h0.8V140.8z M975.3,140.8h-0.8v-1h0.8V140.8z M972.5,140.8h-0.8v-1h0.8V140.8z M969.7,140.8h-0.8v-1h0.8
+			V140.8z M966.9,140.8h-0.8v-1h0.8V140.8z M964.1,140.8h-0.8v-1h0.8V140.8z M961.3,140.8h-0.8v-1h0.8V140.8z M958.5,140.8h-0.8v-1
+			h0.8V140.8z M955.7,140.8h-0.8v-1h0.8V140.8z M952.9,140.8h-0.8v-1h0.8V140.8z M950.1,140.8h-0.8v-1h0.8V140.8z M947.3,140.8h-0.8
+			v-1h0.8V140.8z M944.6,140.8h-0.8v-1h0.8V140.8z M941.8,140.8H941v-1h0.8V140.8z M939,140.8h-0.8v-1h0.8V140.8z M936.2,140.8h-0.8
+			v-1h0.8V140.8z M933.4,140.8h-0.8v-1h0.8V140.8z M930.6,140.8h-0.8v-1h0.8V140.8z M927.8,140.8H927v-1h0.8V140.8z M925,140.8h-0.8
+			v-1h0.8V140.8z M922.2,140.8h-0.8v-1h0.8V140.8z M919.4,140.8h-0.8v-1h0.8V140.8z M916.6,140.8h-0.8v-1h0.8V140.8z M913.8,140.8
+			H913v-1h0.8V140.8z M911,140.8h-0.8v-1h0.8V140.8z M908.2,140.8h-0.8v-1h0.8V140.8z M905.4,140.8h-0.8v-1h0.8V140.8z M902.6,140.8
+			h-0.8v-1h0.8V140.8z M899.8,140.8H899v-1h0.8V140.8z M897,140.8h-0.8v-1h0.8V140.8z M894.2,140.8h-0.8v-1h0.8V140.8z M891.4,140.8
+			h-0.8v-1h0.8V140.8z M888.6,140.8h-0.8v-1h0.8V140.8z M885.8,140.8H885v-1h0.8V140.8z M883,140.8h-0.8v-1h0.8V140.8z M880.2,140.8
+			h-0.8v-1h0.8V140.8z M877.4,140.8h-0.8v-1h0.8V140.8z M874.6,140.8h-0.8v-1h0.8V140.8z M871.8,140.8H871v-1h0.8V140.8z M869,140.8
+			h-0.8v-1h0.8V140.8z M866.2,140.8h-0.8v-1h0.8V140.8z M863.4,140.8h-0.8v-1h0.8V140.8z M860.6,140.8h-0.8v-1h0.8V140.8z
+			 M857.8,140.8H857v-1h0.8V140.8z M855,140.8h-0.8v-1h0.8V140.8z M852.2,140.8h-0.8v-1h0.8V140.8z M849.4,140.8h-0.8v-1h0.8V140.8z
+			 M846.6,140.8h-0.8v-1h0.8V140.8z M843.8,140.8H843v-1h0.8V140.8z M841,140.8h-0.8v-1h0.8V140.8z M838.2,140.8h-0.8v-1h0.8V140.8z
+			 M835.4,140.8h-0.8v-1h0.8V140.8z M832.6,140.8h-0.8v-1h0.8V140.8z M829.8,140.8H829v-1h0.8V140.8z M827,140.8h-0.8v-1h0.8V140.8z
+			 M824.2,140.8h-0.8v-1h0.8V140.8z M821.4,140.8h-0.8v-1h0.8V140.8z M818.6,140.8h-0.8v-1h0.8V140.8z M815.8,140.8H815v-1h0.8
+			V140.8z M813,140.8h-0.8v-1h0.8V140.8z M810.2,140.8h-0.8v-1h0.8V140.8z M807.4,140.8h-0.8v-1h0.8V140.8z M804.6,140.8h-0.8v-1
+			h0.8V140.8z M801.8,140.8H801v-1h0.8V140.8z M799,140.8h-0.8v-1h0.8V140.8z M796.2,140.8h-0.8v-1h0.8V140.8z M793.4,140.8h-0.8v-1
+			h0.8V140.8z M790.6,140.8h-0.8v-1h0.8V140.8z M787.8,140.8H787v-1h0.8V140.8z M785,140.8h-0.8v-1h0.8V140.8z M782.2,140.8h-0.8v-1
+			h0.8V140.8z M779.4,140.8h-0.8v-1h0.8V140.8z M776.6,140.8h-0.8v-1h0.8V140.8z M773.8,140.8H773v-1h0.8V140.8z M771,140.8h-0.8v-1
+			h0.8V140.8z M768.2,140.8h-0.8v-1h0.8V140.8z M765.4,140.8h-0.8v-1h0.8V140.8z M762.6,140.8h-0.8v-1h0.8V140.8z M759.8,140.8H759
+			v-1h0.8V140.8z M757,140.8h-0.8v-1h0.8V140.8z M754.2,140.8h-0.8v-1h0.8V140.8z M751.4,140.8h-0.8v-1h0.8V140.8z M748.6,140.8
+			h-0.8v-1h0.8V140.8z M745.8,140.8H745v-1h0.8V140.8z M743,140.8h-0.8v-1h0.8V140.8z M740.2,140.8h-0.8v-1h0.8V140.8z M737.4,140.8
+			h-0.8v-1h0.8V140.8z M734.6,140.8h-0.8v-1h0.8V140.8z M731.8,140.8H731v-1h0.8V140.8z M729,140.8h-0.8v-1h0.8V140.8z M726.2,140.8
+			h-0.8v-1h0.8V140.8z M723.4,140.8h-0.8v-1h0.8V140.8z M720.6,140.8h-0.8v-1h0.8V140.8z M717.8,140.8H717v-1h0.8V140.8z M715,140.8
+			h-0.8v-1h0.8V140.8z M712.2,140.8h-0.8v-1h0.8V140.8z M709.4,140.8h-0.8v-1h0.8V140.8z M706.6,140.8h-0.8v-1h0.8V140.8z
+			 M703.8,140.8H703v-1h0.8V140.8z M701,140.8h-0.8v-1h0.8V140.8z M698.2,140.8h-0.8v-1h0.8V140.8z M695.4,140.8h-0.8v-1h0.8V140.8z
+			 M692.6,140.8h-0.8v-1h0.8V140.8z M689.8,140.8H689v-1h0.8V140.8z M687,140.8h-0.8v-1h0.8V140.8z M684.2,140.8h-0.8v-1h0.8V140.8z
+			 M681.4,140.8h-0.8v-1h0.8V140.8z M678.6,140.8h-0.8v-1h0.8V140.8z M675.8,140.8H675v-1h0.8V140.8z M673,140.8h-0.8v-1h0.8V140.8z
+			 M670.2,140.8h-0.8v-1h0.8V140.8z M667.4,140.8h-0.8v-1h0.8V140.8z M664.6,140.8h-0.8v-1h0.8V140.8z M661.8,140.8H661v-1h0.8
+			V140.8z M659,140.8h-0.8v-1h0.8V140.8z M656.2,140.8h-0.8v-1h0.8V140.8z M653.4,140.8h-0.8v-1h0.8V140.8z M650.6,140.8h-0.8v-1
+			h0.8V140.8z M647.8,140.8H647v-1h0.8V140.8z M645,140.8h-0.8v-1h0.8V140.8z M642.2,140.8h-0.8v-1h0.8V140.8z M639.4,140.8h-0.8v-1
+			h0.8V140.8z M636.6,140.8h-0.8v-1h0.8V140.8z M633.8,140.8H633v-1h0.8V140.8z M631,140.8h-0.8v-1h0.8V140.8z M628.2,140.8h-0.8v-1
+			h0.8V140.8z M625.4,140.8h-0.8v-1h0.8V140.8z M622.6,140.8h-0.8v-1h0.8V140.8z M619.8,140.8H619v-1h0.8V140.8z M617,140.8h-0.8v-1
+			h0.8V140.8z M614.2,140.8h-0.8v-1h0.8V140.8z M611.4,140.8h-0.8v-1h0.8V140.8z M608.6,140.8h-0.8v-1h0.8V140.8z M605.8,140.8H605
+			v-1h0.8V140.8z M603,140.8h-0.8v-1h0.8V140.8z M600.2,140.8h-0.8v-1h0.8V140.8z M597.4,140.8h-0.8v-1h0.8V140.8z M594.6,140.8
+			h-0.8v-1h0.8V140.8z M591.8,140.8H591v-1h0.8V140.8z M589,140.8h-0.8v-1h0.8V140.8z M586.2,140.8h-0.8v-1h0.8V140.8z M583.4,140.8
+			h-0.8v-1h0.8V140.8z M580.6,140.8h-0.8v-1h0.8V140.8z M577.8,140.8H577v-1h0.8V140.8z M575,140.8h-0.8v-1h0.8V140.8z M572.2,140.8
+			h-0.8v-1h0.8V140.8z M569.4,140.8h-0.8v-1h0.8V140.8z M566.6,140.8h-0.8v-1h0.8V140.8z M563.8,140.8H563v-1h0.8V140.8z M561,140.8
+			h-0.8v-1h0.8V140.8z"/>
+		<g>
+			<g>
+				<path class="st0" d="M472.8,462.2c0,2.2-1.8,4-4,4h-289c-2.2,0-4-1.8-4-4v-318c0-2.2,1.8-4,4-4h289c2.2,0,4,1.8,4,4V462.2z"/>
+				<path class="st1" d="M472.8,462.2c0,2.2-1.8,4-4,4h-289c-2.2,0-4-1.8-4-4v-318c0-2.2,1.8-4,4-4h289c2.2,0,4,1.8,4,4V462.2z"/>
+				<path class="st2" d="M468.8,466.6h-289c-2.4,0-4.4-2-4.4-4.4v-318c0-2.4,2-4.4,4.4-4.4h289c2.4,0,4.4,2,4.4,4.4v318
+					C473.2,464.6,471.2,466.6,468.8,466.6z M179.8,140.6c-2,0-3.6,1.6-3.6,3.6v318c0,2,1.6,3.6,3.6,3.6h289c2,0,3.6-1.6,3.6-3.6
+					v-318c0-2-1.6-3.6-3.6-3.6H179.8z"/>
+			</g>
+			<path class="st3" d="M468.8,466.6h-0.1v-0.8h0.1c0.2,0,0.4,0,0.6-0.1l0.1,0.8C469.3,466.6,469,466.6,468.8,466.6z M466.7,466.6
+				h-0.8v-0.8h0.8V466.6z M463.9,466.6h-0.8v-0.8h0.8V466.6z M461.1,466.6h-0.8v-0.8h0.8V466.6z M458.3,466.6h-0.8v-0.8h0.8V466.6z
+				 M455.5,466.6h-0.8v-0.8h0.8V466.6z M452.7,466.6h-0.8v-0.8h0.8V466.6z M449.9,466.6h-0.8v-0.8h0.8V466.6z M447.1,466.6h-0.8
+				v-0.8h0.8V466.6z M444.3,466.6h-0.8v-0.8h0.8V466.6z M441.5,466.6h-0.8v-0.8h0.8V466.6z M438.7,466.6h-0.8v-0.8h0.8V466.6z
+				 M435.9,466.6h-0.8v-0.8h0.8V466.6z M433.1,466.6h-0.8v-0.8h0.8V466.6z M430.3,466.6h-0.8v-0.8h0.8V466.6z M427.5,466.6h-0.8
+				v-0.8h0.8V466.6z M424.7,466.6h-0.8v-0.8h0.8V466.6z M421.9,466.6h-0.8v-0.8h0.8V466.6z M419.1,466.6h-0.8v-0.8h0.8V466.6z
+				 M416.3,466.6h-0.8v-0.8h0.8V466.6z M413.5,466.6h-0.8v-0.8h0.8V466.6z M410.7,466.6h-0.8v-0.8h0.8V466.6z M407.9,466.6h-0.8
+				v-0.8h0.8V466.6z M405.1,466.6h-0.8v-0.8h0.8V466.6z M402.3,466.6h-0.8v-0.8h0.8V466.6z M399.5,466.6h-0.8v-0.8h0.8V466.6z
+				 M396.8,466.6H396v-0.8h0.8V466.6z M394,466.6h-0.8v-0.8h0.8V466.6z M391.2,466.6h-0.8v-0.8h0.8V466.6z M388.4,466.6h-0.8v-0.8
+				h0.8V466.6z M385.6,466.6h-0.8v-0.8h0.8V466.6z M382.8,466.6H382v-0.8h0.8V466.6z M380,466.6h-0.8v-0.8h0.8V466.6z M377.2,466.6
+				h-0.8v-0.8h0.8V466.6z M374.4,466.6h-0.8v-0.8h0.8V466.6z M371.6,466.6h-0.8v-0.8h0.8V466.6z M368.8,466.6H368v-0.8h0.8V466.6z
+				 M366,466.6h-0.8v-0.8h0.8V466.6z M363.2,466.6h-0.8v-0.8h0.8V466.6z M360.4,466.6h-0.8v-0.8h0.8V466.6z M357.6,466.6h-0.8v-0.8
+				h0.8V466.6z M354.8,466.6H354v-0.8h0.8V466.6z M352,466.6h-0.8v-0.8h0.8V466.6z M349.2,466.6h-0.8v-0.8h0.8V466.6z M346.4,466.6
+				h-0.8v-0.8h0.8V466.6z M343.6,466.6h-0.8v-0.8h0.8V466.6z M340.8,466.6H340v-0.8h0.8V466.6z M338,466.6h-0.8v-0.8h0.8V466.6z
+				 M335.2,466.6h-0.8v-0.8h0.8V466.6z M332.4,466.6h-0.8v-0.8h0.8V466.6z M329.6,466.6h-0.8v-0.8h0.8V466.6z M326.8,466.6H326v-0.8
+				h0.8V466.6z M324,466.6h-0.8v-0.8h0.8V466.6z M321.2,466.6h-0.8v-0.8h0.8V466.6z M318.4,466.6h-0.8v-0.8h0.8V466.6z M315.6,466.6
+				h-0.8v-0.8h0.8V466.6z M312.8,466.6H312v-0.8h0.8V466.6z M310,466.6h-0.8v-0.8h0.8V466.6z M307.2,466.6h-0.8v-0.8h0.8V466.6z
+				 M304.5,466.6h-0.8v-0.8h0.8V466.6z M301.7,466.6h-0.8v-0.8h0.8V466.6z M298.9,466.6h-0.8v-0.8h0.8V466.6z M296.1,466.6h-0.8
+				v-0.8h0.8V466.6z M293.3,466.6h-0.8v-0.8h0.8V466.6z M290.5,466.6h-0.8v-0.8h0.8V466.6z M287.7,466.6h-0.8v-0.8h0.8V466.6z
+				 M284.9,466.6h-0.8v-0.8h0.8V466.6z M282.1,466.6h-0.8v-0.8h0.8V466.6z M279.3,466.6h-0.8v-0.8h0.8V466.6z M276.5,466.6h-0.8
+				v-0.8h0.8V466.6z M273.7,466.6h-0.8v-0.8h0.8V466.6z M270.9,466.6h-0.8v-0.8h0.8V466.6z M268.1,466.6h-0.8v-0.8h0.8V466.6z
+				 M265.3,466.6h-0.8v-0.8h0.8V466.6z M262.5,466.6h-0.8v-0.8h0.8V466.6z M259.7,466.6h-0.8v-0.8h0.8V466.6z M256.9,466.6h-0.8
+				v-0.8h0.8V466.6z M254.1,466.6h-0.8v-0.8h0.8V466.6z M251.3,466.6h-0.8v-0.8h0.8V466.6z M248.5,466.6h-0.8v-0.8h0.8V466.6z
+				 M245.7,466.6h-0.8v-0.8h0.8V466.6z M242.9,466.6h-0.8v-0.8h0.8V466.6z M240.1,466.6h-0.8v-0.8h0.8V466.6z M237.3,466.6h-0.8
+				v-0.8h0.8V466.6z M234.5,466.6h-0.8v-0.8h0.8V466.6z M231.7,466.6h-0.8v-0.8h0.8V466.6z M228.9,466.6h-0.8v-0.8h0.8V466.6z
+				 M226.1,466.6h-0.8v-0.8h0.8V466.6z M223.3,466.6h-0.8v-0.8h0.8V466.6z M220.5,466.6h-0.8v-0.8h0.8V466.6z M217.7,466.6h-0.8
+				v-0.8h0.8V466.6z M214.9,466.6h-0.8v-0.8h0.8V466.6z M181.4,466.6h-0.8v-0.8h0.8V466.6z M178.5,466.4c-0.3-0.1-0.5-0.2-0.8-0.3
+				l0.4-0.7c0.2,0.1,0.4,0.2,0.7,0.3L178.5,466.4z M471.5,465.7L471,465c0.2-0.1,0.4-0.3,0.5-0.5l0.6,0.5
+				C472,465.3,471.7,465.5,471.5,465.7z M176.1,464.6c-0.2-0.2-0.3-0.5-0.4-0.8l0.7-0.3c0.1,0.2,0.2,0.4,0.3,0.6L176.1,464.6z
+				 M473.1,463.1l-0.8-0.2c0-0.2,0.1-0.5,0.1-0.7h0.8l0,0C473.2,462.5,473.2,462.8,473.1,463.1z M176.2,461.7h-0.8v-0.8h0.8V461.7z
+				 M473.2,460.2h-0.8v-0.8h0.8V460.2z M176.2,458.9h-0.8v-0.8h0.8V458.9z M473.2,457.4h-0.8v-0.8h0.8V457.4z M176.2,456.1h-0.8
+				v-0.8h0.8V456.1z M473.2,454.6h-0.8v-0.8h0.8V454.6z M176.2,453.3h-0.8v-0.8h0.8V453.3z M473.2,451.8h-0.8V451h0.8V451.8z
+				 M176.2,450.5h-0.8v-0.8h0.8V450.5z M473.2,449h-0.8v-0.8h0.8V449z M176.2,447.7h-0.8v-0.8h0.8V447.7z M473.2,446.2h-0.8v-0.8
+				h0.8V446.2z M176.2,444.9h-0.8v-0.8h0.8V444.9z M473.2,443.4h-0.8v-0.8h0.8V443.4z M176.2,442.1h-0.8v-0.8h0.8V442.1z
+				 M473.2,440.6h-0.8v-0.8h0.8V440.6z M176.2,439.3h-0.8v-0.8h0.8V439.3z M473.2,437.8h-0.8V437h0.8V437.8z M176.2,436.5h-0.8v-0.8
+				h0.8V436.5z M473.2,435h-0.8v-0.8h0.8V435z M176.2,433.7h-0.8v-0.8h0.8V433.7z M473.2,432.2h-0.8v-0.8h0.8V432.2z M176.2,430.9
+				h-0.8v-0.8h0.8V430.9z M473.2,429.4h-0.8v-0.8h0.8V429.4z M176.2,428.1h-0.8v-0.8h0.8V428.1z M473.2,426.6h-0.8v-0.8h0.8V426.6z
+				 M176.2,425.4h-0.8v-0.8h0.8V425.4z M473.2,423.8h-0.8V423h0.8V423.8z M176.2,422.6h-0.8v-0.8h0.8V422.6z M473.2,421h-0.8v-0.8
+				h0.8V421z M176.2,419.8h-0.8V419h0.8V419.8z M473.2,418.2h-0.8v-0.8h0.8V418.2z M176.2,417h-0.8v-0.8h0.8V417z M473.2,415.4h-0.8
+				v-0.8h0.8V415.4z M176.2,414.2h-0.8v-0.8h0.8V414.2z M473.2,412.6h-0.8v-0.8h0.8V412.6z M176.2,411.4h-0.8v-0.8h0.8V411.4z
+				 M473.2,409.8h-0.8V409h0.8V409.8z M176.2,408.6h-0.8v-0.8h0.8V408.6z M473.2,407h-0.8v-0.8h0.8V407z M176.2,405.8h-0.8V405h0.8
+				V405.8z M473.2,404.2h-0.8v-0.8h0.8V404.2z M176.2,403h-0.8v-0.8h0.8V403z M473.2,401.4h-0.8v-0.8h0.8V401.4z M176.2,400.2h-0.8
+				v-0.8h0.8V400.2z M473.2,398.6h-0.8v-0.8h0.8V398.6z M176.2,397.4h-0.8v-0.8h0.8V397.4z M473.2,395.9h-0.8v-0.8h0.8V395.9z
+				 M176.2,394.6h-0.8v-0.8h0.8V394.6z M473.2,393.1h-0.8v-0.8h0.8V393.1z M176.2,391.8h-0.8V391h0.8V391.8z M473.2,390.3h-0.8v-0.8
+				h0.8V390.3z M176.2,389h-0.8v-0.8h0.8V389z M473.2,387.5h-0.8v-0.8h0.8V387.5z M176.2,386.2h-0.8v-0.8h0.8V386.2z M473.2,384.7
+				h-0.8v-0.8h0.8V384.7z M176.2,383.4h-0.8v-0.8h0.8V383.4z M473.2,381.9h-0.8v-0.8h0.8V381.9z M176.2,380.6h-0.8v-0.8h0.8V380.6z
+				 M473.2,379.1h-0.8v-0.8h0.8V379.1z M176.2,377.8h-0.8V377h0.8V377.8z M473.2,376.3h-0.8v-0.8h0.8V376.3z M176.2,375h-0.8v-0.8
+				h0.8V375z M473.2,373.5h-0.8v-0.8h0.8V373.5z M176.2,372.2h-0.8v-0.8h0.8V372.2z M473.2,370.7h-0.8v-0.8h0.8V370.7z M176.2,369.4
+				h-0.8v-0.8h0.8V369.4z M473.2,367.9h-0.8v-0.8h0.8V367.9z M176.2,366.6h-0.8v-0.8h0.8V366.6z M473.2,365.1h-0.8v-0.8h0.8V365.1z
+				 M176.2,363.8h-0.8V363h0.8V363.8z M473.2,362.3h-0.8v-0.8h0.8V362.3z M176.2,361h-0.8v-0.8h0.8V361z M473.2,359.5h-0.8v-0.8h0.8
+				V359.5z M176.2,358.2h-0.8v-0.8h0.8V358.2z M473.2,356.7h-0.8v-0.8h0.8V356.7z M176.2,355.4h-0.8v-0.8h0.8V355.4z M473.2,353.9
+				h-0.8v-0.8h0.8V353.9z M176.2,352.6h-0.8v-0.8h0.8V352.6z M473.2,351.1h-0.8v-0.8h0.8V351.1z M176.2,349.8h-0.8V349h0.8V349.8z
+				 M473.2,348.3h-0.8v-0.8h0.8V348.3z M176.2,347h-0.8v-0.8h0.8V347z M473.2,345.5h-0.8v-0.8h0.8V345.5z M176.2,344.2h-0.8v-0.8
+				h0.8V344.2z M473.2,342.7h-0.8v-0.8h0.8V342.7z M176.2,341.4h-0.8v-0.8h0.8V341.4z M473.2,339.9h-0.8v-0.8h0.8V339.9z
+				 M176.2,338.6h-0.8v-0.8h0.8V338.6z M473.2,337.1h-0.8v-0.8h0.8V337.1z M176.2,335.8h-0.8V335h0.8V335.8z M473.2,334.3h-0.8v-0.8
+				h0.8V334.3z M176.2,333h-0.8v-0.8h0.8V333z M473.2,331.5h-0.8v-0.8h0.8V331.5z M176.2,330.3h-0.8v-0.8h0.8V330.3z M473.2,328.7
+				h-0.8v-0.8h0.8V328.7z M176.2,327.5h-0.8v-0.8h0.8V327.5z M473.2,325.9h-0.8v-0.8h0.8V325.9z M176.2,324.7h-0.8v-0.8h0.8V324.7z
+				 M473.2,323.1h-0.8v-0.8h0.8V323.1z M176.2,321.9h-0.8v-0.8h0.8V321.9z M473.2,320.3h-0.8v-0.8h0.8V320.3z M176.2,319.1h-0.8
+				v-0.8h0.8V319.1z M473.2,317.5h-0.8v-0.8h0.8V317.5z M176.2,316.3h-0.8v-0.8h0.8V316.3z M473.2,314.7h-0.8v-0.8h0.8V314.7z
+				 M176.2,313.5h-0.8v-0.8h0.8V313.5z M473.2,311.9h-0.8v-0.8h0.8V311.9z M176.2,310.7h-0.8v-0.8h0.8V310.7z M473.2,309.1h-0.8
+				v-0.8h0.8V309.1z M176.2,307.9h-0.8v-0.8h0.8V307.9z M473.2,306.3h-0.8v-0.8h0.8V306.3z M176.2,305.1h-0.8v-0.8h0.8V305.1z
+				 M473.2,303.6h-0.8v-0.8h0.8V303.6z M176.2,302.3h-0.8v-0.8h0.8V302.3z M473.2,300.8h-0.8V300h0.8V300.8z M176.2,299.5h-0.8v-0.8
+				h0.8V299.5z M473.2,298h-0.8v-0.8h0.8V298z M176.2,296.7h-0.8v-0.8h0.8V296.7z M473.2,295.2h-0.8v-0.8h0.8V295.2z M176.2,293.9
+				h-0.8v-0.8h0.8V293.9z M473.2,292.4h-0.8v-0.8h0.8V292.4z M176.2,291.1h-0.8v-0.8h0.8V291.1z M473.2,289.6h-0.8v-0.8h0.8V289.6z
+				 M176.2,288.3h-0.8v-0.8h0.8V288.3z M473.2,286.8h-0.8V286h0.8V286.8z M176.2,285.5h-0.8v-0.8h0.8V285.5z M473.2,284h-0.8v-0.8
+				h0.8V284z M176.2,282.7h-0.8v-0.8h0.8V282.7z M473.2,281.2h-0.8v-0.8h0.8V281.2z M176.2,279.9h-0.8v-0.8h0.8V279.9z M473.2,278.4
+				h-0.8v-0.8h0.8V278.4z M176.2,277.1h-0.8v-0.8h0.8V277.1z M473.2,275.6h-0.8v-0.8h0.8V275.6z M176.2,274.3h-0.8v-0.8h0.8V274.3z
+				 M473.2,272.8h-0.8V272h0.8V272.8z M176.2,271.5h-0.8v-0.8h0.8V271.5z M473.2,270h-0.8v-0.8h0.8V270z M176.2,268.7h-0.8v-0.8h0.8
+				V268.7z M473.2,267.2h-0.8v-0.8h0.8V267.2z M176.2,265.9h-0.8v-0.8h0.8V265.9z M473.2,264.4h-0.8v-0.8h0.8V264.4z M176.2,263.1
+				h-0.8v-0.8h0.8V263.1z M473.2,261.6h-0.8v-0.8h0.8V261.6z M176.2,260.3h-0.8v-0.8h0.8V260.3z M473.2,258.8h-0.8V258h0.8V258.8z
+				 M176.2,257.5h-0.8v-0.8h0.8V257.5z M473.2,256h-0.8v-0.8h0.8V256z M176.2,254.7h-0.8v-0.8h0.8V254.7z M473.2,253.2h-0.8v-0.8
+				h0.8V253.2z M176.2,251.9h-0.8v-0.8h0.8V251.9z M473.2,250.4h-0.8v-0.8h0.8V250.4z M176.2,249.1h-0.8v-0.8h0.8V249.1z
+				 M473.2,247.6h-0.8v-0.8h0.8V247.6z M176.2,246.3h-0.8v-0.8h0.8V246.3z M473.2,244.8h-0.8V244h0.8V244.8z M176.2,243.5h-0.8v-0.8
+				h0.8V243.5z M473.2,242h-0.8v-0.8h0.8V242z M176.2,240.7h-0.8v-0.8h0.8V240.7z M473.2,239.2h-0.8v-0.8h0.8V239.2z M176.2,238
+				h-0.8v-0.8h0.8V238z M473.2,236.4h-0.8v-0.8h0.8V236.4z M176.2,235.2h-0.8v-0.8h0.8V235.2z M473.2,233.6h-0.8v-0.8h0.8V233.6z
+				 M176.2,232.4h-0.8v-0.8h0.8V232.4z M473.2,230.8h-0.8V230h0.8V230.8z M176.2,229.6h-0.8v-0.8h0.8V229.6z M473.2,228h-0.8v-0.8
+				h0.8V228z M176.2,226.8h-0.8V226h0.8V226.8z M473.2,225.2h-0.8v-0.8h0.8V225.2z M176.2,224h-0.8v-0.8h0.8V224z M473.2,222.4h-0.8
+				v-0.8h0.8V222.4z M176.2,221.2h-0.8v-0.8h0.8V221.2z M473.2,219.6h-0.8v-0.8h0.8V219.6z M176.2,218.4h-0.8v-0.8h0.8V218.4z
+				 M473.2,216.8h-0.8V216h0.8V216.8z M176.2,215.6h-0.8v-0.8h0.8V215.6z M473.2,214h-0.8v-0.8h0.8V214z M176.2,212.8h-0.8V212h0.8
+				V212.8z M473.2,211.2h-0.8v-0.8h0.8V211.2z M176.2,210h-0.8v-0.8h0.8V210z M473.2,208.5h-0.8v-0.8h0.8V208.5z M176.2,207.2h-0.8
+				v-0.8h0.8V207.2z M473.2,205.7h-0.8v-0.8h0.8V205.7z M176.2,204.4h-0.8v-0.8h0.8V204.4z M473.2,202.9h-0.8v-0.8h0.8V202.9z
+				 M176.2,201.6h-0.8v-0.8h0.8V201.6z M473.2,200.1h-0.8v-0.8h0.8V200.1z M176.2,198.8h-0.8V198h0.8V198.8z M473.2,197.3h-0.8v-0.8
+				h0.8V197.3z M176.2,196h-0.8v-0.8h0.8V196z M473.2,194.5h-0.8v-0.8h0.8V194.5z M176.2,193.2h-0.8v-0.8h0.8V193.2z M473.2,191.7
+				h-0.8v-0.8h0.8V191.7z M176.2,190.4h-0.8v-0.8h0.8V190.4z M473.2,188.9h-0.8v-0.8h0.8V188.9z M176.2,187.6h-0.8v-0.8h0.8V187.6z
+				 M473.2,186.1h-0.8v-0.8h0.8V186.1z M176.2,184.8h-0.8V184h0.8V184.8z M473.2,183.3h-0.8v-0.8h0.8V183.3z M176.2,182h-0.8v-0.8
+				h0.8V182z M473.2,180.5h-0.8v-0.8h0.8V180.5z M176.2,179.2h-0.8v-0.8h0.8V179.2z M473.2,177.7h-0.8v-0.8h0.8V177.7z M176.2,176.4
+				h-0.8v-0.8h0.8V176.4z M473.2,174.9h-0.8v-0.8h0.8V174.9z M176.2,173.6h-0.8v-0.8h0.8V173.6z M473.2,172.1h-0.8v-0.8h0.8V172.1z
+				 M176.2,170.8h-0.8V170h0.8V170.8z M473.2,169.3h-0.8v-0.8h0.8V169.3z M176.2,168h-0.8v-0.8h0.8V168z M473.2,166.5h-0.8v-0.8h0.8
+				V166.5z M176.2,165.2h-0.8v-0.8h0.8V165.2z M473.2,163.7h-0.8v-0.8h0.8V163.7z M176.2,162.4h-0.8v-0.8h0.8V162.4z M473.2,160.9
+				h-0.8v-0.8h0.8V160.9z M176.2,159.6h-0.8v-0.8h0.8V159.6z M473.2,158.1h-0.8v-0.8h0.8V158.1z M176.2,156.8h-0.8V156h0.8V156.8z
+				 M473.2,155.3h-0.8v-0.8h0.8V155.3z M176.2,154h-0.8v-0.8h0.8V154z M473.2,152.5h-0.8v-0.8h0.8V152.5z M176.2,151.2h-0.8v-0.8
+				h0.8V151.2z M473.2,149.7h-0.8v-0.8h0.8V149.7z M176.2,148.4h-0.8v-0.8h0.8V148.4z M473.2,146.9h-0.8v-0.8h0.8V146.9z
+				 M176.2,145.6h-0.8v-0.8h0.8V145.6z M472.4,144.1c0-0.2,0-0.5-0.1-0.7l0.8-0.2c0.1,0.3,0.1,0.6,0.1,0.9H472.4z M176.4,143
+				l-0.8-0.3c0.1-0.3,0.2-0.5,0.4-0.8l0.7,0.4C176.6,142.6,176.5,142.8,176.4,143z M471.5,141.8c-0.2-0.2-0.3-0.3-0.5-0.5l0.5-0.6
+				c0.2,0.2,0.4,0.4,0.6,0.6L471.5,141.8z M178,141.1l-0.4-0.7c0.3-0.1,0.5-0.3,0.8-0.4l0.3,0.8C178.4,140.9,178.2,141,178,141.1z
+				 M469.3,140.7c-0.2,0-0.3,0-0.5,0h-0.2v-0.8h0.2c0.2,0,0.4,0,0.6,0L469.3,140.7z M466.6,140.6h-0.8v-0.8h0.8V140.6z M463.8,140.6
+				H463v-0.8h0.8V140.6z M461,140.6h-0.8v-0.8h0.8V140.6z M458.2,140.6h-0.8v-0.8h0.8V140.6z M455.4,140.6h-0.8v-0.8h0.8V140.6z
+				 M452.6,140.6h-0.8v-0.8h0.8V140.6z M449.8,140.6H449v-0.8h0.8V140.6z M447,140.6h-0.8v-0.8h0.8V140.6z M444.2,140.6h-0.8v-0.8
+				h0.8V140.6z M441.4,140.6h-0.8v-0.8h0.8V140.6z M438.6,140.6h-0.8v-0.8h0.8V140.6z M435.8,140.6H435v-0.8h0.8V140.6z M433,140.6
+				h-0.8v-0.8h0.8V140.6z M430.2,140.6h-0.8v-0.8h0.8V140.6z M427.4,140.6h-0.8v-0.8h0.8V140.6z M424.6,140.6h-0.8v-0.8h0.8V140.6z
+				 M421.8,140.6H421v-0.8h0.8V140.6z M419,140.6h-0.8v-0.8h0.8V140.6z M416.2,140.6h-0.8v-0.8h0.8V140.6z M413.4,140.6h-0.8v-0.8
+				h0.8V140.6z M410.6,140.6h-0.8v-0.8h0.8V140.6z M407.8,140.6H407v-0.8h0.8V140.6z M405,140.6h-0.8v-0.8h0.8V140.6z M402.2,140.6
+				h-0.8v-0.8h0.8V140.6z M399.4,140.6h-0.8v-0.8h0.8V140.6z M396.6,140.6h-0.8v-0.8h0.8V140.6z M393.8,140.6H393v-0.8h0.8V140.6z
+				 M391.1,140.6h-0.8v-0.8h0.8V140.6z M388.3,140.6h-0.8v-0.8h0.8V140.6z M385.5,140.6h-0.8v-0.8h0.8V140.6z M382.7,140.6h-0.8
+				v-0.8h0.8V140.6z M379.9,140.6h-0.8v-0.8h0.8V140.6z M377.1,140.6h-0.8v-0.8h0.8V140.6z M374.3,140.6h-0.8v-0.8h0.8V140.6z
+				 M371.5,140.6h-0.8v-0.8h0.8V140.6z M368.7,140.6h-0.8v-0.8h0.8V140.6z M365.9,140.6h-0.8v-0.8h0.8V140.6z M363.1,140.6h-0.8
+				v-0.8h0.8V140.6z M360.3,140.6h-0.8v-0.8h0.8V140.6z M357.5,140.6h-0.8v-0.8h0.8V140.6z M354.7,140.6h-0.8v-0.8h0.8V140.6z
+				 M351.9,140.6h-0.8v-0.8h0.8V140.6z M349.1,140.6h-0.8v-0.8h0.8V140.6z M346.3,140.6h-0.8v-0.8h0.8V140.6z M343.5,140.6h-0.8
+				v-0.8h0.8V140.6z M340.7,140.6h-0.8v-0.8h0.8V140.6z M337.9,140.6h-0.8v-0.8h0.8V140.6z M335.1,140.6h-0.8v-0.8h0.8V140.6z
+				 M332.3,140.6h-0.8v-0.8h0.8V140.6z M329.5,140.6h-0.8v-0.8h0.8V140.6z M326.7,140.6h-0.8v-0.8h0.8V140.6z M323.9,140.6h-0.8
+				v-0.8h0.8V140.6z M321.1,140.6h-0.8v-0.8h0.8V140.6z M318.3,140.6h-0.8v-0.8h0.8V140.6z M315.5,140.6h-0.8v-0.8h0.8V140.6z
+				 M312.7,140.6h-0.8v-0.8h0.8V140.6z M309.9,140.6h-0.8v-0.8h0.8V140.6z M307.1,140.6h-0.8v-0.8h0.8V140.6z M304.3,140.6h-0.8
+				v-0.8h0.8V140.6z M301.5,140.6h-0.8v-0.8h0.8V140.6z M298.7,140.6H298v-0.8h0.8L298.7,140.6L298.7,140.6z M296,140.6h-0.8v-0.8
+				h0.8V140.6z M293.2,140.6h-0.8v-0.8h0.8V140.6z M290.4,140.6h-0.8v-0.8h0.8V140.6z M287.6,140.6h-0.8v-0.8h0.8V140.6z
+				 M284.8,140.6H284v-0.8h0.8V140.6z M282,140.6h-0.8v-0.8h0.8V140.6z M279.2,140.6h-0.8v-0.8h0.8V140.6z M276.4,140.6h-0.8v-0.8
+				h0.8V140.6z M273.6,140.6h-0.8v-0.8h0.8V140.6z M270.8,140.6H270v-0.8h0.8V140.6z M268,140.6h-0.8v-0.8h0.8V140.6z M265.2,140.6
+				h-0.8v-0.8h0.8V140.6z M262.4,140.6h-0.8v-0.8h0.8V140.6z M259.6,140.6h-0.8v-0.8h0.8V140.6z M256.8,140.6H256v-0.8h0.8V140.6z
+				 M254,140.6h-0.8v-0.8h0.8V140.6z M251.2,140.6h-0.8v-0.8h0.8V140.6z M248.4,140.6h-0.8v-0.8h0.8V140.6z M245.6,140.6h-0.8v-0.8
+				h0.8V140.6z M242.8,140.6H242v-0.8h0.8V140.6z M240,140.6h-0.8v-0.8h0.8V140.6z M237.2,140.6h-0.8v-0.8h0.8V140.6z M234.4,140.6
+				h-0.8v-0.8h0.8V140.6z M231.6,140.6h-0.8v-0.8h0.8V140.6z M228.8,140.6H228v-0.8h0.8V140.6z M226,140.6h-0.8v-0.8h0.8V140.6z
+				 M223.2,140.6h-0.8v-0.8h0.8V140.6z M220.4,140.6h-0.8v-0.8h0.8V140.6z M217.6,140.6h-0.8v-0.8h0.8V140.6z M214.8,140.6H214v-0.8
+				h0.8V140.6z M212,140.6h-0.8v-0.8h0.8V140.6z M209.2,140.6h-0.8v-0.8h0.8V140.6z M206.4,140.6h-0.8v-0.8h0.8V140.6z M203.7,140.6
+				h-0.8v-0.8h0.8V140.6z M200.9,140.6h-0.8v-0.8h0.8V140.6z M198.1,140.6h-0.8v-0.8h0.8V140.6z M195.3,140.6h-0.8v-0.8h0.8V140.6z
+				 M192.5,140.6h-0.8v-0.8h0.8V140.6z M189.7,140.6h-0.8v-0.8h0.8V140.6z M186.9,140.6h-0.8v-0.8h0.8V140.6z M184.1,140.6h-0.8
+				v-0.8h0.8V140.6z M181.3,140.6h-0.8v-0.8h0.8V140.6z"/>
+		</g>
+		<g>
+			<rect x="437.8" y="6.5" class="st0" width="157.8" height="53"/>
+			<rect x="437.8" y="6.5" class="st4" width="157.8" height="53"/>
+			<path class="st5" d="M595.4,6.6v52.7H437.9V6.6H595.4 M595.6,6.3h-158v53.2h158V6.3L595.6,6.3z"/>
+		</g>
+		<g>
+			<rect x="921.4" y="6.5" class="st0" width="197.8" height="114.1"/>
+			<rect x="921.4" y="6.5" class="st4" width="197.8" height="114.1"/>
+			<path class="st5" d="M1119,6.6v113.9H921.5V6.6H1119 M1119.2,6.3h-198v114.4h198V6.3L1119.2,6.3z"/>
+		</g>
+		<g>
+			<rect x="771.8" y="6.5" class="st0" width="136.2" height="114.4"/>
+			<rect x="771.8" y="6.5" class="st4" width="136.2" height="114.4"/>
+			<path class="st5" d="M907.8,6.6v114.1H771.9V6.6H907.8 M908,6.3H771.6v114.6H908V6.3L908,6.3z"/>
+		</g>
+		<g>
+			<rect x="622.2" y="6.5" class="st0" width="136.2" height="114.4"/>
+			<rect x="622.2" y="6.5" class="st4" width="136.2" height="114.4"/>
+			<path class="st5" d="M758.2,6.6v114.1H622.3V6.6H758.2 M758.4,6.3H622v114.6h136.4V6.3L758.4,6.3z"/>
+		</g>
+		<g>
+			<rect x="126.8" y="150.8" transform="matrix(0.5 -0.866 0.866 0.5 -65.1201 191.6776)" class="st6" width="13.2" height="2.8"/>
+			<rect x="141.1" y="145.8" transform="matrix(0.866 -0.5 0.5 0.866 -57.0954 91.6634)" class="st6" width="2.8" height="13.2"/>
+			<rect x="131.2" y="158.8" class="st7" width="13.2" height="2.8"/>
+			
+				<linearGradient id="SVGID_1_" gradientUnits="userSpaceOnUse" x1="133.8307" y1="-648.625" x2="138.5701" y2="-643.8856" gradientTransform="matrix(1 -1.396263e-03 1.396263e-03 1 2.7866 790.5302)">
+				<stop  offset="0" style="stop-color:#86D633"/>
+				<stop  offset="1" style="stop-color:#5E9624"/>
+			</linearGradient>
+			<circle class="st8" cx="138.1" cy="144.1" r="3.4"/>
+			
+				<linearGradient id="SVGID_00000000187490938243452320000008912111104070471563_" gradientUnits="userSpaceOnUse" x1="144.3445" y1="-634.1787" x2="149.0769" y2="-629.4324" gradientTransform="matrix(1 0 0 1 0 791.7148)">
+				<stop  offset="0" style="stop-color:#86D633"/>
+				<stop  offset="1" style="stop-color:#5E9624"/>
+			</linearGradient>
+			<circle style="fill:url(#SVGID_00000000187490938243452320000008912111104070471563_);" cx="147.2" cy="160.4" r="3.4"/>
+			
+				<linearGradient id="SVGID_00000089557541226887537140000015089911590135218845_" gradientUnits="userSpaceOnUse" x1="125.966" y1="-634.1489" x2="130.6939" y2="-629.4209" gradientTransform="matrix(1 0 0 1 0 791.7148)">
+				<stop  offset="0" style="stop-color:#86D633"/>
+				<stop  offset="1" style="stop-color:#5E9624"/>
+			</linearGradient>
+			<circle style="fill:url(#SVGID_00000089557541226887537140000015089911590135218845_);" cx="128.8" cy="160.4" r="3.4"/>
+		</g>
+		<g>
+			<g>
+				<rect x="534.7" y="406" class="st11" width="16.6" height="1"/>
+				<g>
+					<polygon class="st11" points="550.2,402.8 556.7,406.5 550.2,410.2 					"/>
+				</g>
+			</g>
+		</g>
+		<g>
+			<path class="st12" d="M208.5,432.6c0,5.9-7.2,10.7-8.7,11.6c-0.2,0.1-0.4,0.1-0.6,0c-1.6-1-8.7-5.7-8.7-11.6v-7.1
+				c0-0.3,0.2-0.6,0.6-0.6c5.6-0.1,4.3-2.6,8.4-2.6c4.2,0,2.9,2.4,8.4,2.6c0.3,0,0.6,0.3,0.6,0.6V432.6z"/>
+			<path class="st13" d="M207.8,432.7c0,5.4-6.6,9.8-8,10.7c-0.2,0.1-0.4,0.1-0.5,0c-1.4-0.9-8-5.3-8-10.7v-6.5
+				c0-0.3,0.2-0.5,0.5-0.5c5.1-0.1,3.9-2.4,7.7-2.4s2.7,2.2,7.7,2.4c0.3,0,0.5,0.2,0.5,0.5v6.5H207.8z"/>
+			
+				<linearGradient id="SVGID_00000160886280609935653350000005542927525750062754_" gradientUnits="userSpaceOnUse" x1="199.5" y1="-368.4709" x2="199.5" y2="-348.3015" gradientTransform="matrix(1 0 0 1 0 791.7148)">
+				<stop  offset="0" style="stop-color:#5EA0EF"/>
+				<stop  offset="0.18" style="stop-color:#559CEC"/>
+				<stop  offset="0.47" style="stop-color:#3C91E5"/>
+				<stop  offset="0.84" style="stop-color:#1380DA"/>
+				<stop  offset="1" style="stop-color:#0078D4"/>
+			</linearGradient>
+			<path style="fill:url(#SVGID_00000160886280609935653350000005542927525750062754_);" d="M199.5,433.3v-10.1
+				c3.8,0,2.7,2.2,7.7,2.4c0.3,0,0.5,0.2,0.5,0.5v6.5c0,0.2,0,0.4,0,0.7H199.5z M199.5,433.3h-8.2c0.5,5.1,6.6,9.2,7.9,10
+				c0.1,0,0.1,0.1,0.2,0.1l0,0v-10.1H199.5z"/>
+			<path class="st15" d="M191.8,425.6c5.1-0.1,3.9-2.4,7.7-2.4v10.1h-8.2c0-0.2,0-0.4,0-0.7v-6.5
+				C191.3,425.9,191.5,425.6,191.8,425.6z"/>
+			<path class="st15" d="M207.7,433.3h-8.2v10.1l0,0c0.1,0,0.2,0,0.2-0.1C201.2,442.5,207.3,438.4,207.7,433.3z"/>
+		</g>
+		<g>
+			
+				<linearGradient id="SVGID_00000028291076717768269360000016434484944893045155_" gradientUnits="userSpaceOnUse" x1="199.7836" y1="-326.103" x2="202.1524" y2="-323.7342" gradientTransform="matrix(1 -1.396263e-03 1.396263e-03 1 2.7866 791.5001)">
+				<stop  offset="0" style="stop-color:#86D633"/>
+				<stop  offset="0.24" style="stop-color:#83D232"/>
+				<stop  offset="0.5" style="stop-color:#7CC52F"/>
+				<stop  offset="0.76" style="stop-color:#6FB02A"/>
+				<stop  offset="1" style="stop-color:#5E9624"/>
+			</linearGradient>
+			<circle style="fill:url(#SVGID_00000028291076717768269360000016434484944893045155_);" cx="203.3" cy="466.3" r="1.7"/>
+			
+				<linearGradient id="SVGID_00000072973511465357596710000004207500016219704500_" gradientUnits="userSpaceOnUse" x1="194.4196" y1="-326.0817" x2="196.7732" y2="-323.7135" gradientTransform="matrix(1 -1.396263e-03 1.396263e-03 1 2.7866 791.5001)">
+				<stop  offset="0" style="stop-color:#86D633"/>
+				<stop  offset="0.24" style="stop-color:#83D232"/>
+				<stop  offset="0.5" style="stop-color:#7CC52F"/>
+				<stop  offset="0.76" style="stop-color:#6FB02A"/>
+				<stop  offset="1" style="stop-color:#5E9624"/>
+			</linearGradient>
+			<circle style="fill:url(#SVGID_00000072973511465357596710000004207500016219704500_);" cx="197.9" cy="466.3" r="1.7"/>
+			
+				<linearGradient id="SVGID_00000142885956740325833730000017177284219813519807_" gradientUnits="userSpaceOnUse" x1="189.1021" y1="-326.1066" x2="191.4557" y2="-323.7386" gradientTransform="matrix(1 -1.396263e-03 1.396263e-03 1 2.7866 791.5001)">
+				<stop  offset="0" style="stop-color:#86D633"/>
+				<stop  offset="0.24" style="stop-color:#83D232"/>
+				<stop  offset="0.5" style="stop-color:#7CC52F"/>
+				<stop  offset="0.76" style="stop-color:#6FB02A"/>
+				<stop  offset="1" style="stop-color:#5E9624"/>
+			</linearGradient>
+			<circle style="fill:url(#SVGID_00000142885956740325833730000017177284219813519807_);" cx="192.6" cy="466.3" r="1.7"/>
+			<path class="st15" d="M193.8,473l-1,1c-0.2,0.2-0.4,0.2-0.6,0l0,0l-7.1-7.1c-0.3-0.3-0.3-0.9,0-1.2l0,0l1-1l0,0l7.7,7.7
+				C194,472.6,194,472.8,193.8,473L193.8,473z"/>
+			<path class="st19" d="M192.7,458.7l1,1c0.2,0.2,0.2,0.4,0,0.6l-7.6,7.6l0,0l-1-1c-0.3-0.3-0.3-0.9,0-1.2l0,0l7-7
+				C192.3,458.5,192.5,458.5,192.7,458.7z"/>
+			<path class="st15" d="M209.7,464.7l1,1c0.3,0.3,0.3,0.9,0,1.2l0,0l-7.1,7.1c-0.2,0.2-0.4,0.2-0.6,0l0,0l-1-1
+				c-0.2-0.2-0.2-0.4,0-0.6l0,0L209.7,464.7L209.7,464.7z"/>
+			<path class="st19" d="M210.6,466.9l-1,1l0,0l-7.6-7.6c-0.2-0.2-0.2-0.4,0-0.6l0,0l1-1c0.2-0.2,0.4-0.2,0.6,0l0,0l7,7
+				C211,466,211,466.5,210.6,466.9L210.6,466.9L210.6,466.9z"/>
+		</g>
+		<g>
+			
+				<linearGradient id="SVGID_00000060730483245202692970000007675694704337716667_" gradientUnits="userSpaceOnUse" x1="516.8526" y1="-383.872" x2="519.2214" y2="-381.5031" gradientTransform="matrix(1 -1.396263e-03 1.396263e-03 1 2.7866 791.5001)">
+				<stop  offset="0" style="stop-color:#86D633"/>
+				<stop  offset="0.24" style="stop-color:#83D232"/>
+				<stop  offset="0.5" style="stop-color:#7CC52F"/>
+				<stop  offset="0.76" style="stop-color:#6FB02A"/>
+				<stop  offset="1" style="stop-color:#5E9624"/>
+			</linearGradient>
+			<circle style="fill:url(#SVGID_00000060730483245202692970000007675694704337716667_);" cx="520.3" cy="408.1" r="1.7"/>
+			
+				<linearGradient id="SVGID_00000111908865861548187520000017494648738944426679_" gradientUnits="userSpaceOnUse" x1="511.4886" y1="-383.8506" x2="513.8423" y2="-381.4825" gradientTransform="matrix(1 -1.396263e-03 1.396263e-03 1 2.7866 791.5001)">
+				<stop  offset="0" style="stop-color:#86D633"/>
+				<stop  offset="0.24" style="stop-color:#83D232"/>
+				<stop  offset="0.5" style="stop-color:#7CC52F"/>
+				<stop  offset="0.76" style="stop-color:#6FB02A"/>
+				<stop  offset="1" style="stop-color:#5E9624"/>
+			</linearGradient>
+			<circle style="fill:url(#SVGID_00000111908865861548187520000017494648738944426679_);" cx="514.9" cy="408.1" r="1.7"/>
+			
+				<linearGradient id="SVGID_00000092436892703092179810000007600799561639942039_" gradientUnits="userSpaceOnUse" x1="506.1711" y1="-383.8756" x2="508.5247" y2="-381.5075" gradientTransform="matrix(1 -1.396263e-03 1.396263e-03 1 2.7866 791.5001)">
+				<stop  offset="0" style="stop-color:#86D633"/>
+				<stop  offset="0.24" style="stop-color:#83D232"/>
+				<stop  offset="0.5" style="stop-color:#7CC52F"/>
+				<stop  offset="0.76" style="stop-color:#6FB02A"/>
+				<stop  offset="1" style="stop-color:#5E9624"/>
+			</linearGradient>
+			<circle style="fill:url(#SVGID_00000092436892703092179810000007600799561639942039_);" cx="509.6" cy="408.1" r="1.7"/>
+			<path class="st15" d="M510.8,414.8l-1,1c-0.2,0.2-0.4,0.2-0.6,0l0,0l-7.1-7.1c-0.3-0.3-0.3-0.9,0-1.2l0,0l1-1l0,0l7.7,7.7
+				C511,414.4,511,414.6,510.8,414.8L510.8,414.8z"/>
+			<path class="st19" d="M509.7,400.5l1,1c0.2,0.2,0.2,0.4,0,0.6l-7.6,7.6l0,0l-1-1c-0.3-0.3-0.3-0.9,0-1.2l0,0l7-7
+				C509.2,400.3,509.5,400.3,509.7,400.5z"/>
+			<path class="st15" d="M526.6,406.5l1,1c0.3,0.3,0.3,0.9,0,1.2l0,0l-7.1,7.1c-0.2,0.2-0.4,0.2-0.6,0l0,0l-1-1
+				c-0.2-0.2-0.2-0.4,0-0.6l0,0L526.6,406.5L526.6,406.5z"/>
+			<path class="st19" d="M527.6,408.7l-1,1l0,0l-7.6-7.6c-0.2-0.2-0.2-0.4,0-0.6l0,0l1-1c0.2-0.2,0.4-0.2,0.6,0l0,0l7,7
+				C527.9,407.8,527.9,408.3,527.6,408.7L527.6,408.7L527.6,408.7z"/>
+		</g>
+		<g>
+			
+				<linearGradient id="SVGID_00000091726909683237077600000003738466385106614202_" gradientUnits="userSpaceOnUse" x1="580.1114" y1="-325.5435" x2="582.48" y2="-323.1747" gradientTransform="matrix(1 -1.396263e-03 1.396263e-03 1 2.7866 791.5001)">
+				<stop  offset="0" style="stop-color:#86D633"/>
+				<stop  offset="0.24" style="stop-color:#83D232"/>
+				<stop  offset="0.5" style="stop-color:#7CC52F"/>
+				<stop  offset="0.76" style="stop-color:#6FB02A"/>
+				<stop  offset="1" style="stop-color:#5E9624"/>
+			</linearGradient>
+			<circle style="fill:url(#SVGID_00000091726909683237077600000003738466385106614202_);" cx="583.6" cy="466.3" r="1.7"/>
+			
+				<linearGradient id="SVGID_00000023279292154197907960000002242211277530541234_" gradientUnits="userSpaceOnUse" x1="574.7972" y1="-325.5721" x2="577.1509" y2="-323.2041" gradientTransform="matrix(1 -1.396263e-03 1.396263e-03 1 2.7866 791.5001)">
+				<stop  offset="0" style="stop-color:#86D633"/>
+				<stop  offset="0.24" style="stop-color:#83D232"/>
+				<stop  offset="0.5" style="stop-color:#7CC52F"/>
+				<stop  offset="0.76" style="stop-color:#6FB02A"/>
+				<stop  offset="1" style="stop-color:#5E9624"/>
+			</linearGradient>
+			<circle style="fill:url(#SVGID_00000023279292154197907960000002242211277530541234_);" cx="578.3" cy="466.3" r="1.7"/>
+			
+				<linearGradient id="SVGID_00000013176007890877859840000002852885110204869013_" gradientUnits="userSpaceOnUse" x1="569.4799" y1="-325.5972" x2="571.8334" y2="-323.229" gradientTransform="matrix(1 -1.396263e-03 1.396263e-03 1 2.7866 791.5001)">
+				<stop  offset="0" style="stop-color:#86D633"/>
+				<stop  offset="0.24" style="stop-color:#83D232"/>
+				<stop  offset="0.5" style="stop-color:#7CC52F"/>
+				<stop  offset="0.76" style="stop-color:#6FB02A"/>
+				<stop  offset="1" style="stop-color:#5E9624"/>
+			</linearGradient>
+			<circle style="fill:url(#SVGID_00000013176007890877859840000002852885110204869013_);" cx="573" cy="466.3" r="1.7"/>
+			<path class="st15" d="M574.2,473l-1,1c-0.2,0.2-0.4,0.2-0.6,0l0,0l-7.1-7.1c-0.3-0.3-0.3-0.9,0-1.2l0,0l1-1l0,0l7.7,7.7
+				C574.3,472.6,574.3,472.8,574.2,473L574.2,473z"/>
+			<path class="st19" d="M573.1,458.7l1,1c0.2,0.2,0.2,0.4,0,0.6l-7.6,7.6l0,0l-1-1c-0.3-0.3-0.3-0.9,0-1.2l0,0l7-7
+				C572.6,458.5,572.9,458.5,573.1,458.7z"/>
+			<path class="st15" d="M590,464.7l1,1c0.3,0.3,0.3,0.9,0,1.2l0,0l-7.1,7.1c-0.2,0.2-0.4,0.2-0.6,0l0,0l-1-1
+				c-0.2-0.2-0.2-0.4,0-0.6l0,0L590,464.7L590,464.7z"/>
+			<path class="st19" d="M591,466.9l-1,1l0,0l-7.6-7.6c-0.2-0.2-0.2-0.4,0-0.6l0,0l1-1c0.2-0.2,0.4-0.2,0.6,0l0,0l7,7
+				C591.3,466,591.3,466.5,591,466.9L591,466.9L591,466.9z"/>
+		</g>
+		<g>
+			<rect x="571.2" y="154.3" class="st0" width="386.6" height="124"/>
+			<rect x="571.2" y="154.3" class="st26" width="386.6" height="124"/>
+		</g>
+		<g>
+			<rect x="194.9" y="290.4" class="st0" width="117.5" height="124.1"/>
+			<rect x="194.9" y="290.4" class="st26" width="117.5" height="124.1"/>
+		</g>
+		<g>
+			<rect x="334.1" y="290.4" class="st0" width="117.5" height="124.1"/>
+			<rect x="334.1" y="290.4" class="st26" width="117.5" height="124.1"/>
+		</g>
+		<g>
+			
+				<linearGradient id="SVGID_00000014621242285214071440000012400832607825518722_" gradientUnits="userSpaceOnUse" x1="253.7035" y1="-431.2095" x2="253.7035" y2="-459.403" gradientTransform="matrix(1 0 0 1 -3.547359e-03 791.7134)">
+				<stop  offset="0" style="stop-color:#258378"/>
+				<stop  offset="0.42" style="stop-color:#49A498"/>
+				<stop  offset="0.78" style="stop-color:#60BBAD"/>
+				<stop  offset="1" style="stop-color:#68C2B5"/>
+			</linearGradient>
+			<path style="fill:url(#SVGID_00000014621242285214071440000012400832607825518722_);" d="M239,344.3l14-14c0.4-0.4,1-0.4,1.4,0
+				l14,14c0.4,0.4,0.4,1,0,1.4l-14,14c-0.4,0.4-1,0.4-1.4,0l-14-14C238.6,345.3,238.6,344.7,239,344.3z"/>
+			<path class="st0" d="M250.3,337.4l3.3-3.3c0.1-0.1,0.2-0.1,0.2,0l3.4,3.3c0.1,0.1,0.1,0.2,0,0.2c0,0-0.1,0.1-0.2,0.1h-2
+				c-0.1,0-0.2,0.1-0.2,0.2l0,0v4.3c0,0.1-0.1,0.2-0.2,0.2l0,0h-2.1c-0.1,0-0.2-0.1-0.2-0.1l0,0V338c0-0.1-0.1-0.2-0.2-0.2h-2
+				C250.3,337.6,250.2,337.5,250.3,337.4C250.2,337.4,250.3,337.4,250.3,337.4z M257.2,352.6l-3.4,3.3c-0.1,0.1-0.2,0.1-0.2,0
+				l-3.3-3.3c-0.1-0.1,0-0.2,0-0.2h0.1h2c0.1,0,0.2-0.1,0.2-0.2v-4.3c0-0.1,0.1-0.2,0.2-0.2l0,0h2.1c0.1,0,0.2,0.1,0.2,0.2l0,0v4.3
+				c0,0.1,0.1,0.2,0.2,0.2l0,0h1.9c0.1-0.1,0.2,0,0.2,0S257.3,352.6,257.2,352.6z M247.3,348.2v-1.9c0-0.1-0.1-0.2-0.2-0.2h-4.3
+				c-0.1,0-0.2-0.1-0.2-0.2v-2.1c0-0.1,0.1-0.2,0.2-0.2h4.3c0.1,0,0.2-0.1,0.2-0.2v-2c0-0.1,0-0.2,0.1-0.2s0.1,0,0.2,0.1l3.3,3.4
+				c0.1,0.1,0.1,0.2,0,0.2l0,0l-3.3,3.3c-0.1,0.1-0.2,0.1-0.2,0C247.3,348.4,247.2,348.3,247.3,348.2z M260.2,341.6v2
+				c0,0.1,0.1,0.2,0.2,0.2h4.3c0.1,0,0.2,0.1,0.2,0.2v2.1c0,0.1-0.1,0.2-0.2,0.2h-4.3c-0.1,0-0.2,0.1-0.2,0.2v1.9
+				c0,0.1,0,0.2-0.1,0.2s-0.1,0-0.2-0.1l-3.3-3.4c-0.1-0.1-0.1-0.2,0-0.2l0,0l3.3-3.3c0-0.1,0.1-0.1,0.2,0
+				C260.2,341.5,260.2,341.5,260.2,341.6z"/>
+		</g>
+		<g>
+			
+				<radialGradient id="f57e105d-6d2d-4ad7-b8c3-c10684c9f9b8_00000084510605217529114300000017714341169937939378_" cx="-6175.6484" cy="5988.916" r="30.0455" gradientTransform="matrix(0.5 0 0 -0.5 3481.2424 3352.9788)" gradientUnits="userSpaceOnUse">
+				<stop  offset="0.18" style="stop-color:#699CD3"/>
+				<stop  offset="1" style="stop-color:#2E76BC"/>
+			</radialGradient>
+			
+				<path id="f57e105d-6d2d-4ad7-b8c3-c10684c9f9b8_4_" style="fill:url(#f57e105d-6d2d-4ad7-b8c3-c10684c9f9b8_00000084510605217529114300000017714341169937939378_);" d="
+				M402.3,370c-6.6,5.1-16,3.9-21.1-2.7s-3.9-16,2.7-21.1l0.2-0.1c6.6-5,16.1-3.6,21,3.1C409.9,355.8,408.7,365,402.3,370"/>
+			<path class="st29" d="M393,344.6c-7.5,0-13.6,6.1-13.6,13.6s6.1,13.6,13.6,13.6s13.6-6.1,13.6-13.6S400.6,344.6,393,344.6z
+				 M402.2,349.1c-1.2,0.7-2.5,1.1-3.8,1.4c-0.5-1.7-1.2-3.3-2.2-4.8C398.4,346.3,400.5,347.5,402.2,349.1z M393,345.3
+				c0.6,0,1.3,0.1,1.9,0.2l0,0c1.3,1.5,2.2,3.4,2.7,5.3c-3.2,0.6-6.4,0.6-9.6,0c0.5-1.9,1.4-3.7,2.7-5.2l0,0
+				C391.5,345.4,392.3,345.3,393,345.3z M389.5,345.8c-1,1.4-1.8,3-2.2,4.7c-1.2-0.2-2.3-0.7-3.4-1.4
+				C385.5,347.6,387.4,346.4,389.5,345.8z M383.7,367c1-0.6,2-1.1,3.1-1.3c0.4,1.8,1.3,3.4,2.4,4.8
+				C387.1,369.8,385.2,368.6,383.7,367z M395,370.9c-0.7,0.1-1.3,0.1-2,0.1c-0.9,0-1.7-0.1-2.5-0.3l0,0c-1.5-1.4-2.5-3.3-3-5.3
+				c3.4-0.7,7-0.7,10.4,0c-0.5,2-1.5,3.9-3,5.3L395,370.9z M396.3,370.6c1.2-1.4,2-3.1,2.4-4.9c1.3,0.3,2.4,0.8,3.5,1.5
+				C400.7,368.8,398.6,370,396.3,370.6L396.3,370.6z M399,364.9c0.1-0.6,0.3-1.3,0.4-2l-0.8,0.2c-0.1,0.5-0.2,1.1-0.3,1.6
+				c-3.6-0.7-7.2-0.7-10.8,0c-0.1-0.5-0.2-1-0.3-1.5c0-0.1,0-0.1,0-0.2l-0.8-0.2c0,0.2,0,0.3,0,0.5c0,0.6,0.2,1.1,0.3,1.6
+				c-1.3,0.3-2.5,0.8-3.5,1.5c-4-4.8-3.9-11.9,0.2-16.6c1.1,0.7,2.4,1.2,3.7,1.5c-0.1,0.4-0.2,0.9-0.3,1.3s0,0.4-0.1,0.7l0.8-0.2
+				v-0.3c0.1-0.5,0.2-0.9,0.3-1.3c1.8,0.3,3.6,0.5,5.4,0.4c1.6,0,3.3-0.2,4.9-0.5c0.1,0.5,0.2,1,0.4,1.5l0.8,0.2
+				c-0.1-0.6-0.3-1.2-0.4-1.8c1.4-0.3,2.8-0.9,4.1-1.6c4.2,4.8,4.3,11.9,0.1,16.8C401.7,365.8,400.3,365.2,399,364.9L399,364.9z"/>
+			<path class="st0" d="M383.7,354.6c0.7-0.1,1.4-0.1,2.1-0.1c1.1-0.1,2.2,0.2,3,0.9c0.7,0.7,1.1,1.6,1,2.6c0.1,1.1-0.3,2.1-1.1,2.9
+				c-0.9,0.8-2.1,1.2-3.3,1.1c-0.6,0-1.2,0-1.8-0.1L383.7,354.6z M384.6,361.2c0.3,0,0.6,0,1,0c1.6,0.2,3-1,3.2-2.5
+				c0-0.2,0-0.5,0-0.7c0.1-1.5-0.9-2.7-2.4-2.9c-0.2,0-0.4,0-0.6,0c-0.4,0-0.7,0-1.1,0v6.1H384.6z"/>
+			<path class="st0" d="M391,361.9v-7.4h1l2.4,3.7c0.5,0.8,0.9,1.6,1.3,2.4l0,0c-0.1-1-0.1-1.9-0.1-3.1v-3.1h0.9v7.4h-1l-2.3-3.7
+				c-0.5-0.8-1-1.8-1.4-2.5l0,0c0,0.9,0,1.8,0,3.1v3.2H391z"/>
+			<path class="st0" d="M398.2,360.7c0.5,0.3,1.1,0.5,1.8,0.5c1,0,1.6-0.5,1.6-1.3s-0.4-1.1-1.4-1.5s-2-1.1-2-2.1
+				c0.1-1.2,1.1-2.1,2.3-2h0.1c0.6,0,1.1,0.1,1.6,0.4l-0.3,0.8c-0.4-0.2-0.9-0.4-1.4-0.4c-1,0-1.4,0.6-1.4,1.1s0.5,1,1.5,1.4
+				s1.9,1.1,1.9,2.2s-0.8,2.1-2.6,2.1c-0.7,0-1.3-0.2-1.9-0.5L398.2,360.7z"/>
+		</g>
+		<g>
+			<path class="st30" d="M660.9,81.8l1.4-1.5v-4.1h-7.1v4.1l1.4,1.5c0.1,0.1,0.2,0.2,0.3,0.2h3.5C660.7,82,660.8,81.9,660.9,81.8z"
+				/>
+			
+				<radialGradient id="SVGID_00000088113309501092997250000006250448545135943848_" cx="658.7664" cy="-727.6449" r="11.3217" gradientTransform="matrix(1 0 0 1 0 791.7148)" gradientUnits="userSpaceOnUse">
+				<stop  offset="0" style="stop-color:#9F7DB8"/>
+				<stop  offset="0.21" style="stop-color:#9B7BB7"/>
+				<stop  offset="0.43" style="stop-color:#9074B4"/>
+				<stop  offset="0.65" style="stop-color:#8068AE"/>
+				<stop  offset="0.88" style="stop-color:#6C5FAA"/>
+				<stop  offset="1" style="stop-color:#6059A7"/>
+			</radialGradient>
+			<path style="fill:url(#SVGID_00000088113309501092997250000006250448545135943848_);" d="M658.8,52c-5.7-0.1-10.4,4.5-10.5,10.3
+				c0,0.4,0,0.9,0.1,1.3c0.5,4.4,4.6,6.4,5.8,11.9c0.1,0.4,0.4,0.7,0.8,0.7h7.6c0.4,0,0.7-0.3,0.8-0.7c1.2-5.5,5.3-7.6,5.8-11.9
+				c0.7-5.7-3.4-10.9-9.1-11.5C659.6,52,659.2,52,658.8,52z"/>
+			
+				<linearGradient id="SVGID_00000057136801981932892120000009424209643001483165_" gradientUnits="userSpaceOnUse" x1="658.6958" y1="-733.7144" x2="658.8017" y2="-720.3381" gradientTransform="matrix(1 0 0 1 0 791.7148)">
+				<stop  offset="0" style="stop-color:#F2F2F3"/>
+				<stop  offset="0.23" style="stop-color:#F2F1F2;stop-opacity:0.99"/>
+				<stop  offset="0.37" style="stop-color:#EDEDF0;stop-opacity:0.95"/>
+				<stop  offset="0.48" style="stop-color:#E7E5EF;stop-opacity:0.89"/>
+				<stop  offset="0.58" style="stop-color:#DEDBEE;stop-opacity:0.81"/>
+				<stop  offset="0.67" style="stop-color:#D4CEE7;stop-opacity:0.7"/>
+				<stop  offset="0.76" style="stop-color:#C4BDDE;stop-opacity:0.57"/>
+				<stop  offset="0.84" style="stop-color:#B5ABD4;stop-opacity:0.41"/>
+				<stop  offset="0.92" style="stop-color:#A094C7;stop-opacity:0.22"/>
+				<stop  offset="0.99" style="stop-color:#877CBA;stop-opacity:2.000000e-02"/>
+				<stop  offset="1" style="stop-color:#847AB9;stop-opacity:0"/>
+			</linearGradient>
+			<path style="fill:url(#SVGID_00000057136801981932892120000009424209643001483165_);" d="M663.1,57.8c-1.4,0-2.4,1.2-2.4,2.5v1.4
+				H657v-1.4c0-1.4-1.1-2.5-2.4-2.5c0,0,0,0-0.1,0c-1.4,0-2.4,1.2-2.4,2.5c0,1.4,1,2.5,2.4,2.6h1.1v10.6c0,0.4,0.3,0.6,0.6,0.6
+				c0.4,0,0.6-0.3,0.6-0.6V62.9h3.8v10.6c0,0.4,0.3,0.6,0.6,0.6s0.6-0.3,0.6-0.6V62.9h1.1c1.4,0,2.4-1.2,2.4-2.6l0,0
+				C665.5,59,664.5,57.8,663.1,57.8z M655.6,61.7h-1.2c-0.7-0.1-1.2-0.7-1.2-1.4s0.5-1.3,1.2-1.4c0.7,0.1,1.2,0.7,1.2,1.4V61.7z
+				 M663.2,61.7H662v-1.4c-0.1-0.7,0.4-1.3,1-1.3c0.7-0.1,1.3,0.4,1.3,1c0,0.1,0,0.2,0,0.3C664.5,61,663.9,61.6,663.2,61.7
+				L663.2,61.7z"/>
+			<polygon class="st33" points="655.2,79 662.4,77.6 662.4,76.8 655.2,78.2 			"/>
+			<polygon class="st33" points="662.4,79.5 662.4,78.8 655.2,80.2 655.2,80.3 655.7,80.9 			"/>
+		</g>
+		<g>
+			
+				<radialGradient id="aacf8311-a317-400f-b613-74bd00da5ce3_00000164515531377708796600000010271099008094296767_" cx="805.0439" cy="-724.7148" r="14.9781" gradientTransform="matrix(1 0 0 1 0 791.7148)" gradientUnits="userSpaceOnUse">
+				<stop  offset="0.18" style="stop-color:#699CD3"/>
+				<stop  offset="0.56" style="stop-color:#669CD3"/>
+				<stop  offset="0.69" style="stop-color:#6198D1"/>
+				<stop  offset="0.78" style="stop-color:#5793CE"/>
+				<stop  offset="0.86" style="stop-color:#4A8CCA"/>
+				<stop  offset="0.93" style="stop-color:#3B83C5"/>
+				<stop  offset="0.99" style="stop-color:#3078BE"/>
+				<stop  offset="1" style="stop-color:#2E76BC"/>
+			</radialGradient>
+			
+				<path id="aacf8311-a317-400f-b613-74bd00da5ce3_2_" style="fill:url(#aacf8311-a317-400f-b613-74bd00da5ce3_00000164515531377708796600000010271099008094296767_);" d="
+				M805,52c-8.3,0-15,6.7-15,15s6.7,15,15,15s15-6.7,15-15S813.3,52,805,52z M805,79.9c-7.2,0-13-5.8-13-13s5.8-13,13-13
+				s13,5.8,13,13l0,0C818,74.1,812.2,79.9,805,79.9z"/>
+			<circle class="st0" cx="805" cy="67" r="13"/>
+			<g>
+				
+					<radialGradient id="bd983c41-db73-40ec-a4f4-da1213fc9924_00000004531700060299832790000010113159240275663782_" cx="876.4448" cy="-564.8007" r="17.4353" gradientTransform="matrix(0.94 0 0 0.94 -20.7501 595.9635)" gradientUnits="userSpaceOnUse">
+					<stop  offset="0.27" style="stop-color:#FED70A"/>
+					<stop  offset="0.49" style="stop-color:#FFCC12"/>
+					<stop  offset="0.88" style="stop-color:#FBAC1D"/>
+					<stop  offset="1" style="stop-color:#F9A120"/>
+				</radialGradient>
+				
+					<path id="bd983c41-db73-40ec-a4f4-da1213fc9924_2_" style="fill:url(#bd983c41-db73-40ec-a4f4-da1213fc9924_00000004531700060299832790000010113159240275663782_);" d="
+					M812.9,64c1.3-1.3,1.3-3.3,0-4.6l0,0l-5.6-5.6c-1.3-1.3-3.3-1.3-4.6,0l0,0l-5.6,5.6c-1.3,1.3-1.3,3.3,0,4.6l4.6,4.7
+					c0.2,0.2,0.3,0.4,0.3,0.6V78c0,0.3,0.1,0.6,0.3,0.8l2.1,2.1c0.3,0.3,0.7,0.3,1,0l0,0l2-2l0,0l1.2-1.2c0.2-0.2,0.2-0.4,0-0.6
+					l-0.9-0.9c-0.2-0.2-0.2-0.5,0-0.7l0.9-0.9c0.2-0.2,0.2-0.4,0-0.6l-0.9-0.9c-0.2-0.2-0.2-0.5,0-0.7l0.9-0.9
+					c0.2-0.2,0.2-0.4,0-0.6l-1.2-1.2v-0.4L812.9,64z M805,55.2c1,0,1.8,0.8,1.8,1.8s-0.8,1.8-1.8,1.8s-1.8-0.8-1.8-1.8
+					S804,55.2,805,55.2z"/>
+				<path id="ad2e7e44-9bfd-4775-8bf4-8ef26a544921_2_" class="st36" d="M803.6,78.1L803.6,78.1c0.2,0.1,0.4,0.1,0.6,0
+					c0.1-0.1,0.1-0.2,0.1-0.3v-7.1c0-0.1-0.1-0.3-0.2-0.4l0,0c-0.2-0.1-0.4-0.1-0.5,0.1c0,0.1-0.1,0.2-0.1,0.2v7.1
+					C803.5,77.9,803.5,78,803.6,78.1z"/>
+				<path id="a996fbff-3936-4b24-b407-369336c143ba_2_" class="st36" d="M801.1,61.3h8.1c0.3,0,0.5,0.2,0.5,0.5v0.1
+					c0,0.3-0.2,0.5-0.5,0.5h-8.1c-0.3,0-0.5-0.2-0.5-0.5v-0.1C800.6,61.5,800.8,61.3,801.1,61.3z"/>
+				<path id="bb12d31c-3352-4a18-87dd-a169a4a8721d_2_" class="st36" d="M801.1,63.1h8.1c0.3,0,0.5,0.2,0.5,0.5v0.1
+					c0,0.3-0.2,0.5-0.5,0.5h-8.1c-0.3,0-0.5-0.2-0.5-0.5v-0.1C800.6,63.3,800.8,63.1,801.1,63.1z"/>
+			</g>
+		</g>
+		<g>
+			
+				<radialGradient id="SVGID_00000096752844017513769540000003731395997681392519_" cx="715.6403" cy="-724.8522" r="14.8961" gradientTransform="matrix(1.01 0 0 1.01 1.9033 798.6435)" gradientUnits="userSpaceOnUse">
+				<stop  offset="0.18" style="stop-color:#699CD3"/>
+				<stop  offset="0.56" style="stop-color:#669CD3"/>
+				<stop  offset="0.69" style="stop-color:#6198D1"/>
+				<stop  offset="0.78" style="stop-color:#5793CE"/>
+				<stop  offset="0.86" style="stop-color:#4A8CCA"/>
+				<stop  offset="0.93" style="stop-color:#3B83C5"/>
+				<stop  offset="0.99" style="stop-color:#3078BE"/>
+				<stop  offset="1" style="stop-color:#2E76BC"/>
+			</radialGradient>
+			
+				<ellipse style="fill:url(#SVGID_00000096752844017513769540000003731395997681392519_);" cx="724.7" cy="66.5" rx="15.1" ry="15"/>
+			<ellipse class="st0" cx="724.7" cy="66.5" rx="13.1" ry="13.1"/>
+			<path class="st38" d="M713.6,67.3c0.2,2.7,1.3,5.2,3.2,7.1l3.5-3.5c-1-1-1.6-2.2-1.8-3.5L713.6,67.3L713.6,67.3z"/>
+			<path class="st39" d="M732,58.1c-1.8-1.6-4.1-2.5-6.5-2.7v4.9c1.1,0.1,2.2,0.6,3,1.2L732,58.1z"/>
+			<path class="st39" d="M717.4,58.1l3.5,3.5c0.9-0.7,1.9-1.1,3-1.2v-5C721.5,55.6,719.2,56.5,717.4,58.1z"/>
+			<path class="st39" d="M729.6,62.7c0.7,0.9,1.1,1.9,1.3,3h4.9c-0.2-2.4-1.1-4.7-2.7-6.5L729.6,62.7z"/>
+			<path class="st40" d="M719.8,62.7l-3.5-3.5c-1.6,1.8-2.5,4.1-2.7,6.6h4.9C718.6,64.6,719.1,63.6,719.8,62.7z"/>
+			<path class="st41" d="M733.8,62.9c-0.2-0.4-0.6-0.6-1-0.4l-7.3,2.9l0.6,1.4l7.3-2.9C733.7,63.8,733.9,63.4,733.8,62.9
+				C733.8,63,733.8,63,733.8,62.9z"/>
+			
+				<radialGradient id="SVGID_00000099644781406402286780000010254393285469768590_" cx="774.54" cy="-543.557" r="4.7847" gradientTransform="matrix(0.95 0 0 0.95 -11.1368 579.612)" gradientUnits="userSpaceOnUse">
+				<stop  offset="0.19" style="stop-color:#8C8E90"/>
+				<stop  offset="0.35" style="stop-color:#848688"/>
+				<stop  offset="0.6" style="stop-color:#6E7071"/>
+				<stop  offset="0.91" style="stop-color:#4A4B4D"/>
+				<stop  offset="1" style="stop-color:#3E403F"/>
+			</radialGradient>
+			
+				<ellipse style="fill:url(#SVGID_00000099644781406402286780000010254393285469768590_);" cx="724.7" cy="66.5" rx="2.1" ry="2.1"/>
+		</g>
+		<g>
+			<path class="st43" d="M881.9,66c0,8.1-9.9,14.6-12.1,15.9c-0.2,0.2-0.6,0.2-0.8,0c-2.1-1.3-12-7.8-12-15.9v-9.7
+				c0-0.4,0.3-0.8,0.8-0.8c7.7-0.2,5.9-3.5,11.7-3.5s4,3.3,11.7,3.5c0.4,0,0.8,0.4,0.8,0.8L881.9,66L881.9,66z"/>
+			
+				<linearGradient id="SVGID_00000170969368947398574260000002369811488569778332_" gradientUnits="userSpaceOnUse" x1="869.4904" y1="-710.9982" x2="869.4904" y2="-738.4731" gradientTransform="matrix(1 0 0 1 0 791.7148)">
+				<stop  offset="0" style="stop-color:#2E76BC"/>
+				<stop  offset="6.000000e-02" style="stop-color:#3179BE"/>
+				<stop  offset="0.34" style="stop-color:#4288C8"/>
+				<stop  offset="0.59" style="stop-color:#5693CE"/>
+				<stop  offset="0.82" style="stop-color:#639BD2"/>
+				<stop  offset="1" style="stop-color:#699CD3"/>
+			</linearGradient>
+			<path style="fill:url(#SVGID_00000170969368947398574260000002369811488569778332_);" d="M880.9,66.1c0,7.4-9.1,13.4-11.1,14.6
+				c-0.2,0.1-0.5,0.1-0.7,0c-2-1.2-11.1-7.1-11.1-14.6v-8.8c-0.1-0.4,0.2-0.8,0.6-0.8h0.1c7.1-0.1,5.5-3.2,10.8-3.2s3.7,3,10.8,3.2
+				c0.4,0,0.7,0.3,0.7,0.7L880.9,66.1L880.9,66.1z"/>
+			<path class="st45" d="M874.5,64.6h-0.7v-2.5c0-1.2-0.4-2.3-1.2-3.2c-1.6-1.7-4.2-1.8-5.9-0.2c-0.1,0.1-0.2,0.2-0.2,0.2
+				c-0.8,0.9-1.2,2-1.2,3.2v2.5h-0.7c-0.3,0-0.6,0.2-0.6,0.5v0.1v6.5c0,0.3,0.3,0.6,0.6,0.6l0,0h10.1c0.3,0,0.6-0.2,0.6-0.5l0,0
+				v-6.5C875.1,64.9,874.8,64.6,874.5,64.6L874.5,64.6z M871.7,64.6h-4.6v-2.5c0-0.7,0.3-1.3,0.7-1.8c0.8-0.9,2.1-0.9,3-0.2
+				c0.1,0.1,0.1,0.1,0.2,0.2c0.1,0.1,0.2,0.2,0.3,0.4l0,0c0.3,0.4,0.4,0.9,0.4,1.4L871.7,64.6L871.7,64.6z"/>
+			<path class="st46" d="M864.4,64.6h10.1c0.1,0,0.3,0.1,0.4,0.1L864,72.1c-0.1-0.1-0.2-0.3-0.2-0.4v-6.5
+				C863.8,64.9,864.1,64.6,864.4,64.6L864.4,64.6z"/>
+			<path class="st47" d="M874.5,64.6h-10.1c-0.1,0-0.3,0.1-0.4,0.1l10.8,7.3c0.1-0.1,0.2-0.3,0.2-0.4v-6.5
+				C875.1,64.9,874.8,64.6,874.5,64.6L874.5,64.6z"/>
+		</g>
+		<g>
+			<rect x="462.3" y="139.2" class="st11" width="1" height="1.5"/>
+			<path class="st11" d="M463.3,136.2h-1v-3h1V136.2z M570.3,136.2h-1v-3h1V136.2z M463.3,130.1h-1v-3h1V130.1z M570.3,130.1h-1v-3
+				h1V130.1z M463.3,124h-1v-3h1V124z M570.3,124h-1v-3h1V124z M463.3,118h-1v-3h1V118z M570.3,118h-1v-3h1V118z M463.3,111.9h-1v-3
+				h1V111.9z M570.3,111.9h-1v-3h1V111.9z M463.3,105.8h-1v-3h1V105.8z M570.3,105.8h-1v-3h1V105.8z M463.3,99.8h-1v-3h1V99.8z
+				 M570.3,99.7h-1v-3h1V99.7z M463.3,93.7h-1v-3h1V93.7z M570.3,93.7h-1v-3h1V93.7z M463.3,87.6h-1v-0.4c0-1,0.3-2,1-2.8l0.8,0.6
+				c-0.5,0.6-0.7,1.4-0.7,2.1L463.3,87.6L463.3,87.6z M570.3,87.6h-1v-0.4c0-0.8-0.3-1.5-0.8-2.2l0.8-0.6c0.6,0.8,1,1.8,1,2.8V87.6z
+				 M466.3,83.8l-0.2-1c0.2,0,0.4-0.1,0.7-0.1h2.4v1h-2.4C466.6,83.7,466.4,83.7,466.3,83.8z M566.3,83.8c-0.2,0-0.3,0-0.5,0h-2.5
+				v-1h2.5c0.2,0,0.4,0,0.6,0L566.3,83.8z M560.3,83.7h-3v-1h3V83.7z M554.2,83.7h-3v-1h3V83.7z M548.2,83.7h-3v-1h3V83.7z
+				 M542.1,83.7h-3v-1h3V83.7z M536,83.7h-3v-1h3V83.7z M529.9,83.7h-3v-1h3V83.7z M523.9,83.7h-3v-1h3V83.7z M517.8,83.7h-3v-1h3
+				V83.7z M511.7,83.7h-3v-1h3V83.7z M505.7,83.7h-3v-1h3V83.7z M499.6,83.7h-3v-1h3V83.7z M493.5,83.7h-3v-1h3V83.7z M487.4,83.7
+				h-3v-1h3V83.7z M481.4,83.7h-3v-1h3V83.7z M475.3,83.7h-3v-1h3V83.7z"/>
+			<rect x="569.3" y="139.2" class="st11" width="1" height="1.5"/>
+		</g>
+		<g>
+			
+				<radialGradient id="f57e105d-6d2d-4ad7-b8c3-c10684c9f9b8_00000006671934311318513580000013389067423131819680_" cx="-5928.103" cy="6559.3418" r="34.0553" gradientTransform="matrix(0.5 0 0 -0.5 3481.2424 3352.9788)" gradientUnits="userSpaceOnUse">
+				<stop  offset="0.18" style="stop-color:#699CD3"/>
+				<stop  offset="1" style="stop-color:#2E76BC"/>
+			</radialGradient>
+			
+				<path id="f57e105d-6d2d-4ad7-b8c3-c10684c9f9b8_1_" style="fill:url(#f57e105d-6d2d-4ad7-b8c3-c10684c9f9b8_00000006671934311318513580000013389067423131819680_);" d="
+				M527.2,86.4c-7.4,5.8-18.1,4.4-23.9-3s-4.4-18.1,3-23.9l0.2-0.1c7.5-5.6,18.2-4.1,23.8,3.5C535.9,70.2,534.5,80.7,527.2,86.4"/>
+			<path class="st29" d="M516.8,57.5c-8.5,0-15.4,6.9-15.4,15.4s6.9,15.4,15.4,15.4s15.4-6.9,15.4-15.4S525.3,57.5,516.8,57.5z
+				 M527.1,62.7c-1.3,0.8-2.8,1.3-4.3,1.6c-0.5-1.9-1.4-3.8-2.5-5.4C522.9,59.5,525.2,60.8,527.1,62.7z M516.8,58.4
+				c0.7,0,1.5,0.1,2.2,0.2l0,0c1.5,1.7,2.5,3.8,3.1,6c-3.6,0.7-7.3,0.7-10.9,0c0.6-2.2,1.6-4.2,3-5.9l0,0
+				C515,58.5,515.9,58.4,516.8,58.4z M512.8,58.9c-1.1,1.6-2,3.4-2.5,5.4c-1.4-0.3-2.6-0.8-3.8-1.5
+				C508.2,60.9,510.4,59.6,512.8,58.9z M506.2,82.9c1.1-0.7,2.3-1.2,3.6-1.5c0.5,2,1.4,3.8,2.7,5.4
+				C510.1,86.1,507.9,84.7,506.2,82.9z M519,87.3c-0.8,0.1-1.5,0.1-2.3,0.1c-1,0-1.9-0.1-2.9-0.3l0,0c-1.7-1.6-2.8-3.7-3.3-6
+				c3.9-0.8,7.9-0.8,11.8,0c-0.5,2.3-1.7,4.4-3.4,6L519,87.3z M520.5,87c1.3-1.6,2.3-3.6,2.8-5.6c1.4,0.3,2.8,0.9,4,1.7
+				C525.4,84.9,523.1,86.3,520.5,87L520.5,87z M523.5,80.5c0.2-0.7,0.3-1.5,0.4-2.2l-0.9,0.2c-0.1,0.6-0.2,1.2-0.3,1.8
+				c-4-0.8-8.2-0.8-12.2,0c-0.1-0.5-0.2-1.1-0.3-1.7c0-0.1,0-0.1,0-0.2l-0.9-0.3c0,0.2,0,0.4,0,0.6c0,0.6,0.2,1.2,0.3,1.8
+				c-1.4,0.3-2.8,0.9-4,1.7c-4.6-5.5-4.5-13.5,0.2-18.8c1.3,0.8,2.7,1.4,4.2,1.7c-0.1,0.5-0.3,1-0.4,1.5s0,0.5-0.2,0.7l0.9-0.2v-0.3
+				c0.1-0.5,0.2-1,0.4-1.5c2,0.4,4.1,0.5,6.1,0.5c1.9,0,3.7-0.2,5.6-0.5c0.1,0.5,0.3,1.1,0.4,1.7l0.9,0.2c-0.1-0.7-0.3-1.4-0.5-2
+				c1.6-0.4,3.2-1,4.6-1.8c4.8,5.4,4.8,13.5,0.1,19C526.5,81.5,525,80.9,523.5,80.5L523.5,80.5z"/>
+			<path class="st0" d="M506.1,68.9c0.8-0.1,1.5-0.2,2.3-0.2c1.2-0.1,2.5,0.3,3.4,1c0.8,0.8,1.2,1.8,1.2,2.9
+				c0.1,1.2-0.4,2.4-1.2,3.3c-1,0.9-2.4,1.3-3.7,1.2c-0.7,0-1.3,0-2-0.1L506.1,68.9z M507.2,76.4c0.4,0,0.7,0,1.1,0
+				c1.8,0.2,3.4-1.1,3.6-2.9c0-0.3,0-0.5,0-0.8c0.2-1.7-1.1-3.1-2.7-3.3c-0.2,0-0.5,0-0.7,0c-0.4,0-0.8,0-1.3,0V76.4z"/>
+			<path class="st0" d="M514.5,77.1v-8.4h1.2l2.7,4.2c0.6,0.9,1.1,1.8,1.5,2.7l0,0c-0.1-1.1-0.1-2.1-0.1-3.5v-3.5h1V77h-1.1
+				l-2.6-4.2c-0.6-0.9-1.1-2-1.6-2.8l0,0c0,1.1,0,2,0,3.5v3.6L514.5,77.1z"/>
+			<path class="st0" d="M522.6,75.8c0.6,0.4,1.3,0.5,2,0.5c1.1,0,1.8-0.6,1.8-1.4c0-0.9-0.4-1.2-1.6-1.7c-1.1-0.4-2.2-1.2-2.2-2.4
+				c0.1-1.3,1.2-2.4,2.6-2.3c0.1,0,0.1,0,0.2,0c0.6,0,1.3,0.1,1.9,0.4l-0.3,0.9c-0.5-0.3-1-0.4-1.6-0.4c-1.2,0-1.6,0.7-1.6,1.3
+				s0.5,1.2,1.7,1.6s2.2,1.2,2.2,2.5c0,1.2-1,2.4-3,2.4c-0.7,0-1.5-0.2-2.1-0.5L522.6,75.8z"/>
+		</g>
+		<g>
+			<rect x="571.2" y="309.3" class="st0" width="386.6" height="124"/>
+			<rect x="571.2" y="309.3" class="st26" width="386.6" height="124"/>
+		</g>
+		<g>
+			<rect x="6.8" y="6.1" class="st49" width="131" height="55"/>
+			<path class="st50" d="M137.9,61.2H6.7V6h131.2V61.2z M6.9,61h130.8V6.2H6.9V61z"/>
+		</g>
+		<g>
+			<g>
+				<rect x="20.2" y="42" class="st51" width="26.5" height="3"/>
+				<g>
+					<polygon class="st51" points="56.2,43.5 42.8,38 46,43.5 42.8,49 					"/>
+				</g>
+			</g>
+			<path class="st52" d="M46.7,44.2h-4v-1.5h4V44.2z M40.7,44.2h-4v-1.5h4V44.2z M34.7,44.2h-4v-1.5h4V44.2z M28.7,44.2h-4v-1.5h4
+				V44.2z M22.7,44.2h-2.5v-1.5h2.5V44.2z"/>
+		</g>
+		<g>
+			<g>
+				<rect x="20.2" y="22.4" class="st53" width="26.5" height="3"/>
+				<g>
+					<polygon class="st53" points="44.9,17.9 55.3,23.9 44.9,29.9 					"/>
+				</g>
+			</g>
+			<g>
+				<rect x="46.2" y="22.9" class="st54" width="0.5" height="2"/>
+				<path class="st54" d="M44.2,24.9l-1.1-0.1l0-1.9l1,0V24.9z M41.3,24.9l-1.1-0.1l0-1.9l1,0V24.9z M38.4,24.9l-1.1-0.1l0-1.9l1,0
+					V24.9z M35.5,24.9l-1.1-0.1l0-1.9l1,0V24.9z M32.5,24.9l-1.1-0.1l0.1-1.9l1,0V24.9z M29.6,24.9l-1.1-0.1l0-1.9l1,0V24.9z
+					 M26.7,24.9l-1.1-0.1l0.1-1.9l1,0V24.9z M23.8,24.9l-1.1-0.1l0-1.9l1,0V24.9z M20.8,24.9l-0.2-0.1l0-1.9l0.1,0V24.9z"/>
+				<rect x="20.2" y="22.9" class="st54" width="0.5" height="2"/>
+			</g>
+		</g>
+		<circle class="st55" cx="800.5" cy="295.4" r="35"/>
+		
+			<linearGradient id="SVGID_00000132775788051385684580000009632540499318477246_" gradientUnits="userSpaceOnUse" x1="800.45" y1="-516.8149" x2="800.45" y2="-476.8148" gradientTransform="matrix(1 0 0 1 0 791.7148)">
+			<stop  offset="0" style="stop-color:#008BF1"/>
+			<stop  offset="0.2215" style="stop-color:#0086EC"/>
+			<stop  offset="0.4939" style="stop-color:#0078DD"/>
+			<stop  offset="0.7916" style="stop-color:#0061C4"/>
+			<stop  offset="1" style="stop-color:#004DAE"/>
+		</linearGradient>
+		<path style="fill:url(#SVGID_00000132775788051385684580000009632540499318477246_);" d="M799.1,293.6h-18.7v-18.7h18.7V293.6z
+			 M783.6,290.5H796v-12.4h-12.4V290.5z M820.5,293.6h-18.7v-18.7h18.7V293.6z M804.9,290.5h12.4v-12.4h-12.4V290.5z M820.5,314.9
+			h-18.7v-18.7h18.7V314.9z M799.1,314.9h-18.7v-18.7h18.7V314.9z M804.9,311.8h12.4v-12.4h-12.4V311.8z M783.6,311.8H796v-12.4
+			h-12.4V311.8z"/>
+		
+			<linearGradient id="SVGID_00000140007395292357271790000009192282953079427996_" gradientUnits="userSpaceOnUse" x1="803.6527" y1="-498.9648" x2="816.4731" y2="-498.9648" gradientTransform="matrix(1 0 0 1 0 791.7148)">
+			<stop  offset="0" style="stop-color:#000000;stop-opacity:0.64"/>
+			<stop  offset="0.5677" style="stop-color:#000000;stop-opacity:0.22"/>
+			<stop  offset="1" style="stop-color:#FFFFFF;stop-opacity:0"/>
+		</linearGradient>
+		<path style="fill:url(#SVGID_00000140007395292357271790000009192282953079427996_);" d="M816.5,291.4v2.7h-12.8v-2.7H816.5z"/>
+		
+			<linearGradient id="SVGID_00000084507003691171838420000011882851092600640420_" gradientUnits="userSpaceOnUse" x1="804.9531" y1="-499.6649" x2="820.4731" y2="-499.6649" gradientTransform="matrix(1 0 0 1 0 791.7148)">
+			<stop  offset="0" style="stop-color:#00315C"/>
+			<stop  offset="0.785" style="stop-color:#0080E5"/>
+		</linearGradient>
+		<path style="fill:url(#SVGID_00000084507003691171838420000011882851092600640420_);" d="M820.5,293.6v-3.1h-15.6v3.1H820.5z"/>
+		
+			<linearGradient id="SVGID_00000047037067641336322590000016181389888802493060_" gradientUnits="userSpaceOnUse" x1="796" y1="-499.6648" x2="780.4798" y2="-499.6648" gradientTransform="matrix(1 0 0 1 0 791.7148)">
+			<stop  offset="0" style="stop-color:#00315C"/>
+			<stop  offset="0.785" style="stop-color:#0080E5"/>
+		</linearGradient>
+		<path style="fill:url(#SVGID_00000047037067641336322590000016181389888802493060_);" d="M780.5,293.6v-3.1H796v3.1H780.5z"/>
+		
+			<linearGradient id="SVGID_00000008842882357255619750000001619230133382557624_" gradientUnits="userSpaceOnUse" x1="804.9531" y1="-493.8649" x2="820.4731" y2="-493.8649" gradientTransform="matrix(1 0 0 1 0 791.7148)">
+			<stop  offset="0" style="stop-color:#00315C"/>
+			<stop  offset="0.5792" style="stop-color:#0E71C7"/>
+			<stop  offset="1" style="stop-color:#0A75D5"/>
+		</linearGradient>
+		<path style="fill:url(#SVGID_00000008842882357255619750000001619230133382557624_);" d="M820.5,296.3v3.1h-15.6v-3.1H820.5z"/>
+		
+			<linearGradient id="SVGID_00000031198932628394784750000015345843136565111983_" gradientUnits="userSpaceOnUse" x1="796" y1="-493.8648" x2="780.4799" y2="-493.8648" gradientTransform="matrix(1 0 0 1 0 791.7148)">
+			<stop  offset="0" style="stop-color:#00315C"/>
+			<stop  offset="0.5792" style="stop-color:#0E71C7"/>
+			<stop  offset="1" style="stop-color:#0A75D5"/>
+		</linearGradient>
+		<path style="fill:url(#SVGID_00000031198932628394784750000015345843136565111983_);" d="M780.5,299.4v-3.1H796v3.1H780.5z"/>
+		
+			<linearGradient id="SVGID_00000009560944415575533460000011271274765129985700_" gradientUnits="userSpaceOnUse" x1="797.55" y1="-501.2148" x2="797.55" y2="-514.7897" gradientTransform="matrix(1 0 0 1 0 791.7148)">
+			<stop  offset="0" style="stop-color:#00315C"/>
+			<stop  offset="0.785" style="stop-color:#008AF0"/>
+		</linearGradient>
+		<path style="fill:url(#SVGID_00000009560944415575533460000011271274765129985700_);" d="M796,274.9h3.1v15.6H796V274.9z"/>
+		
+			<linearGradient id="SVGID_00000103228320725056345580000017531573366367091847_" gradientUnits="userSpaceOnUse" x1="803.35" y1="-501.2148" x2="803.35" y2="-514.7897" gradientTransform="matrix(1 0 0 1 0 791.7148)">
+			<stop  offset="0" style="stop-color:#00315C"/>
+			<stop  offset="0.785" style="stop-color:#008AF0"/>
+		</linearGradient>
+		<path style="fill:url(#SVGID_00000103228320725056345580000017531573366367091847_);" d="M801.8,274.9h3.1v15.6h-3.1V274.9z"/>
+		
+			<linearGradient id="SVGID_00000078757027748365503980000015172228481603137166_" gradientUnits="userSpaceOnUse" x1="803.35" y1="-491.8822" x2="803.35" y2="-476.5841" gradientTransform="matrix(1 0 0 1 0 791.7148)">
+			<stop  offset="0" style="stop-color:#00294F"/>
+			<stop  offset="0.704" style="stop-color:#005BA6"/>
+			<stop  offset="0.828" style="stop-color:#0457AC"/>
+			<stop  offset="1" style="stop-color:#0050B2"/>
+		</linearGradient>
+		<path style="fill:url(#SVGID_00000078757027748365503980000015172228481603137166_);" d="M804.9,314.9h-3.1v-15.6h3.1V314.9z"/>
+		
+			<linearGradient id="SVGID_00000004530028557231126560000009421418395925844894_" gradientUnits="userSpaceOnUse" x1="797.55" y1="-491.8822" x2="797.55" y2="-476.5841" gradientTransform="matrix(1 0 0 1 0 791.7148)">
+			<stop  offset="0" style="stop-color:#00294F"/>
+			<stop  offset="0.704" style="stop-color:#005BA6"/>
+			<stop  offset="0.828" style="stop-color:#0457AC"/>
+			<stop  offset="1" style="stop-color:#0050B2"/>
+		</linearGradient>
+		<path style="fill:url(#SVGID_00000004530028557231126560000009421418395925844894_);" d="M799.1,314.9H796v-15.6h3.1V314.9z"/>
+		<path class="st66" d="M813.8,294.7c0-3.1-0.9-7-2.4-11.6c-0.3,0.9-0.9,1.7-1.3,2.3c-2.6-2.4-5.9-3.9-9.6-3.9
+			c-7.3,0-13.3,6-13.3,13.3s6,13.3,13.3,13.3S813.8,302.1,813.8,294.7C813.8,294.8,813.8,294.8,813.8,294.7z"/>
+		<path class="st0" d="M811.3,300.9c-3.3,4.3-10.3,2.9-14.8,3.1c0,0-0.8,0-1.6,0.1c0,0,0.3-0.1,0.7-0.2c3.1-1.1,4.7-1.3,6.6-2.3
+			c3.7-1.9,7.2-5.9,7.9-10.1c-1.3,4.1-5.6,7.6-9.3,8.9c-2.6,1-7.3,1.9-7.3,1.9l-0.2-0.1c-3.2-1.6-3.3-8.6,2.4-10.8
+			c2.6-1,5-0.4,7.8-1.1c3-0.8,6.3-2.9,7.8-5.8C812.8,289.3,814.6,296.5,811.3,300.9z"/>
+		<path class="st0" d="M792.5,305.3c0.6,0,1.1-0.5,1.1-1.1s-0.5-1.1-1.1-1.1s-1.1,0.5-1.1,1.1S791.9,305.3,792.5,305.3z"/>
+		<g>
+			<path class="st67" d="M1030.8,66.4c0,5.9-4.7,10.8-10.5,10.8c-5.8,0-10.5-4.8-10.5-10.8s4.7-10.8,10.5-10.8
+				C1026.1,55.7,1030.8,60.5,1030.8,66.4"/>
+			<path class="st68" d="M1010.2,69.1c0,0-0.8-11.2,9.6-11.5l-0.7-1.2l-5.6,1.9l-1.6,1.8l-1.4,2.7l-0.8,3.1l0.2,2.1"/>
+			<path class="st69" d="M1013,59.1c-1.9,2-3,4.6-3,7.4l0,0c0,2.8,1.1,5.4,3,7.4l0,0c1.9,2,4.5,3.1,7.2,3.1l0,0
+				c2.7,0,5.3-1.1,7.2-3.1l0,0c1.9-2,3-4.6,3-7.4l0,0c0-2.8-1.1-5.4-3-7.4l0,0c-1.9-2-4.5-3.1-7.2-3.1l0,0
+				C1017.5,56,1014.9,57.1,1013,59.1z M1012.6,74.3c-2-2.1-3.2-4.9-3.2-7.8l0,0c0-2.9,1.1-5.7,3.2-7.8l0,0c2-2.1,4.8-3.2,7.7-3.3
+				l0,0c2.9,0,5.7,1.2,7.7,3.3l0,0c2,2.1,3.2,4.9,3.2,7.8l0,0c0,2.9-1.1,5.7-3.2,7.8l0,0c-2,2.1-4.8,3.2-7.7,3.3l0,0
+				C1017.4,77.6,1014.6,76.4,1012.6,74.3L1012.6,74.3"/>
+			<path class="st70" d="M1024.7,66.5l-1.6,0.2l-2.2,0.2h-1.4h-1.4l-1-0.3l-0.9-1l-0.7-2l-0.2-0.4l-1-0.3l-0.6-0.9l-0.4-1.3l0.4-1.2
+				l1-0.4l0.8,0.4l0.4,0.9l0.5-0.1l0.2-0.2l-0.2-0.9V58l0.2-1.6v-0.9l0.7-1.2l1.3-0.9l2.2-1l2.5,0.4l2.2,1.6l1,1.6l0.6,1.2l0.2,2.9
+				l-0.5,2.5l-0.9,2.2l-0.8,1.2"/>
+			<path class="st71" d="M1023.3,73.4l-5.7,0.2v1l0.5,3.4l-0.2,0.3l-4-1.4l-0.3-0.5l-0.4-4.5l-0.9-2.7l-0.2-0.6l3.2-2.2l1-0.4
+				l0.9,1.1l0.8,0.7l0.9,0.3l0.4,0.1l0.5,2.1l0.4,0.4l0.9-0.3l-0.6,1.2l3.5,1.6L1023.3,73.4"/>
+			<path class="st72" d="M1013.8,59.4l1-0.4l0.8,0.4l0.4,0.9l0.5-0.1l0.1-0.5l-0.2-0.9l0.2-2.2l-0.2-1.2l0.7-0.8l1.6-1.2l-0.4-0.6
+				l-2.2,1.1l-0.9,0.7l-0.5,1.1l-0.8,1.1l-0.2,1.3L1013.8,59.4"/>
+			<path class="st73" d="M1015.5,55.7c0,0,0.6-1.5,3-2.2s0.1-0.5,0.1-0.5l-2.6,1l-1,1l-0.4,0.8L1015.5,55.7"/>
+			<path class="st73" d="M1014.3,59.2c0,0-0.8-2.8,2.4-3.2l-0.1-0.5l-2.2,0.5l-0.6,2.1l0.2,1.4L1014.3,59.2"/>
+			<path class="st74" d="M1015.5,62.9l0.5-0.5c0.2,0,0.3,0.2,0.3,0.3c0,0.3,0.2,2.8,1.9,4.2c0.2,0.1-1.3-0.2-1.3-0.2l-1.3-2"/>
+			<path class="st74" d="M1022.9,62.1c0,0,0.1-1.2,0.4-1.1c0.2,0.1,0.3,0.2,0.3,0.4C1023.7,61.4,1022.9,61.9,1022.9,62.1"/>
+			<path class="st74" d="M1026.2,57.7c0,0-0.7,0.1-0.7,0.7s0.7,0.1,0.8,0.1"/>
+			<path class="st74" d="M1021.4,57.7c0,0-0.9,0.1-0.9,0.7s1,0.5,1.3,0.3"/>
+			<path class="st74" d="M1015.9,60.3c0,0-1.5-0.9-1.7,0s-0.5,1.5,0.2,2.4l-0.5-0.2l-0.5-1.2l-0.2-1.2l0.9-1l1,0.1l0.6,0.5
+				L1015.9,60.3"/>
+			<path class="st74" d="M1016.7,57.8c0,0,0.7-3.5,4.1-4.2c2.8-0.6,4.3,0.1,4.9,0.8c0,0-2.5-3-4.9-2.1s-4.2,2.6-4.1,3.7
+				C1016.7,57.8,1016.7,57.8,1016.7,57.8"/>
+			<path class="st74" d="M1026,54.8c0,0-1.2,0-1.2,1c0,0.1,0,0.2,0.1,0.3c0,0,0.9-1,1.5-0.5"/>
+			<path class="st74" d="M1020.9,56.2c0,0-0.2-1.6-1.6-0.7c-0.9,0.6-0.8,1.4-0.6,1.6c0.2,0.2,0.1,0.5,0.2,0.3s0.1-0.9,0.5-1.1
+				C1019.9,56,1020.6,55.8,1020.9,56.2"/>
+			<path class="st75" d="M1017.1,67l-3.8,1.7c0,0,1.6,6.2,0.8,8.1l-0.6-0.2v-2.4l-1-4.5l-0.4-1.2l3.9-2.6L1017.1,67"/>
+			<path class="st75" d="M1017.5,70.5l0.5,0.7v2.4h-0.6c0,0-0.1-1.7-0.1-1.9s0.1-0.9,0.1-0.9"/>
+			<path class="st75" d="M1017.5,73.9l-1.8,0.1l0.5,0.4l1.3,0.2"/>
+			<path class="st71" d="M1023.7,73.5h1.5l0.4,3.7l-1.5,0.2L1023.7,73.5"/>
+			<path class="st71" d="M1024.1,73.5l2.2-0.1c0,0,0.9-2.3,0.9-2.4s0.8-3.4,0.8-3.4l-1.8-1.9l-0.4-0.3l-1,1V70L1024.1,73.5"/>
+			<path class="st75" d="M1025.1,73.2l-1.4,0.3l0.2,1.1c0.5,0.2,1.4-0.4,1.4-0.4"/>
+			<path class="st75" d="M1025.1,66.2l2.8,2.1l0.1-1l-2.1-2L1025.1,66.2"/>
+			<path class="st0" d="M1018.9,81.4l-0.8-3.4l-0.4-2.5l-0.1-1.8l3.8-0.2h2.3l-0.2,4.2l0.4,3.2v0.6l-3,0.2L1018.9,81.4"/>
+			<path class="st73" d="M1023.2,73.4c0,0-0.2,4.2,0.4,7.1c-0.9,0.5-1.9,0.8-3,1l3.4-0.1l0.4-0.2l-0.5-6.6l-0.1-1.4"/>
+			<path class="st0" d="M1025.6,76.8l1.6-0.4l3-0.2l0.4-1.4l-0.8-2.4l-0.9-0.1l-1.3,0.4l-1.2,0.6l-0.7-0.1l-0.5,0.2"/>
+			<path class="st73" d="M1025.6,76c0,0,1-0.5,1.2-0.4l-0.4-2.2l0.5-0.2c0,0,0.4,2.1,0.4,2.3c0,0,2.2,0.1,2.4,0.1
+				c0,0,0.5-0.9,0.4-1.9l0.4,1.3v0.7l-0.6,1l-0.7,0.2h-1.2l-0.4-0.5l-1.4,0.2l-0.4,0.2"/>
+			<path class="st0" d="M1024,73.2l-0.9-2.2l-0.9-1.3c0,0,0.2-0.6,0.5-0.6h0.9l0.9,0.3l-0.1,1.5L1024,73.2"/>
+			<path class="st73" d="M1024.2,72.4c0,0-1.1-2.2-1.1-2.5c0,0,0.2-0.5,0.5-0.4s0.9,0.4,0.9,0.4v-0.8l-1.4-0.3l-0.9,0.1l1.6,3.7h0.3
+				"/>
+			<path class="st0" d="M1019.3,67.1l-1.1-0.1l-1-0.3V67l0.5,0.6l1.6,0.7"/>
+			<path class="st73" d="M1017.5,67.2c0,0,1.2,0.5,1.6,0.4v0.5l-1.1-0.2l-0.7-0.5L1017.5,67.2"/>
+			<path class="st67" d="M1025.6,69.2c-0.6,0-1.2-0.1-1.8-0.3c0-0.2,0-0.4,0-0.6c0.2-0.1,0.4-0.1,0.6-0.1c-0.2-0.1-0.5-0.1-0.7-0.1
+				c0-0.2-0.1-0.2-0.1-0.4c0.4-0.1,1.3-1,1.8-0.7c0.2,0.1,0.3,0.9,0.4,1.3C1025.8,68.7,1025.7,69,1025.6,69.2"/>
+			<path class="st67" d="M1026.2,70.2h-0.6c-0.7,0-1.4-0.1-2.1-0.4l-0.7-0.2v-0.5h-0.1v-0.9c-0.1-0.1-0.1-0.3-0.1-0.5v-0.8l0.8-0.2
+				c0,0,0.1-0.1,0.2-0.2c0.5-0.4,1.5-0.9,2.3-0.4c0.5,0.3,0.7,0.9,0.8,1.6c0,0.1,0,0.2,0.1,0.3l0,0.2c0,0.5-0.1,1-0.3,1.3
+				L1026.2,70.2z"/>
+			<path class="st67" d="M1022.3,68c0,0.1,0,0.1,0,0.2c-0.2,0.1-0.6,0.1-0.8,0.3c0.3,0,0.6,0.1,0.8,0.2c0,0.1,0,0.3,0,0.4
+				c-0.4,0.3-0.7,0.7-1.2,0.9c-0.2,0.1-1,0.4-1.2,0.4c-0.1,0-0.1-0.2-0.2-0.3c-0.1-0.3-0.4-0.8-0.4-1.3c0-0.6-0.1-1.7,0.6-1.5
+				c0.6,0.1,1.1,0.3,1.6,0.6C1021.8,67.8,1021.9,68,1022.3,68"/>
+			<path class="st67" d="M1019.9,71.4c-0.2,0-0.7-0.1-1-0.7l-0.1-0.1l-0.1-0.2c0-0.1-0.1-0.1-0.1-0.2c-0.1-0.3-0.4-0.8-0.4-1.4
+				l0-0.2c0-0.7,0-1.6,0.6-2.1c0.3-0.3,0.7-0.3,1.2-0.2c0.6,0.1,1.1,0.3,1.6,0.6c0.2,0,0.4,0.1,0.5,0.1h1l0.1,2.6l-0.4,0.3
+				c-0.1,0.1-0.2,0.2-0.3,0.3c-0.3,0.3-0.6,0.6-1.1,0.8C1021.4,70.9,1020.4,71.4,1019.9,71.4z"/>
+			<path class="st67" d="M1022.7,68.8c-0.1-0.3-0.1-0.4-0.1-0.7C1023.5,67.5,1023.7,69.1,1022.7,68.8"/>
+			<path class="st67" d="M1022.9,69.8c-0.2,0-0.3,0-0.5-0.1l-0.5-0.1l-0.2-0.5c-0.1-0.4-0.2-0.6-0.2-1v-0.5l0.4-0.3
+				c0.8-0.5,1.5-0.3,1.9,0.1c0.5,0.5,0.6,1.2,0.3,1.8C1023.9,69.6,1023.5,69.8,1022.9,69.8z M1022.9,67.8c-0.1,0-0.4,0.1-0.5,0.3
+				c-0.1,0.2-0.1,0.5,0.1,0.6c0.2,0.2,0.5,0.2,0.6,0.2l-0.2-0.2l-0.3,0.1l0.1-0.4l-0.2-0.3h0.3L1022.9,67.8
+				C1023,67.8,1023,67.8,1022.9,67.8z M1022.8,68.4l-0.1,0.4L1022.8,68.4L1022.8,68.4z M1022.9,68.1L1022.9,68.1l0.1-0.3
+				c0,0,0,0,0,0L1022.9,68.1z"/>
+			<path class="st68" d="M1024,69.1c0,0-0.3-0.4-0.1-0.5c0.2-0.1,0.4,0,0.5-0.2s0-0.3,0-0.6s0.2-0.3,0.4-0.3c0.2,0,0.8-0.1,0.8,0.1
+				l-0.2-0.7l-0.5-0.2l-1.5,0.9l-0.1,0.4v0.9"/>
+			<path class="st68" d="M1019.8,70.4c0-0.6-0.1-1.3-0.2-1.9c-0.1-0.9,0.2-0.8,1-0.8c0.1,0,0.8,0.1,0.8,0.2c0.2,0.4-0.4,0.3,0.3,0.7
+				c0.5,0.3,1.4-0.2,1.2-0.8c-0.1-0.1-0.6,0-0.8-0.1l-0.9-0.5c-0.4-0.2-1.3-0.5-1.7-0.2c-1.1,0.7,0.1,2.6,0.5,3.3"/>
+			<path class="st69" d="M1020.9,56.2c-1.1-0.3-1.6,0.5-2,1.2c-0.3-0.1-0.2-0.5-0.1-0.7c0.2-0.5,1-1.3,1.6-1.2
+				C1020.7,55.6,1021.1,55.8,1020.9,56.2"/>
+			<path class="st69" d="M1026.2,57.4L1026.2,57.4c0.3,0.5,0.5,1.1,0.8,1.5c-0.2,0.5-1.6,0.9-1.6,0c0.3-0.1,0.8,0,1.1-0.2
+				C1026.4,58.4,1026.2,58,1026.2,57.4"/>
+			<path class="st69" d="M1021.4,57.4c0.2,0.4,0.3,0.9,0.6,1.2c0.1,0.1,0.4,0.3,0.3,0.7c0,0.1-0.3,0.3-0.4,0.4
+				c-0.5,0.2-1.7,0-1.3-0.6c0.4,0,1,0.3,1.3,0C1021.7,58.7,1021.3,57.9,1021.4,57.4"/>
+			<path class="st69" d="M1026,61.8c-0.8,0.5-1.7,1.1-2.9,0.9c-0.3-0.3-0.4-0.8-0.1-1.1c0.1,0.2,0.1,0.7,0.4,0.7
+				c0.7,0.1,1.6-0.4,2.1-0.6c0.3-0.5,0-0.7-0.3-1.1c-0.6-0.7-1.4-1.6-1.4-2.7c0.2-0.2,0.3,0.3,0.3,0.3c0.3,0.7,1.1,1.7,1.7,2.3
+				c0.1,0.2,0.4,0.3,0.4,0.4C1026.2,61.3,1026,61.6,1026,61.8"/>
+			<path class="st69" d="M1015.7,61.3c-0.2-0.1-0.3-0.8-0.6-0.8c-0.4,0-0.3,0.8-0.3,1.3c-0.3-0.3-0.3-1.1-0.1-1.5
+				c-0.2-0.1-0.3,0.1-0.5,0.2C1014.3,59.3,1015.9,60,1015.7,61.3"/>
+			<path class="st69" d="M1026.5,62.3c-0.4,0.7-0.9,1.5-2,1.5c0-0.2,0-0.6,0-0.7C1025.4,63,1025.9,62.6,1026.5,62.3"/>
+			<path class="st69" d="M1021.4,62.8c0.7,0.4,1.9,0.4,2.9,0.4c0,0.2,0.1,0.5,0.1,0.7C1023.1,63.9,1021.7,63.6,1021.4,62.8"/>
+			<path class="st69" d="M1021.2,63.4c0.5,1.2,2.1,1,3.5,1c-0.1,0.2-0.2,0.3-0.4,0.4c-0.4,0.2-1.6,0.3-2.3,0
+				c-0.4-0.2-0.6-0.7-0.8-0.9C1021.1,63.8,1020.6,63.4,1021.2,63.4"/>
+			<path class="st76" d="M1025.9,70c-0.6,0.9-1.1,1.9-1.7,2.8c0.3-0.8,0.4-2.2,0.4-3.2C1025.2,69.3,1025.7,69.6,1025.9,70"/>
+			<path class="st69" d="M1028.9,73.4c-0.6,0.1-1.1,0.7-1.7,0.7C1027.6,73.6,1028.2,73.4,1028.9,73.4"/>
+			<path class="st69" d="M1029.2,74.4c-0.5,0.1-1.1,0.1-1.6,0.1C1027.8,74.1,1028.8,74.2,1029.2,74.4"/>
+			<path class="st69" d="M1029.4,75.2c-0.6,0-1.3,0-1.8,0C1027.9,74.8,1029,75,1029.4,75.2"/>
+			<path class="st73" d="M1024.9,77.5c0.1,0.7,0.4,1.4,0.3,2.2c-0.3,0.1-0.5,0.2-0.9,0.2c0-0.7-0.1-1.7-0.1-2.3
+				C1024.4,77.6,1024.7,77.4,1024.9,77.5"/>
+			<path class="st70" d="M1024,67c-0.3,0.2-0.5,0.4-0.8,0.6c-0.6,0-0.9,0-1.4-0.4h0.1C1022.5,67.4,1023.3,67,1024,67"/>
+			<path class="st76" d="M1020.5,71.4c0.2-0.8,0.9-1.2,1.5-1.6c0.7,0.8,1.1,1.9,1.5,2.9C1022.5,72.4,1021.4,71.9,1020.5,71.4"/>
+			<path class="st69" d="M1024.2,77.6c0,0.6,0.1,1.6,0.1,2.3c0.4,0,0.6-0.1,0.9-0.2c0-0.8-0.2-1.5-0.3-2.2
+				C1024.7,77.4,1024.4,77.6,1024.2,77.6z M1017.6,74c0.3,2.6,0.7,4.7,1.4,7c1.6,0.5,3.6,0.5,5.1,0.1c-0.3-1.3-0.1-2.8-0.3-4.2
+				c-0.1-1-0.1-2.1-0.2-3.1C1021.8,73.4,1019.4,73.7,1017.6,74z M1024,73.8c0,1.1,0,2.2,0.1,3.3c0.4-0.1,0.7-0.1,1.1-0.2
+				c-0.1-1.1-0.1-2.2-0.4-3.2C1024.6,73.7,1024.3,73.7,1024,73.8L1024,73.8z M1026.1,73.6c-0.2,0-0.4,0-0.6,0
+				c0.1,0.9,0.3,1.9,0.4,2.8c0.3,0,0.5-0.1,0.7-0.2C1026.6,75.4,1026.5,74.3,1026.1,73.6L1026.1,73.6z M1029.4,76.5
+				c0.6-0.2,1-0.9,0.8-1.7c-0.1-0.5-0.3-1.5-0.6-1.9c-0.2-0.3-0.6-0.6-1-0.3c-0.6,0.4-1.6,0.5-2,0.9c0.2,0.7,0.3,1.7,0.4,2.6
+				c0.7,0,1.6-0.2,2.2,0.1c-0.4,0.1-1,0.1-1.3,0.3C1028.2,76.7,1028.9,76.7,1029.4,76.5L1029.4,76.5z M1023.5,72.7
+				c-0.4-1-0.8-2.1-1.5-2.9c-0.6,0.4-1.3,0.8-1.5,1.6C1021.4,71.9,1022.5,72.4,1023.5,72.7L1023.5,72.7z M1024.6,69.5
+				c0,1-0.2,2.4-0.4,3.2c0.7-0.8,1.2-1.8,1.7-2.8C1025.7,69.6,1025.2,69.3,1024.6,69.5z M1023.4,69.1c-0.2,0-0.5,0.3-0.8,0.2
+				c-0.1,0.1-0.1,0.2-0.2,0.3c0.7,0.9,1,2.1,1.6,3.1c0.3-1,0.3-2,0.3-3.1C1023.9,69.5,1023.7,69.1,1023.4,69.1z M1022.6,68.1
+				c0,0.3,0,0.4,0.1,0.7C1023.7,69.1,1023.5,67.5,1022.6,68.1L1022.6,68.1z M1021.5,67.7c-0.5-0.3-1-0.5-1.6-0.6
+				c-0.7-0.1-0.6,0.9-0.6,1.5c0,0.5,0.3,1,0.4,1.3c0.1,0.2,0.1,0.3,0.2,0.3c0.2,0.1,1-0.3,1.2-0.4c0.5-0.3,0.8-0.6,1.2-0.9
+				c0-0.1,0-0.3,0-0.4c-0.3-0.1-0.6-0.2-0.8-0.2c0.2-0.1,0.6-0.1,0.8-0.3c0-0.1,0-0.1,0-0.2C1021.9,68,1021.8,67.8,1021.5,67.7z
+				 M1017.5,67c-0.3,0.4,1,0.8,1.4,0.9c0-0.2,0.1-0.4,0.1-0.6C1018.5,67.2,1017.9,67.2,1017.5,67L1017.5,67z M1021.8,67.1
+				C1021.8,67.2,1021.8,67.2,1021.8,67.1c0.4,0.4,0.7,0.5,1.3,0.4c0.3-0.2,0.5-0.4,0.8-0.6C1023.3,67,1022.5,67.4,1021.8,67.1
+				L1021.8,67.1z M1025.7,68.3c0-0.4-0.1-1.2-0.4-1.3c-0.5-0.3-1.4,0.6-1.8,0.7c0,0.1,0.1,0.2,0.1,0.4c0.2-0.1,0.5,0,0.7,0.1
+				c-0.2,0-0.5,0-0.6,0.1c-0.1,0.2,0,0.4,0,0.6c0.6,0.2,1.2,0.2,1.8,0.3C1025.7,69,1025.8,68.7,1025.7,68.3z M1017,67.3
+				c-0.1-0.1-0.8-1-0.9-1c-1.3,0.5-2.6,1.4-3.7,2.3c1.1,2.3,1.5,5.1,1.6,7.8c1.2,0.6,2.3,1.4,3.9,1.5c-0.2-1.4-0.4-2.6-0.5-3.8
+				c-0.4-0.2-1,0-1.4-0.1c0-0.5,0.6-0.2,0.6-0.5c0-0.2-0.3-0.3-0.2-0.6c0.3,0.1,0.5,0.4,0.8,0.4c0.3-0.6,0-1.8,0-2.3
+				c0-0.1,0.1-0.6,0.3-0.5s0,1.2,0,1.7s-0.1,0.9,0.1,1.2c1.6-0.2,3.3-0.4,4.9-0.4c-0.4-0.2-0.8-0.3-1.3-0.6
+				c-0.3-0.2-1.1-0.5-1.2-0.7c-0.1-0.4,0.3-0.6,0.4-1c-0.8,0.4-1-0.4-1.2-1c-0.1-0.4-0.2-0.8-0.3-1.3
+				C1018.3,68.1,1017.6,67.7,1017,67.3L1017,67.3z M1025,66.4c1.1-0.5,1.3,2,0.9,2.8c0.1,0.2,0.3,0.3,0.4,0.6
+				c-0.6,1.1-1.3,2.1-1.9,3.2c0.5-0.3,1.1-0.1,1.7-0.3c0.2-0.1,0.3-0.5,0.5-0.9c0.4-1,0.9-2.3,1.1-3.3c0-0.2,0.2-0.7,0.1-0.9
+				c0-0.4-0.5-0.6-0.8-0.8c-0.4-0.4-0.7-0.8-1.2-1.1C1025.6,66,1025.2,66.2,1025,66.4L1025,66.4z M1014.4,56.6
+				c-0.5,0.6-0.4,1.7-0.4,2.5c1-0.6,2.2,0,2.2,1.1c0.5,0,0.2-0.6,0.1-0.9c-0.3-1.2,0.5-2.5,0-3.5C1015.6,55.7,1014.9,56,1014.4,56.6
+				L1014.4,56.6z M1018.2,53.2c-1.2,0.3-2.7,1.2-3.2,2.3c0.4-0.1,0.6-0.2,1-0.3c0.1,0,0.3,0.1,0.5,0c0.3-0.1,0.6-0.8,0.8-1.1
+				s0.5-0.4,0.7-0.6c0.1-0.1,0.3-0.1,0.3-0.2S1018.3,53.2,1018.2,53.2z M1024.4,53.5c-1.2-0.7-3.4-1.2-4.7-0.6
+				c-1.1,0.5-2.5,1.4-3,2.5c0.5,1.1-0.1,2.1-0.2,3.2c0,0.6,0.3,1.1,0.3,1.7c-0.2,0.3-0.6,0.3-1,0.3c-0.1-0.6-0.3-1.2-0.9-1.3
+				c-0.8-0.1-1.4,0.6-1.5,1.3c0,0.8,0.6,2.2,1.6,2.1c0.4,0,0.5-0.4,0.9-0.4c0.2,0.4-0.3,0.6-0.4,0.9c0,0.2,0,0.4,0.1,0.5
+				c0.2,0.7,0.6,1.7,1,2.2c0.5,0.7,1.4,0.8,2.5,0.9c0.2-0.4,0.9-0.4,1.3-0.3c-0.5-0.2-1-0.7-1.4-1.2c-0.5-0.5-0.9-1.1-1-1.8
+				c0.9,1.2,1.6,2.3,3.2,2.8c1.2,0.4,2.6-0.2,3.6-0.8c0.4-0.3,0.6-0.7,0.9-1.1c1-1.5,1.5-3.6,1.4-5.7c0-0.9,0-1.7-0.3-2.3
+				s-1.3-1.1-1.9-0.6c-0.1-0.6,0.5-0.9,1.2-0.7C1025.7,54.7,1025.2,53.9,1024.4,53.5z M1026.8,72.7c1-0.5,2.8-1.3,3.4,0
+				c0.3,0.6,0.5,1.2,0.6,1.8c0.2,0.7-0.2,2.2-0.9,2.4c-0.6,0.2-1.4,0.2-2.1,0c-0.1-0.1-0.2-0.2-0.3-0.3c-0.5,0-1.1,0-1.5,0.3
+				c0,0.4-0.2,0.5-0.5,0.6c-0.2,0.8,0.4,1.7,0.2,2.4c-0.1,0.5-0.7,0.6-1.1,0.7c0,0.2,0,0.5,0,0.7c-0.1,0.4-0.6,0.6-1,0.6
+				c-1.4,0.2-3.6,0.2-4.9-0.2c-0.4-0.9-0.7-2.1-1-3.1c-1.3,0.1-2.4-0.6-3.4-1c-0.4-0.2-0.8-0.3-1-0.5c-0.1-0.3-0.1-0.8-0.1-1.3
+				c-0.1-1.2-0.1-2.5-0.5-3.7c-0.1-0.6-0.4-1.1-0.6-1.6c-0.2-0.5-0.5-1.1-0.5-1.7c-0.1-0.8,0.6-0.8,1.1-1.1c0.7-0.5,1.3-0.8,2-1.2
+				c0.2-0.1,0.9-0.5,1-0.6c0.2-0.3-0.3-0.8-0.4-1c-0.2-0.3-0.3-0.7-0.3-1.1c-0.6-0.1-1.1-0.4-1.4-0.9c-0.5-0.7-0.8-2-0.4-3
+				c0-0.1,0.2-0.2,0.2-0.4s-0.1-0.6-0.1-0.8c0-1.3,0.2-2.4,1.1-2.8c0.4-1.4,1.6-1.9,2.8-2.6c0.4-0.3,0.9-0.4,1.5-0.6
+				c1.8-0.7,4.6-0.5,6.2,0.6c0.6,0.5,1.7,1.5,2,2.3c1,2,0.9,5.2,0.2,7.6c-0.1,0.4-0.2,0.8-0.4,1.2c-0.1,0.3-0.5,0.8-0.5,1
+				c0.1,0.2,0.9,0.9,1.1,1.1c0.3,0.3,1,0.7,1,1.2c0.1,0.4-0.2,1-0.3,1.4C1027.6,70.2,1027.2,71.5,1026.8,72.7"/>
+			<path class="st74" d="M1020.3,63.1c0.1-0.1,0.3-0.2,0.7,0c0,0-0.5,0.1-0.4,0.9h-0.2C1020.4,63.9,1020.2,63.2,1020.3,63.1"/>
+			<path class="st77" d="M1023.8,70c0,0.1-0.1,0.2-0.2,0.2s-0.2-0.1-0.2-0.2s0.1-0.2,0.2-0.2S1023.8,69.8,1023.8,70L1023.8,70"/>
+			<path class="st77" d="M1024,71c0,0.1-0.1,0.2-0.2,0.2s-0.2-0.1-0.2-0.2s0.1-0.2,0.2-0.2S1024,70.9,1024,71L1024,71"/>
+		</g>
+		
+			<linearGradient id="a91f0ca4-8fb7-4019-9c09-0a52e2c05754_00000060017991729052870010000008731193771680852369_" gradientUnits="userSpaceOnUse" x1="394" y1="-943.8148" x2="394" y2="-973.6649" gradientTransform="matrix(1 0 0 1 564 1025.7148)">
+			<stop  offset="0" style="stop-color:#0078D4"/>
+			<stop  offset="0.16" style="stop-color:#1380DA"/>
+			<stop  offset="0.53" style="stop-color:#3C91E5"/>
+			<stop  offset="0.82" style="stop-color:#559CEC"/>
+			<stop  offset="1" style="stop-color:#5EA0EF"/>
+		</linearGradient>
+		
+			<path id="a91f0ca4-8fb7-4019-9c09-0a52e2c05754_1_" style="fill:url(#a91f0ca4-8fb7-4019-9c09-0a52e2c05754_00000060017991729052870010000008731193771680852369_);" d="
+			M973,57.6v18.2l-7.5,6.1l-11.6-4.2v4.2l-6.6-8.6l19.2,1.5V58.4L973,57.6z M966.6,58.5L955.9,52v4.3l-9.9,2.9l-3,3.8v8.6l4.2,1.9
+			V62.4L966.6,58.5z"/>
+		<g>
+			<g>
+				<path class="st0" d="M98.4,462.1c0,2.2-1.8,4-4,4h-83c-2.2,0-4-1.8-4-4V144.4c0-2.2,1.8-4,4-4h83c2.2,0,4,1.8,4,4V462.1z"/>
+				<path class="st1" d="M98.4,462.1c0,2.2-1.8,4-4,4h-83c-2.2,0-4-1.8-4-4V144.4c0-2.2,1.8-4,4-4h83c2.2,0,4,1.8,4,4V462.1z"/>
+				<path class="st2" d="M94.4,466.5h-83c-2.4,0-4.4-2-4.4-4.4V144.4c0-2.4,2-4.4,4.4-4.4h83c2.4,0,4.4,2,4.4,4.4v317.7
+					C98.8,464.5,96.8,466.5,94.4,466.5z M11.4,140.8c-2,0-3.6,1.6-3.6,3.6v317.7c0,2,1.6,3.6,3.6,3.6h83c2,0,3.6-1.6,3.6-3.6V144.4
+					c0-2-1.6-3.6-3.6-3.6H11.4z"/>
+			</g>
+			<path class="st3" d="M94.4,466.6L94.4,466.6l-0.1-1.1h0.1c0.2,0,0.4,0,0.6-0.1l0.1,1.1C94.9,466.6,94.7,466.6,94.4,466.6z
+				 M92.3,466.6h-0.8v-1.1h0.8V466.6z M89.5,466.6h-0.8v-1.1h0.8V466.6z M86.7,466.6h-0.8v-1.1h0.8V466.6z M83.9,466.6h-0.8v-1.1
+				h0.8V466.6z M81.1,466.6h-0.8v-1.1h0.8V466.6z M78.3,466.6h-0.8v-1.1h0.8V466.6z M75.5,466.6h-0.8v-1.1h0.8V466.6z M72.7,466.6
+				h-0.8v-1.1h0.8V466.6z M69.9,466.6h-0.8v-1.1h0.8V466.6z M67.1,466.6h-0.8v-1.1h0.8V466.6z M64.4,466.6h-0.8v-1.1h0.8V466.6z
+				 M61.6,466.6h-0.8v-1.1h0.8V466.6z M58.8,466.6H58v-1.1h0.8V466.6z M56,466.6h-0.8v-1.1H56V466.6z M53.2,466.6h-0.8v-1.1h0.8
+				V466.6z M50.4,466.6h-0.8v-1.1h0.8V466.6z M47.6,466.6h-0.8v-1.1h0.8V466.6z M44.8,466.6H44v-1.1h0.8V466.6z M42,466.6h-0.8v-1.1
+				H42V466.6z M39.2,466.6h-0.8v-1.1h0.8V466.6z M36.4,466.6h-0.8v-1.1h0.8V466.6z M33.6,466.6h-0.8v-1.1h0.8V466.6z M30.8,466.6H30
+				v-1.1h0.8V466.6z M28,466.6h-0.8v-1.1H28V466.6z M25.2,466.6h-0.8v-1.1h0.8V466.6z M22.4,466.6h-0.8v-1.1h0.8V466.6z M19.6,466.6
+				h-0.8v-1.1h0.8V466.6z M16.8,466.6H16v-1.1h0.8V466.6z M14.1,466.6h-0.8v-1.1h0.8V466.6z M11.2,466.6c-0.3,0-0.6-0.1-0.9-0.2
+				l0.2-1.1c0.2,0.1,0.5,0.1,0.7,0.1V466.6z M97.1,465.3l-0.5-0.9c0.2-0.2,0.4-0.4,0.5-0.7l0.6,0.7
+				C97.6,464.8,97.4,465.1,97.1,465.3z M8.5,465.1c-0.2-0.3-0.4-0.6-0.6-0.9l0.6-0.7c0.1,0.3,0.3,0.5,0.5,0.7L8.5,465.1z
+				 M98.7,461.8l-0.8-0.2c0-0.3,0.1-0.6,0.1-1l0.8-0.1v0.1C98.8,461,98.8,461.4,98.7,461.8z M7,461.4c0-0.3,0-0.6,0-0.8v-0.3h0.8
+				v0.3c0,0.2,0,0.5,0,0.7L7,461.4z M98.8,457.8H98v-1.1h0.8V457.8z M7.8,457.5H7v-1.1h0.8V457.5z M98.8,454H98v-1.1h0.8V454z
+				 M7.8,453.7H7v-1.1h0.8V453.7z M98.8,450.2H98v-1.1h0.8V450.2z M7.8,449.9H7v-1.1h0.8V449.9z M98.8,446.3H98v-1.1h0.8V446.3z
+				 M7.8,446.1H7V445h0.8V446.1z M98.8,442.5H98v-1.1h0.8V442.5z M7.8,442.2H7v-1.1h0.8V442.2z M98.8,438.7H98v-1.1h0.8V438.7z
+				 M7.8,438.4H7v-1.1h0.8V438.4z M98.8,434.9H98v-1.1h0.8V434.9z M7.8,434.6H7v-1.1h0.8V434.6z M98.8,431H98v-1.1h0.8V431z
+				 M7.8,430.8H7v-1.1h0.8V430.8z M98.8,427.2H98v-1.1h0.8V427.2z M7.8,427H7v-1.1h0.8V427z M98.8,423.4H98v-1.1h0.8V423.4z
+				 M7.8,423.1H7V422h0.8V423.1z M98.8,419.6H98v-1.1h0.8V419.6z M7.8,419.3H7v-1.1h0.8V419.3z M98.8,415.7H98v-1.1h0.8V415.7z
+				 M7.8,415.5H7v-1.1h0.8V415.5z M98.8,411.9H98v-1.1h0.8V411.9z M7.8,411.7H7v-1.1h0.8V411.7z M98.8,408.1H98V407h0.8V408.1z
+				 M7.8,407.8H7v-1.1h0.8V407.8z M98.8,404.3H98v-1.1h0.8V404.3z M7.8,404H7v-1.1h0.8V404z M98.8,400.4H98v-1.1h0.8V400.4z
+				 M7.8,400.2H7v-1.1h0.8V400.2z M98.8,396.6H98v-1.1h0.8V396.6z M7.8,396.4H7v-1.1h0.8V396.4z M98.8,392.8H98v-1.1h0.8V392.8z
+				 M7.8,392.5H7v-1.1h0.8V392.5z M98.8,389H98v-1.1h0.8V389z M7.8,388.7H7v-1.1h0.8V388.7z M98.8,385.2H98v-1.1h0.8V385.2z
+				 M7.8,384.9H7v-1.1h0.8V384.9z M98.8,381.3H98v-1.1h0.8V381.3z M7.8,381.1H7V380h0.8V381.1z M98.8,377.5H98v-1.1h0.8V377.5z
+				 M7.8,377.2H7v-1.1h0.8V377.2z M98.8,373.7H98v-1.1h0.8V373.7z M7.8,373.4H7v-1.1h0.8V373.4z M98.8,369.9H98v-1.1h0.8V369.9z
+				 M7.8,369.6H7v-1.1h0.8V369.6z M98.8,366H98v-1.1h0.8V366z M7.8,365.8H7v-1.1h0.8V365.8z M98.8,362.2H98v-1.1h0.8V362.2z
+				 M7.8,361.9H7v-1.1h0.8V361.9z M98.8,358.4H98v-1.1h0.8V358.4z M7.8,358.1H7V357h0.8V358.1z M98.8,354.6H98v-1.1h0.8V354.6z
+				 M7.8,354.3H7v-1.1h0.8V354.3z M98.8,350.7H98v-1.1h0.8V350.7z M7.8,350.5H7v-1.1h0.8V350.5z M98.8,346.9H98v-1.1h0.8V346.9z
+				 M7.8,346.6H7v-1.1h0.8V346.6z M98.8,343.1H98V342h0.8V343.1z M7.8,342.8H7v-1.1h0.8V342.8z M98.8,339.3H98v-1.1h0.8V339.3z
+				 M7.8,339H7v-1.1h0.8V339z M98.8,335.4H98v-1.1h0.8V335.4z M7.8,335.2H7v-1.1h0.8V335.2z M98.8,331.6H98v-1.1h0.8V331.6z
+				 M7.8,331.3H7v-1.1h0.8V331.3z M98.8,327.8H98v-1.1h0.8V327.8z M7.8,327.5H7v-1.1h0.8V327.5z M98.8,324H98v-1.1h0.8V324z
+				 M7.8,323.7H7v-1.1h0.8V323.7z M98.8,320.1H98V319h0.8V320.1z M7.8,319.9H7v-1.1h0.8V319.9z M98.8,316.3H98v-1.1h0.8V316.3z
+				 M7.8,316.1H7V315h0.8V316.1z M98.8,312.5H98v-1.1h0.8V312.5z M7.8,312.2H7v-1.1h0.8V312.2z M98.8,308.7H98v-1.1h0.8V308.7z
+				 M7.8,308.4H7v-1.1h0.8V308.4z M98.8,304.8H98v-1.1h0.8V304.8z M7.8,304.6H7v-1.1h0.8V304.6z M98.8,301H98v-1.1h0.8V301z
+				 M7.8,300.8H7v-1.1h0.8V300.8z M98.8,297.2H98v-1.1h0.8V297.2z M7.8,296.9H7v-1.1h0.8V296.9z M98.8,293.4H98v-1.1h0.8V293.4z
+				 M7.8,293.1H7V292h0.8V293.1z M98.8,289.6H98v-1.1h0.8V289.6z M7.8,289.3H7v-1.1h0.8V289.3z M98.8,285.7H98v-1.1h0.8V285.7z
+				 M7.8,285.5H7v-1.1h0.8V285.5z M98.8,281.9H98v-1.1h0.8V281.9z M7.8,281.6H7v-1.1h0.8V281.6z M98.8,278.1H98V277h0.8V278.1z
+				 M7.8,277.8H7v-1.1h0.8V277.8z M98.8,274.3H98v-1.1h0.8V274.3z M7.8,274H7v-1.1h0.8V274z M98.8,270.4H98v-1.1h0.8V270.4z
+				 M7.8,270.2H7v-1.1h0.8V270.2z M98.8,266.6H98v-1.1h0.8V266.6z M7.8,266.3H7v-1.1h0.8V266.3z M98.8,262.8H98v-1.1h0.8V262.8z
+				 M7.8,262.5H7v-1.1h0.8V262.5z M98.8,259H98v-1.1h0.8V259z M7.8,258.7H7v-1.1h0.8V258.7z M98.8,255.1H98V254h0.8V255.1z
+				 M7.8,254.9H7v-1.1h0.8V254.9z M98.8,251.3H98v-1.1h0.8V251.3z M7.8,251H7v-1h0.8V251z M98.8,247.5H98v-1.1h0.8V247.5z
+				 M7.8,247.2H7v-1.1h0.8V247.2z M98.8,243.7H98v-1.1h0.8V243.7z M7.8,243.4H7v-1.1h0.8V243.4z M98.8,239.8H98v-1.1h0.8V239.8z
+				 M7.8,239.6H7v-1.1h0.8V239.6z M98.8,236H98v-1.1h0.8V236z M7.8,235.7H7v-1.1h0.8V235.7z M98.8,232.2H98v-1.1h0.8V232.2z
+				 M7.8,231.9H7v-1.1h0.8V231.9z M98.8,228.4H98v-1.1h0.8V228.4z M7.8,228.1H7V227h0.8V228.1z M98.8,224.5H98v-1.1h0.8V224.5z
+				 M7.8,224.3H7v-1.1h0.8V224.3z M98.8,220.7H98v-1.1h0.8V220.7z M7.8,220.5H7v-1.1h0.8V220.5z M98.8,216.9H98v-1.1h0.8V216.9z
+				 M7.8,216.6H7v-1.1h0.8V216.6z M98.8,213.1H98V212h0.8V213.1z M7.8,212.8H7v-1.1h0.8V212.8z M98.8,209.2H98v-1.1h0.8V209.2z
+				 M7.8,209H7v-1.1h0.8V209z M98.8,205.4H98v-1.1h0.8V205.4z M7.8,205.2H7v-1.1h0.8V205.2z M98.8,201.6H98v-1.1h0.8V201.6z
+				 M7.8,201.3H7v-1.1h0.8V201.3z M98.8,197.8H98v-1.1h0.8V197.8z M7.8,197.5H7v-1.1h0.8V197.5z M98.8,193.9H98v-1.1h0.8V193.9z
+				 M7.8,193.7H7v-1.1h0.8V193.7z M98.8,190.1H98V189h0.8V190.1z M7.8,189.9H7v-1.1h0.8V189.9z M98.8,186.3H98v-1.1h0.8V186.3z
+				 M7.8,186H7v-1.1h0.8V186z M98.8,182.5H98v-1.1h0.8V182.5z M7.8,182.2H7v-1.1h0.8V182.2z M98.8,178.7H98v-1.1h0.8V178.7z
+				 M7.8,178.4H7v-1.1h0.8V178.4z M98.8,174.8H98v-1.1h0.8V174.8z M7.8,174.6H7v-1.1h0.8V174.6z M98.8,171H98v-1.1h0.8V171z
+				 M7.8,170.7H7v-1.1h0.8V170.7z M98.8,167.2H98v-1.1h0.8V167.2z M7.8,166.9H7v-1.1h0.8V166.9z M98.8,163.4H98v-1.1h0.8V163.4z
+				 M7.8,163.1H7V162h0.8V163.1z M98.8,159.5H98v-1.1h0.8V159.5z M7.8,159.3H7v-1.1h0.8V159.3z M98.8,155.7H98v-1.1h0.8V155.7z
+				 M7.8,155.4H7v-1.1h0.8V155.4z M98.8,151.9H98v-1.1h0.8V151.9z M7.8,151.6H7v-1.1h0.8V151.6z M98.8,148.1H98V147h0.8V148.1z
+				 M7.8,147.8H7v-1.1h0.8V147.8z M97.8,144.4c-0.1-0.3-0.2-0.6-0.3-0.9l0.7-0.5c0.1,0.4,0.3,0.7,0.3,1.1L97.8,144.4z M8,144.2
+				l-0.8-0.4c0.1-0.4,0.2-0.7,0.4-1.1l0.7,0.6C8.2,143.6,8.1,143.9,8,144.2z M96.4,141.7c-0.2-0.2-0.4-0.3-0.6-0.5l0.3-1
+				c0.3,0.1,0.5,0.3,0.8,0.6L96.4,141.7z M9.6,141.6l-0.4-0.9c0.3-0.2,0.5-0.4,0.8-0.5l0.3,1C10,141.3,9.8,141.4,9.6,141.6z
+				 M93.9,140.9h-0.8v-1.1h0.8V140.9z M91.1,140.9h-0.8v-1.1h0.8V140.9z M88.3,140.9h-0.8v-1.1h0.8V140.9z M85.5,140.9h-0.8v-1.1
+				h0.8V140.9z M82.7,140.9h-0.8v-1.1h0.8V140.9z M79.9,140.9h-0.8v-1.1h0.8V140.9z M77.1,140.9h-0.8v-1.1h0.8V140.9z M74.4,140.9
+				h-0.8v-1.1h0.8V140.9z M71.6,140.9h-0.8v-1.1h0.8V140.9z M68.8,140.9H68v-1.1h0.8V140.9z M66,140.9h-0.8v-1.1H66V140.9z
+				 M63.2,140.9h-0.8v-1.1h0.8V140.9z M60.4,140.9h-0.8v-1.1h0.8V140.9z M57.6,140.9h-0.8v-1.1h0.8V140.9z M54.8,140.9H54v-1.1h0.8
+				V140.9z M52,140.9h-0.8v-1.1H52V140.9z M49.2,140.9h-0.8v-1.1h0.8V140.9z M46.4,140.9h-0.8v-1.1h0.8V140.9z M43.6,140.9h-0.8
+				v-1.1h0.8V140.9z M40.8,140.9H40v-1.1h0.8V140.9z M38,140.9h-0.8v-1.1H38V140.9z M35.2,140.9h-0.8v-1.1h0.8V140.9z M32.4,140.9
+				h-0.8v-1.1h0.8V140.9z M29.6,140.9h-0.8v-1.1h0.8V140.9z M26.8,140.9H26v-1.1h0.8V140.9z M24.1,140.9h-0.8v-1.1h0.8V140.9z
+				 M21.3,140.9h-0.8v-1.1h0.8V140.9z M18.5,140.9h-0.8v-1.1h0.8V140.9z M15.7,140.9h-0.8v-1.1h0.8V140.9z M12.9,140.9h-0.8v-1.1
+				h0.8V140.9z"/>
+		</g>
+		<g>
+			
+				<linearGradient id="SVGID_00000168096650140917787340000003717042071824589975_" gradientUnits="userSpaceOnUse" x1="52.8035" y1="-554.6132" x2="52.8035" y2="-582.8065" gradientTransform="matrix(1 0 0 1 -3.547359e-03 791.7134)">
+				<stop  offset="0" style="stop-color:#258277"/>
+				<stop  offset="0.42" style="stop-color:#49A498"/>
+				<stop  offset="0.78" style="stop-color:#60BAAD"/>
+				<stop  offset="1" style="stop-color:#68C2B5"/>
+			</linearGradient>
+			<path style="fill:url(#SVGID_00000168096650140917787340000003717042071824589975_);" d="M38.1,220.9l14-14c0.4-0.4,1-0.4,1.4,0
+				l14,14c0.4,0.4,0.4,1,0,1.4l-14,14c-0.4,0.4-1,0.4-1.4,0l-14-14C37.7,221.9,37.7,221.3,38.1,220.9z"/>
+			<path class="st0" d="M49.4,214l3.3-3.3c0.1-0.1,0.2-0.1,0.2,0l3.4,3.3c0.1,0.1,0.1,0.2,0,0.2c0,0-0.1,0.1-0.2,0.1h-2
+				c-0.1,0-0.2,0.1-0.2,0.2l0,0v4.3c0,0.1-0.1,0.2-0.2,0.2l0,0h-2.1c-0.1,0-0.2-0.1-0.2-0.1l0,0v-4.3c0-0.1-0.1-0.2-0.2-0.2h-2
+				C49.4,214.2,49.4,214.1,49.4,214L49.4,214z M56.4,229.2l-3.4,3.3c-0.1,0.1-0.2,0.1-0.2,0l-3.3-3.3c-0.1-0.1,0-0.2,0-0.2h0.1h2
+				c0.1,0,0.2-0.1,0.2-0.2v-4.3c0-0.1,0.1-0.2,0.2-0.2l0,0h2.1c0.1,0,0.2,0.1,0.2,0.2l0,0v4.3c0,0.1,0.1,0.2,0.2,0.2l0,0h1.9
+				c0.1-0.1,0.2,0,0.2,0C56.5,229,56.4,229.2,56.4,229.2z M46.4,224.8v-1.9c0-0.1-0.1-0.2-0.2-0.2h-4.3c-0.1,0-0.2-0.1-0.2-0.2v-2.1
+				c0-0.1,0.1-0.2,0.2-0.2h4.3c0.1,0,0.2-0.1,0.2-0.2v-2c0-0.1,0-0.2,0.1-0.2s0.1,0,0.2,0.1l3.3,3.4c0.1,0.1,0.1,0.2,0,0.2l0,0
+				l-3.3,3.3C46.6,224.9,46.5,224.9,46.4,224.8C46.4,224.9,46.4,224.9,46.4,224.8z M59.3,218.2v2c0,0.1,0.1,0.2,0.2,0.2h4.3
+				c0.1,0,0.2,0.1,0.2,0.2v2.1c0,0.1-0.1,0.2-0.2,0.2h-4.3c-0.1,0-0.2,0.1-0.2,0.2v1.9c0,0.1,0,0.2-0.1,0.2s-0.1,0-0.2-0.1l-3.3-3.4
+				c-0.1-0.1-0.1-0.2,0-0.2l0,0l3.3-3.3C59,218.1,59.1,218.1,59.3,218.2C59.3,218,59.3,218.1,59.3,218.2z"/>
+		</g>
+		<g>
+			
+				<linearGradient id="SVGID_00000156581473025862547970000013066614081321265320_" gradientUnits="userSpaceOnUse" x1="13.3" y1="-343.9832" x2="13.3" y2="-318.9832" gradientTransform="matrix(1 0 0 1 0 791.7148)">
+				<stop  offset="0" style="stop-color:#5EA0EF"/>
+				<stop  offset="0.18" style="stop-color:#559CEC"/>
+				<stop  offset="0.47" style="stop-color:#3C91E5"/>
+				<stop  offset="0.84" style="stop-color:#1380DA"/>
+				<stop  offset="1" style="stop-color:#0078D4"/>
+			</linearGradient>
+			<path style="fill:url(#SVGID_00000156581473025862547970000013066614081321265320_);" d="M20.6,448.6v23.3c0,0.5-0.4,0.8-0.8,0.8
+				l0,0h-13c-0.5,0-0.8-0.4-0.8-0.8l0,0v-23.3c0-0.5,0.4-0.8,0.8-0.8l0,0h13C20.3,447.7,20.6,448.1,20.6,448.6L20.6,448.6z"/>
+			<path id="a1bc77ea-5288-41a0-8f9a-2d282cf54a86_2_" class="st81" d="M7.9,450.3h2.5c0.1,0,0.2,0.1,0.2,0.2v3.1
+				c0,0.1-0.1,0.2-0.2,0.2H7.9c-0.1,0-0.2-0.1-0.2-0.2v-3.1C7.7,450.4,7.8,450.3,7.9,450.3z M12.1,450.3h2.4c0.1,0,0.2,0.1,0.2,0.2
+				l0,0v3.1c0,0.1-0.1,0.2-0.2,0.2l0,0h-2.4c-0.1,0-0.2-0.1-0.2-0.2l0,0v-3.1C11.9,450.4,12,450.3,12.1,450.3L12.1,450.3z
+				 M16.3,450.3h2.4c0.1,0,0.2,0.1,0.2,0.2v3.1c0,0.1-0.1,0.2-0.2,0.2h-2.4c-0.1,0-0.2-0.1-0.2-0.2l0,0v-3.1
+				C16.1,450.4,16.2,450.3,16.3,450.3L16.3,450.3z M7.9,455.9h2.5c0.1,0,0.2,0.1,0.2,0.2v3.1c0,0.1-0.1,0.2-0.2,0.2H7.9
+				c-0.1,0-0.2-0.1-0.2-0.2v-3.1C7.7,456,7.8,455.9,7.9,455.9z M12.1,455.9h2.4c0.1,0,0.2,0.1,0.2,0.2l0,0v3.1
+				c0,0.1-0.1,0.2-0.2,0.2h-2.4c-0.1,0-0.2-0.1-0.2-0.2v-3.1C11.9,456,12,455.9,12.1,455.9L12.1,455.9z M16.3,455.9h2.4
+				c0.1,0,0.2,0.1,0.2,0.2v3.1c0,0.1-0.1,0.2-0.2,0.2h-2.4c-0.1,0-0.2-0.1-0.2-0.2v-3.1C16.1,456,16.2,455.9,16.3,455.9L16.3,455.9z
+				 M7.9,461.6h2.5c0.1,0,0.2,0.1,0.2,0.2l0,0v3.1c0,0.1-0.1,0.2-0.2,0.2l0,0H7.9c-0.1,0-0.2-0.1-0.2-0.2v-3.1
+				C7.7,461.6,7.8,461.5,7.9,461.6z M12.1,461.6h2.4c0.1,0,0.2,0,0.3,0.1l0,0v3.1c0,0.1-0.1,0.2-0.2,0.2l0,0h-2.5
+				c-0.1,0-0.2-0.1-0.2-0.2l0,0v-3.1C11.9,461.6,12,461.6,12.1,461.6z M12.1,467.2h2.4c0.1,0,0.2,0.1,0.2,0.2l0,0v4.6
+				c0,0.1-0.1,0.2-0.2,0.2h-2.4c-0.1,0-0.2-0.1-0.2-0.2v-4.6C11.9,467.3,12,467.2,12.1,467.2z M16.3,461.6h2.4
+				c0.1,0,0.2,0.1,0.2,0.2v3.1c0,0.1-0.1,0.2-0.2,0.2h-2.4c-0.1,0-0.2-0.1-0.2-0.2l0,0v-3.1C16.1,461.6,16.2,461.6,16.3,461.6z"/>
+		</g>
+		<g>
+			<g>
+				<polygon class="st40" points="56.2,326 69.7,334.8 83.5,325.9 85.2,327.9 69.7,337.9 54.4,327.9 				"/>
+				<polygon class="st0" points="57.2,324.8 69.7,309.9 82.5,324.9 69.7,332.9 				"/>
+				<polygon class="st40" points="69.7,309.9 69.7,332.9 57.2,324.8 				"/>
+				
+					<linearGradient id="SVGID_00000183955028822926118420000017851510368249775012_" gradientUnits="userSpaceOnUse" x1="77.1024" y1="-460.9161" x2="69.1879" y2="-475.9076" gradientTransform="matrix(1 0 0 1 0 791.7148)">
+					<stop  offset="0" style="stop-color:#3085C7"/>
+					<stop  offset="0.9" style="stop-color:#5FABDF"/>
+				</linearGradient>
+				<polygon style="fill:url(#SVGID_00000183955028822926118420000017851510368249775012_);" points="69.7,309.9 69.7,332.9 
+					82.5,324.9 				"/>
+				<polygon class="st83" points="69.7,321.8 82.5,324.9 69.7,332.9 				"/>
+				<polygon class="st38" points="69.7,332.9 57.2,324.8 69.7,321.8 				"/>
+				
+					<linearGradient id="SVGID_00000096056442017437846840000013628021894110467478_" gradientUnits="userSpaceOnUse" x1="73.7037" y1="-465.2773" x2="79.1738" y2="-455.8414" gradientTransform="matrix(1 0 0 1 0 791.7148)">
+					<stop  offset="0.1" style="stop-color:#5FABDF"/>
+					<stop  offset="0.29" style="stop-color:#5AA8DD"/>
+					<stop  offset="0.51" style="stop-color:#4DA0D8"/>
+					<stop  offset="0.74" style="stop-color:#3B90CE"/>
+					<stop  offset="0.88" style="stop-color:#3085C7"/>
+				</linearGradient>
+				<polygon style="fill:url(#SVGID_00000096056442017437846840000013628021894110467478_);" points="69.7,337.9 85.2,327.9 
+					83.5,325.9 69.7,334.8 				"/>
+			</g>
+			<g>
+				<g>
+					<g>
+						
+							<linearGradient id="SVGID_00000037666246716907618900000011095726739011998096_" gradientUnits="userSpaceOnUse" x1="36.1" y1="-512.9149" x2="36.1" y2="-489.6793" gradientTransform="matrix(1 0 0 1 0 791.7148)">
+							<stop  offset="0" style="stop-color:#B3B2B4"/>
+							<stop  offset="0.38" style="stop-color:#B0AEAF"/>
+							<stop  offset="0.76" style="stop-color:#A2A1A1"/>
+							<stop  offset="1" style="stop-color:#979797"/>
+						</linearGradient>
+						<path style="fill:url(#SVGID_00000037666246716907618900000011095726739011998096_);" d="M43.7,301.3c0,0.5-0.4,0.8-0.9,0.8
+							H29.4c-0.5,0-0.8-0.3-0.9-0.8v-21.7c0-0.5,0.4-0.8,0.9-0.8h13.3c0.5,0,0.8,0.3,0.9,0.8L43.7,301.3L43.7,301.3z"/>
+						<path class="st86" d="M30.8,288.7c0-0.9,0.7-1.8,1.6-1.8h7.5c0.9,0.1,1.7,0.9,1.6,1.8l0,0c0.1,0.9-0.6,1.8-1.6,1.9
+							c0,0,0,0-0.1,0h-7.5C31.5,290.6,30.8,289.8,30.8,288.7L30.8,288.7z"/>
+						<path class="st86" d="M30.8,283.4c0-0.9,0.7-1.7,1.6-1.8h7.5c0.9,0.1,1.7,0.9,1.6,1.8l0,0c0,0.9-0.7,1.8-1.6,1.8h-7.5
+							C31.5,285.1,30.8,284.3,30.8,283.4L30.8,283.4z"/>
+						<circle class="st40" cx="32.9" cy="283.4" r="1.2"/>
+						<circle class="st40" cx="32.9" cy="288.7" r="1.2"/>
+					</g>
+				</g>
+				<g>
+					
+						<linearGradient id="SVGID_00000013910471034979880420000017415373664488805514_" gradientUnits="userSpaceOnUse" x1="38.2649" y1="-490.9648" x2="48.9914" y2="-490.9648" gradientTransform="matrix(1 0 0 1 0 791.7148)">
+						<stop  offset="0" style="stop-color:#005CA1"/>
+						<stop  offset="7.000000e-02" style="stop-color:#0161AA"/>
+						<stop  offset="0.36" style="stop-color:#2571B8"/>
+						<stop  offset="0.52" style="stop-color:#2E76BC"/>
+						<stop  offset="0.64" style="stop-color:#2973BA"/>
+						<stop  offset="0.82" style="stop-color:#166BB5"/>
+						<stop  offset="1" style="stop-color:#005CA1"/>
+					</linearGradient>
+					<path style="fill:url(#SVGID_00000013910471034979880420000017415373664488805514_);" d="M43.7,296.5c-2.9,0-5.4-0.9-5.4-1.9
+						v10.3c0,1.1,2.4,2,5.3,2h0.1c2.9,0,5.4-0.9,5.4-2v-10.3C49,295.6,46.6,296.5,43.7,296.5z"/>
+					<path class="st88" d="M49,294.5c0,1.1-2.4,2-5.4,2s-5.4-0.9-5.4-2s2.5-1.9,5.4-1.9S49,293.4,49,294.5"/>
+					<path class="st40" d="M47.7,294.4c0,0.7-1.8,1.2-4.1,1.2s-4.1-0.5-4.1-1.2s1.8-1.2,4.2-1.2C46,293.1,47.8,293.7,47.7,294.4"/>
+					<path class="st89" d="M43.7,294.6c-1.1,0-2.2,0.1-3.2,0.5c1,0.3,2.1,0.5,3.2,0.5c1.1,0,2.2-0.1,3.3-0.5
+						C45.9,294.8,44.8,294.6,43.7,294.6z"/>
+				</g>
+			</g>
+			<g>
+				
+					<linearGradient id="SVGID_00000117638233726755948430000005187157899999877038_" gradientUnits="userSpaceOnUse" x1="43.9" y1="-414.9608" x2="43.9" y2="-441.4055" gradientTransform="matrix(1 0 0 1 0 791.7148)">
+					<stop  offset="5.000000e-02" style="stop-color:#949494"/>
+					<stop  offset="0.36" style="stop-color:#979797"/>
+					<stop  offset="0.54" style="stop-color:#9F9E9E"/>
+					<stop  offset="0.69" style="stop-color:#AEADAE"/>
+					<stop  offset="0.73" style="stop-color:#B3B4B4"/>
+				</linearGradient>
+				<path style="fill:url(#SVGID_00000117638233726755948430000005187157899999877038_);" d="M51.7,375.9c0,0.5-0.4,0.9-0.9,0.9l0,0
+					H37c-0.5,0-0.9-0.4-0.9-0.9l0,0v-24.7c0-0.5,0.4-0.9,0.9-0.9l0,0h13.8c0.5,0,0.9,0.4,0.9,0.9l0,0V375.9z"/>
+				<path class="st86" d="M38.4,359.6c0-0.9,0.8-1.7,1.7-1.7h0.1H48c0.9,0,1.6,0.8,1.6,1.7l0,0c0,0.9-0.7,1.7-1.7,1.7l0,0h-7.8
+					C39.1,361.3,38.4,360.5,38.4,359.6L38.4,359.6z"/>
+				<path class="st86" d="M38.4,354.6c0-0.9,0.8-1.7,1.7-1.7c0,0,0,0,0.1,0H48c0.9,0,1.6,0.8,1.6,1.7l0,0c0,0.9-0.8,1.7-1.7,1.7l0,0
+					h-7.8C39.1,356.3,38.4,355.5,38.4,354.6L38.4,354.6z"/>
+				<circle class="st40" cx="40.2" cy="354.6" r="1.1"/>
+				<circle class="st40" cx="40.2" cy="359.6" r="1.1"/>
+				
+					<linearGradient id="SVGID_00000098217721863236508540000013619981007136654241_" gradientUnits="userSpaceOnUse" x1="51.6" y1="-432.8187" x2="51.6" y2="-411.5232" gradientTransform="matrix(1 0 0 1 0 791.7148)">
+					<stop  offset="0.18" style="stop-color:#699CD3"/>
+					<stop  offset="1" style="stop-color:#2E76BC"/>
+				</linearGradient>
+				<path style="fill:url(#SVGID_00000098217721863236508540000013619981007136654241_);" d="M62.3,371.9c-0.1-2.4-1.8-4.3-4.2-4.7
+					c-0.1-3.3-2.9-6-6.2-5.9c-2.7,0-5.1,1.6-6,4.1c-2.8,0.4-4.9,2.7-5,5.6c0.1,3.2,2.8,5.8,6,5.7h0.5h9.7h0.3
+					C60.2,376.7,62.3,374.6,62.3,371.9z"/>
+				<rect x="35.2" y="349.5" class="st92" width="28" height="28"/>
+			</g>
+		</g>
+		<g>
+			<path d="M1076.8,69.3c-0.2,0-0.3-0.1-0.4-0.2l-0.9-0.9c-0.2-0.2-0.3-0.6,0-0.9s0.6-0.3,0.9,0l0,0l0.5,0.5l1.5-1.5
+				c0.2-0.2,0.6-0.2,0.9,0s0.2,0.6,0,0.9l0,0l-1.9,1.9C1077.1,69.2,1076.9,69.3,1076.8,69.3z M1088.5,69.1l1.9-1.9
+				c0.2-0.2,0.2-0.6,0-0.9c-0.2-0.2-0.6-0.2-0.9,0l-1.5,1.5l-0.5-0.5c-0.2-0.2-0.6-0.3-0.9,0s-0.3,0.6,0,0.9l0,0l0.9,0.9
+				C1087.8,69.3,1088.2,69.3,1088.5,69.1L1088.5,69.1z M1068.7,61.3l3.2-2c0.6-0.4,0.8-1.1,0.4-1.7c-0.1-0.2-0.2-0.3-0.4-0.4l-3.2-2
+				c-0.6-0.4-1.4-0.2-1.7,0.4c-0.1,0.2-0.2,0.4-0.2,0.7v4c0,0.7,0.6,1.3,1.3,1.2C1068.3,61.5,1068.5,61.4,1068.7,61.3z M1071.2,58.3
+				l-3.2,2v-4L1071.2,58.3z M1093,67.6c0,2.4-2,4.4-4.4,4.4c-2.2,0-4-1.6-4.3-3.8h-2.6c-0.3,2.1-2.2,3.7-4.3,3.8
+				c-2.2,0-4-1.6-4.3-3.8h-0.7c-1.2,0-2.3-0.5-3.1-1.3v6.3c0,2.1,1.7,3.8,3.8,3.8h0.1c0.3-2.1,2.1-3.8,4.3-3.8c2.4,0,4.4,2,4.4,4.4
+				s-2,4.4-4.4,4.4c-2.2,0-4-1.6-4.3-3.8h-0.1c-2.8,0-5-2.2-5-5v-8.9c-2.9-0.6-5-3.2-5-6.1c0-3.4,2.8-6.2,6.2-6.2s6.2,2.8,6.2,6.2
+				s-2.8,6.2-6.2,6.2c0.3,1.5,1.6,2.5,3,2.5h0.7c0.3-2.1,2.1-3.8,4.3-3.8c2.2,0,4,1.6,4.3,3.8h2.6c0.3-2.1,2.2-3.7,4.3-3.8
+				C1091.1,63.2,1093,65.2,1093,67.6z M1074.3,77.6c0,1.7,1.4,3.1,3.1,3.1s3.1-1.4,3.1-3.1s-1.4-3.1-3.1-3.1
+				S1074.3,75.9,1074.3,77.6z M1069.3,63.2c2.8,0,5-2.2,5-5s-2.2-5-5-5s-5,2.2-5,5S1066.5,63.2,1069.3,63.2z M1080.5,67.6
+				c0-1.7-1.4-3.1-3.1-3.1s-3.1,1.4-3.1,3.1s1.4,3.1,3.1,3.1S1080.5,69.3,1080.5,67.6z M1091.8,67.6c0-1.7-1.4-3.1-3.1-3.1
+				s-3.1,1.4-3.1,3.1s1.4,3.1,3.1,3.1S1091.8,69.3,1091.8,67.6z M1075.5,77.6c0,0.3,0.3,0.6,0.6,0.6s0.6-0.3,0.6-0.6
+				s-0.3-0.6-0.6-0.6S1075.5,77.3,1075.5,77.6z M1078,77.6c0,0.3,0.3,0.6,0.6,0.6s0.6-0.3,0.6-0.6s-0.3-0.6-0.6-0.6
+				S1078,77.3,1078,77.6z M1093,77.6c0,2.4-2,4.4-4.4,4.4c-2.2,0-4-1.6-4.3-3.8l0,0h-0.6l0,0c-0.3,0-0.6-0.3-0.6-0.6
+				c0-0.3,0.3-0.6,0.6-0.6h0.6c0,0,0,0,0.1,0c0.3-2.2,2.1-3.8,4.3-3.8C1091.1,73.2,1093,75.2,1093,77.6z M1091.8,77.6
+				c0-1.7-1.4-3.1-3.1-3.1s-3.1,1.4-3.1,3.1s1.4,3.1,3.1,3.1S1091.8,79.3,1091.8,77.6z"/>
+		</g>
+		<g>
+			<rect x="243.2" y="6.5" class="st0" width="153.8" height="69.8"/>
+			<rect x="243.2" y="6.5" class="st4" width="153.8" height="69.8"/>
+			<path class="st5" d="M396.8,6.6v69.5H243.3V6.6H396.8 M397,6.3H243v70h154V6.3L397,6.3z"/>
+		</g>
+		<g>
+			<g>
+				<rect x="318.3" y="86" class="st51" width="3" height="54.2"/>
+				<g>
+					<polygon class="st51" points="319.8,76.5 325.3,89.9 319.8,86.7 314.3,89.9 					"/>
+				</g>
+			</g>
+			<path class="st52" d="M320.5,140.2H319v-4h1.5V140.2z M320.5,134.2H319v-4h1.5V134.2z M320.5,128.2H319v-4h1.5V128.2z
+				 M320.5,122.2H319v-4h1.5V122.2z M320.5,116.2H319v-4h1.5V116.2z M320.5,110.2H319v-4h1.5V110.2z M320.5,104.2H319v-4h1.5V104.2z
+				 M320.5,98.2H319v-4h1.5V98.2z M320.5,92.2H319v-4h1.5V92.2z M320.5,86.2H319V86h1.5V86.2z"/>
+		</g>
+		<g>
+			<g>
+				<rect x="106.2" y="217.3" class="st53" width="440" height="3"/>
+				<g>
+					<polygon class="st53" points="544.4,212.8 554.8,218.8 544.4,224.8 					"/>
+				</g>
+				<g>
+					<polygon class="st53" points="107.9,212.8 97.6,218.8 107.9,224.8 					"/>
+				</g>
+			</g>
+			<g>
+				<rect x="545.7" y="217.8" class="st54" width="0.5" height="2"/>
+				<path class="st54" d="M543.8,219.8l-1.1,0l0-2l1.1,0V219.8z M540.8,219.8l-1.1,0l0-2l1.1,0V219.8z M537.8,219.8l-1.1,0l0-2l1,0
+					V219.8z M534.8,219.8l-1.1,0l0.1-2l1,0V219.8z M531.8,219.8l-1.1,0l0.1-2l1,0V219.8z M528.8,219.8l-1.1,0l0.1-2l1,0V219.8z
+					 M525.8,219.8l-1.1,0l0-2l1,0V219.8z M522.9,219.8l-1.1,0l0-2l1,0V219.8z M519.9,219.8l-1.1,0l0-2l1,0V219.8z M516.9,219.8
+					l-1.1,0l0-2l1.1,0V219.8z M513.9,219.8l-1.1,0l0-2l1.1,0V219.8z M510.9,219.8l-1.1,0l0-2l1,0V219.8z M507.9,219.8l-1.1,0l0.1-2
+					l1,0V219.8z M505,219.8l-1.1,0l0.1-2l1,0V219.8z M502,219.8l-1.1,0l0.1-2l1,0V219.8z M499,219.8l-1.1,0l0.1-2l1,0V219.8z
+					 M496,219.8l-1.1,0l0-2l1.1,0V219.8z M493,219.8l-1.1,0l0-2l1,0V219.8z M490,219.8l-1.1,0l0-2l1,0V219.8z M487.1,219.8l-1.1,0
+					l0.1-2l1,0V219.8z M484.1,219.8l-1.1,0l0.1-2l1,0V219.8z M481.1,219.8l-1.1,0l0.1-2l1,0V219.8z M478.1,219.8l-1.1,0l0-2l1,0
+					V219.8z M475.1,219.8l-1.1,0l0-2l1,0V219.8z M472.1,219.8l-1.1,0l0-2l1,0V219.8z M469.2,219.8l-1.1,0l0-2l1.1,0V219.8z
+					 M466.2,219.8l-1.1,0l0-2l1.1,0V219.8z M463.2,219.8l-1.1,0l0-2l1,0V219.8z M460.2,219.8l-1.1,0l0.1-2l1,0V219.8z M457.2,219.8
+					l-1.1,0l0.1-2l1,0V219.8z M454.2,219.8l-1.1,0l0.1-2l1,0V219.8z M451.3,219.8l-1.1,0l0-2l1.1,0V219.8z M448.3,219.8l-1.1,0l0-2
+					l1.1,0V219.8z M445.3,219.8l-1.1,0l0-2l1,0V219.8z M442.3,219.8l-1.1,0l0.1-2l1,0V219.8z M439.3,219.8l-1.1,0l0.1-2l1,0V219.8z
+					 M436.3,219.8l-1.1,0l0.1-2l1,0V219.8z M433.4,219.8l-1.1,0l0-2l1,0V219.8z M430.4,219.8l-1.1,0l0-2l1,0V219.8z M427.4,219.8
+					l-1.1,0l0-2l1,0V219.8z M424.4,219.8l-1.1,0l0.1-2l1,0V219.8z M421.4,219.8l-1.1,0l0-2l1.1,0V219.8z M418.5,219.8l-1.1,0l0-2
+					l1.1,0V219.8z M415.5,219.8l-1.1,0l0-2l1,0V219.8z M412.5,219.8l-1.1,0l0.1-2l1,0V219.8z M409.5,219.8l-1.1,0l0.1-2l1,0V219.8z
+					 M406.5,219.8l-1.1,0l0.1-2l1,0V219.8z M403.5,219.8l-1.1,0l0-2l1.1,0V219.8z M400.6,219.8l-1.1,0l0-2l1.1,0V219.8z
+					 M397.6,219.8l-1.1,0l0-2l1,0V219.8z M394.6,219.8l-1.1,0l0.1-2l1,0V219.8z M391.6,219.8l-1.1,0l0.1-2l1,0V219.8z M388.6,219.8
+					l-1.1,0l0-2l1,0V219.8z M385.6,219.8l-1.1,0l0-2l1,0V219.8z M382.7,219.8l-1.1,0l0-2l1,0V219.8z M379.7,219.8l-1.1,0l0.1-2l1,0
+					V219.8z M376.7,219.8l-1.1,0l0-2l1.1,0V219.8z M373.7,219.8l-1.1,0l0-2l1.1,0V219.8z M370.7,219.8l-1.1,0l0-2l1,0V219.8z
+					 M367.7,219.8l-1.1,0l0-2l1,0V219.8z M364.8,219.8l-1.1,0l0.1-2l1,0V219.8z M361.8,219.8l-1.1,0l0.1-2l1,0V219.8z M358.8,219.8
+					l-1.1,0l0-2l1.1,0V219.8z M355.8,219.8l-1.1,0l0-2l1.1,0V219.8z M352.8,219.8l-1.1,0l0-2l1,0V219.8z M349.8,219.8l-1.1,0l0-2
+					l1,0V219.8z M346.9,219.8l-1.1,0l0.1-2l1,0V219.8z M343.9,219.8l-1.1,0l0-2l1.1,0V219.8z M340.9,219.8l-1.1,0l0-2l1,0V219.8z
+					 M337.9,219.8l-1.1,0l0-2l1,0V219.8z M334.9,219.8l-1.1,0l0.1-2l1,0V219.8z M331.9,219.8l-1.1,0l0.1-2l1,0V219.8z M329,219.8
+					l-1.1,0l0-2l1.1,0V219.8z M326,219.8l-1.1,0l0-2l1.1,0V219.8z M323,219.8l-1.1,0l0-2l1,0V219.8z M320,219.8l-1.1,0l0.1-2l1,0
+					V219.8z M317,219.8l-1.1,0l0.1-2l1,0V219.8z M314,219.8l-1.1,0l0.1-2l1,0V219.8z M311.1,219.8l-1.1,0l0-2l1.1,0V219.8z
+					 M308.1,219.8l-1.1,0l0-2l1,0V219.8z M305.1,219.8l-1.1,0l0-2l1,0V219.8z M302.1,219.8l-1.1,0l0.1-2l1,0V219.8z M299.1,219.8
+					l-1.1,0l0-2l1.1,0V219.8z M296.1,219.8l-1.1,0l0-2l1.1,0V219.8z M293.2,219.8l-1.1,0l0-2l1,0V219.8z M290.2,219.8l-1.1,0l0.1-2
+					l1,0V219.8z M287.2,219.8l-1.1,0l0.1-2l1,0V219.8z M284.2,219.8l-1.1,0l0-2l1.1,0V219.8z M281.2,219.8l-1.1,0l0-2l1.1,0V219.8z
+					 M278.2,219.8l-1.1,0l0-2l1.1,0V219.8z M275.3,219.8l-1.1,0l0-2l1,0V219.8z M272.3,219.8l-1.1,0l0.1-2l1,0V219.8z M269.3,219.8
+					l-1.1,0l0.1-2l1,0V219.8z M266.3,219.8l-1.1,0l0.1-2l1,0V219.8z M263.3,219.8l-1.1,0l0-2l1,0V219.8z M260.3,219.8l-1.1,0l0-2
+					l1,0V219.8z M257.4,219.8l-1.1,0l0-2l1,0V219.8z M254.4,219.8l-1.1,0l0-2l1.1,0V219.8z M251.4,219.8l-1.1,0l0-2l1.1,0V219.8z
+					 M248.4,219.8l-1.1,0l0-2l1.1,0V219.8z M245.4,219.8l-1.1,0l0.1-2l1,0V219.8z M242.4,219.8l-1.1,0l0.1-2l1,0V219.8z
+					 M239.5,219.8l-1.1,0l0.1-2l1,0V219.8z M236.5,219.8l-1.1,0l0-2l1.1,0V219.8z M233.5,219.8l-1.1,0l0-2l1.1,0V219.8z
+					 M230.5,219.8l-1.1,0l0-2l1.1,0V219.8z M227.5,219.8l-1.1,0l0.1-2l1,0V219.8z M224.5,219.8l-1.1,0l0.1-2l1,0V219.8z
+					 M221.6,219.8l-1.1,0l0.1-2l1,0V219.8z M218.6,219.8l-1.1,0l0.1-2l1,0V219.8z M215.6,219.8l-1.1,0l0-2l1,0V219.8z M212.6,219.8
+					l-1.1,0l0-2l1,0V219.8z M209.6,219.8l-1.1,0l0-2l1,0V219.8z M206.6,219.8l-1.1,0l0-2l1.1,0V219.8z M203.7,219.8l-1.1,0l0-2
+					l1.1,0V219.8z M200.7,219.8l-1.1,0l0-2l1.1,0V219.8z M197.7,219.8l-1.1,0l0.1-2l1,0V219.8z M194.7,219.8l-1.1,0l0.1-2l1,0V219.8
+					z M191.7,219.8l-1.1,0l0.1-2l1,0V219.8z M188.8,219.8l-1.1,0l0-2l1.1,0V219.8z M185.8,219.8l-1.1,0l0-2l1.1,0V219.8z
+					 M182.8,219.8l-1.1,0l0-2l1.1,0V219.8z M179.8,219.8l-1.1,0l0.1-2l1,0V219.8z M176.8,219.8l-1.1,0l0.1-2l1,0V219.8z
+					 M173.8,219.8l-1.1,0l0.1-2l1,0V219.8z M170.8,219.8l-1.1,0l0.1-2l1,0V219.8z M167.9,219.8l-1.1,0l0-2l1,0V219.8z M164.9,219.8
+					l-1.1,0l0-2l1,0V219.8z M161.9,219.8l-1.1,0l0-2l1,0V219.8z M158.9,219.8l-1.1,0l0-2l1.1,0V219.8z M155.9,219.8l-1.1,0l0-2
+					l1.1,0V219.8z M152.9,219.8l-1.1,0l0-2l1,0V219.8z M150,219.8l-1.1,0l0.1-2l1,0V219.8z M147,219.8l-1.1,0l0.1-2l1,0V219.8z
+					 M144,219.8l-1.1,0l0.1-2l1,0V219.8z M141,219.8l-1.1,0l0-2l1.1,0V219.8z M138,219.8l-1.1,0l0-2l1.1,0V219.8z M135.1,219.8
+					l-1.1,0l0-2l1.1,0V219.8z M132.1,219.8l-1.1,0l0.1-2l1,0V219.8z M129.1,219.8l-1.1,0l0.1-2l1,0V219.8z M126.1,219.8l-1.1,0
+					l0.1-2l1,0V219.8z M123.1,219.8l-1.1,0l0-2l1,0V219.8z M120.1,219.8l-1.1,0l0-2l1,0V219.8z M117.2,219.8l-1.1,0l0-2l1,0V219.8z
+					 M114.2,219.8l-1.1,0l0.1-2l1,0V219.8z M111.2,219.8l-1.1,0l0-2l1.1,0V219.8z M108.2,219.8l-1.1,0l0-2l1.1,0V219.8z"/>
+				<rect x="106.2" y="217.8" class="st54" width="0.5" height="2"/>
+			</g>
+		</g>
+		<g>
+			<g>
+				<rect x="482.2" y="239.3" class="st51" width="72.6" height="3"/>
+				<g>
+					<polygon class="st51" points="472.7,240.8 486.1,235.3 483,240.8 486.1,246.3 					"/>
+				</g>
+			</g>
+			<path class="st52" d="M554.8,241.5h-4V240h4V241.5z M548.8,241.5h-4V240h4V241.5z M542.8,241.5h-4V240h4V241.5z M536.8,241.5h-4
+				V240h4V241.5z M530.8,241.5h-4V240h4V241.5z M524.8,241.5h-4V240h4V241.5z M518.8,241.5h-4V240h4V241.5z M512.8,241.5h-4V240h4
+				V241.5z M506.8,241.5h-4V240h4V241.5z M500.8,241.5h-4V240h4V241.5z M494.8,241.5h-4V240h4V241.5z M488.8,241.5h-4V240h4V241.5z
+				 M482.8,241.5h-0.6V240h0.6V241.5z"/>
+		</g>
+		<g class="st93">
+			<rect x="334.8" y="153.9" class="st0" width="117.5" height="124.1"/>
+			<rect x="334.8" y="153.9" class="st94" width="117.5" height="124.1"/>
+		</g>
+		<g>
+			
+				<linearGradient id="SVGID_00000118356953984428850370000003548647047381868952_" gradientUnits="userSpaceOnUse" x1="393.6035" y1="-558.171" x2="393.6035" y2="-586.3644" gradientTransform="matrix(1 0 0 1 -3.547359e-03 791.7134)">
+				<stop  offset="0" style="stop-color:#258378"/>
+				<stop  offset="0.42" style="stop-color:#49A498"/>
+				<stop  offset="0.78" style="stop-color:#60BBAD"/>
+				<stop  offset="1" style="stop-color:#68C2B5"/>
+			</linearGradient>
+			<path style="fill:url(#SVGID_00000118356953984428850370000003548647047381868952_);" d="M378.9,217.3l14-14c0.4-0.4,1-0.4,1.4,0
+				l14,14c0.4,0.4,0.4,1,0,1.4l-14,14c-0.4,0.4-1,0.4-1.4,0l-14-14C378.5,218.3,378.5,217.7,378.9,217.3z"/>
+			<path class="st0" d="M390.2,210.4l3.3-3.3c0.1-0.1,0.2-0.1,0.2,0l3.4,3.3c0.1,0.1,0.1,0.2,0,0.2c0,0-0.1,0.1-0.2,0.1h-2
+				c-0.1,0-0.2,0.1-0.2,0.2l0,0v4.3c0,0.1-0.1,0.2-0.2,0.2l0,0h-2.1c-0.1,0-0.2-0.1-0.2-0.1l0,0V211c0-0.1-0.1-0.2-0.2-0.2h-2
+				C390.2,210.7,390.1,210.6,390.2,210.4C390.1,210.5,390.2,210.4,390.2,210.4z M397.1,225.7l-3.4,3.3c-0.1,0.1-0.2,0.1-0.2,0
+				l-3.3-3.3c-0.1-0.1,0-0.2,0-0.2h0.1h2c0.1,0,0.2-0.1,0.2-0.2V221c0-0.1,0.1-0.2,0.2-0.2l0,0h2.1c0.1,0,0.2,0.1,0.2,0.2l0,0v4.3
+				c0,0.1,0.1,0.2,0.2,0.2l0,0h1.9c0.1-0.1,0.2,0,0.2,0C397.2,225.5,397.2,225.6,397.1,225.7z M387.2,221.3v-1.9
+				c0-0.1-0.1-0.2-0.2-0.2h-4.3c-0.1,0-0.2-0.1-0.2-0.2v-2.1c0-0.1,0.1-0.2,0.2-0.2h4.3c0.1,0,0.2-0.1,0.2-0.2v-2
+				c0-0.1,0-0.2,0.1-0.2s0.1,0,0.2,0.1l3.3,3.4c0.1,0.1,0.1,0.2,0,0.2l0,0l-3.3,3.3c-0.1,0.1-0.2,0.1-0.2,0
+				C387.2,221.4,387.1,221.3,387.2,221.3z M400.1,214.6v2c0,0.1,0.1,0.2,0.2,0.2h4.3c0.1,0,0.2,0.1,0.2,0.2v2.1
+				c0,0.1-0.1,0.2-0.2,0.2h-4.3c-0.1,0-0.2,0.1-0.2,0.2v1.9c0,0.1,0,0.2-0.1,0.2s-0.1,0-0.2-0.1l-3.3-3.4c-0.1-0.1-0.1-0.2,0-0.2
+				l0,0l3.3-3.3c0-0.1,0.1-0.1,0.2,0C400.1,214.5,400.1,214.6,400.1,214.6z"/>
+		</g>
+		<g class="st93">
+			<rect x="194.9" y="153.9" class="st0" width="117.5" height="124.1"/>
+			<rect x="194.9" y="153.9" class="st94" width="117.5" height="124.1"/>
+		</g>
+		<g>
+			
+				<linearGradient id="SVGID_00000171709567016576937640000011921185079177804465_" gradientUnits="userSpaceOnUse" x1="253.7" y1="-564.205" x2="253.7" y2="-587.7101" gradientTransform="matrix(1 0 0 1 0 791.7148)">
+				<stop  offset="0" style="stop-color:#2E76BC"/>
+				<stop  offset="0.82" style="stop-color:#699CD3"/>
+			</linearGradient>
+			<path style="fill:url(#SVGID_00000171709567016576937640000011921185079177804465_);" d="M270.3,220.1c-0.1-3.6-2.8-6.7-6.5-7.2
+				c-0.2-5.1-4.5-9.1-9.7-9c-4.1-0.1-7.8,2.4-9.2,6.3c-4.4,0.5-7.7,4.2-7.8,8.5c0.2,5,4.4,8.8,9.3,8.7h0.8h15.1c0.1,0,0.3,0,0.4,0
+				C266.9,227.5,270.2,224.2,270.3,220.1z"/>
+			<path class="st97" d="M263.4,222.1c0-0.4-0.4-0.8-0.8-0.8h-17.9c-0.4,0-0.8,0.3-0.8,0.8v9.2c0,0.4,0.4,0.8,0.8,0.8h17.9
+				c0.4,0,0.8-0.3,0.8-0.8V222.1z"/>
+			<rect x="245.1" y="222.4" class="st98" width="5.3" height="2.3"/>
+			<rect x="251.1" y="222.4" class="st99" width="5.3" height="2.3"/>
+			<rect x="257.2" y="222.4" class="st98" width="5.3" height="2.3"/>
+			<rect x="245.1" y="225.5" class="st98" width="2.2" height="2.3"/>
+			<rect x="260.3" y="225.5" class="st99" width="2.2" height="2.3"/>
+			<rect x="248" y="225.5" class="st99" width="5.3" height="2.3"/>
+			<rect x="254.1" y="225.5" class="st98" width="5.3" height="2.3"/>
+			<rect x="245.1" y="228.6" class="st98" width="5.3" height="2.3"/>
+			<rect x="251.1" y="228.6" class="st99" width="5.3" height="2.3"/>
+			<rect x="257.2" y="228.6" class="st98" width="5.3" height="2.3"/>
+		</g>
+		
+			<linearGradient id="SVGID_00000174587383866504030180000016557926496108507780_" gradientUnits="userSpaceOnUse" x1="602.5" y1="-410.9277" x2="602.5" y2="-445.7051" gradientTransform="matrix(1 0 0 1 0 791.7148)">
+			<stop  offset="0" style="stop-color:#5E9741"/>
+			<stop  offset="2.000000e-02" style="stop-color:#5F9841"/>
+			<stop  offset="1" style="stop-color:#76BC43"/>
+		</linearGradient>
+		<path style="fill:url(#SVGID_00000174587383866504030180000016557926496108507780_);" d="M587.8,362l14-14c0.4-0.4,1-0.4,1.4,0
+			l0,0l14,14c0.4,0.4,0.4,1,0,1.4l0,0l-14,14c-0.4,0.4-1,0.4-1.4,0l-14-14C587.4,363,587.4,362.4,587.8,362L587.8,362z"/>
+		<path class="st101" d="M606.2,354.4l-3.5-3.5c-0.1-0.1-0.2-0.1-0.3,0l-3.5,3.5c-0.1,0.1-0.1,0.2,0,0.2c0,0.1,0.1,0.1,0.2,0.1h2.1
+			c0.1,0,0.2,0.1,0.2,0.2v3.3c0,0.1,0.1,0.2,0.2,0.2h2.2c0.1,0,0.2-0.1,0.2-0.2v-3.3c0-0.1,0.1-0.2,0.2-0.2h2.1c0.1,0,0.2,0,0.2-0.1
+			C606.3,354.5,606.2,354.4,606.2,354.4z"/>
+		<path class="st101" d="M594.2,358.7l-3.5,3.5c-0.1,0.1-0.1,0.2,0,0.2l3.5,3.5c0.1,0.1,0.2,0.1,0.3,0l0.1-0.1v-2
+			c0-0.1,0.1-0.2,0.2-0.2h3.3c0.1,0,0.2-0.1,0.2-0.2l0,0v-2.2c0-0.1,0-0.2-0.1-0.2c0,0,0,0-0.1,0h-3.3c-0.1,0-0.2-0.1-0.2-0.1l0,0
+			v-2c0-0.1,0-0.2-0.1-0.2C594.3,358.6,594.2,358.6,594.2,358.7z"/>
+		<path class="st101" d="M611,366l3.5-3.5c0.1-0.1,0.1-0.2,0-0.2l-3.5-3.5c-0.1-0.1-0.2-0.1-0.3,0v0.1v2.1c0,0.1-0.1,0.2-0.2,0.2
+			l0,0h-3.3c-0.1,0-0.2,0.1-0.2,0.2l0,0v2.2c0,0.1,0.1,0.2,0.1,0.2l0,0h3.3c0.1,0,0.2,0.1,0.2,0.2v2.1
+			C610.7,366,610.8,366.1,611,366C610.9,366.1,611,366.1,611,366z"/>
+		<path class="st0" d="M607.2,362.7c0-2.6-2.1-4.7-4.6-4.7c-2.6,0-4.7,2.1-4.7,4.6c0,2.1,1.4,3.9,3.4,4.5v1.6
+			c-1.4,0.7-1.9,2.4-1.2,3.8s2.4,1.9,3.8,1.2s1.9-2.4,1.2-3.8c-0.3-0.5-0.7-1-1.2-1.2V367C605.8,366.5,607.1,364.7,607.2,362.7z"/>
+		<circle id="e99c3387-15c3-4f28-bd4b-cb209b430e06_2_" class="st29" cx="602.5" cy="362.7" r="2.7"/>
+		<g>
+			
+				<linearGradient id="SVGID_00000091716194735397625700000013868345396133510291_" gradientUnits="userSpaceOnUse" x1="943.6937" y1="-447.1354" x2="943.6937" y2="-435.692" gradientTransform="matrix(1 0 0 1 0 791.7148)">
+				<stop  offset="0.22" style="stop-color:#50C8E9"/>
+				<stop  offset="0.47" style="stop-color:#4AC7E9"/>
+				<stop  offset="0.63" style="stop-color:#3BC4E7"/>
+				<stop  offset="0.77" style="stop-color:#2ABADE"/>
+				<stop  offset="0.89" style="stop-color:#21A5CB"/>
+				<stop  offset="1" style="stop-color:#1B8AB3"/>
+				<stop  offset="1" style="stop-color:#1B8AB3"/>
+			</linearGradient>
+			<path style="fill:url(#SVGID_00000091716194735397625700000013868345396133510291_);" d="M949.4,354c0.7,0,1.2-0.5,1.2-1.2v-0.2
+				c-0.5-3.9-2.7-7-6.9-7s-6.5,2.7-6.9,7c-0.1,0.7,0.4,1.3,1.1,1.4L949.4,354L949.4,354z"/>
+			<path class="st103" d="M943.7,346.5c-0.7,0-1.5-0.2-2.1-0.6l2.1,5.4l2.1-5.4C945.1,346.3,944.4,346.5,943.7,346.5z"/>
+			
+				<linearGradient id="SVGID_00000078724940861344981890000013518627556491349142_" gradientUnits="userSpaceOnUse" x1="943.3575" y1="-453.2593" x2="944.1956" y2="-442.8736" gradientTransform="matrix(1 0 0 1 0 791.7148)">
+				<stop  offset="0.22" style="stop-color:#50C8E9"/>
+				<stop  offset="0.47" style="stop-color:#4AC7E9"/>
+				<stop  offset="0.63" style="stop-color:#3BC4E7"/>
+				<stop  offset="0.77" style="stop-color:#2ABADE"/>
+				<stop  offset="0.89" style="stop-color:#21A5CB"/>
+				<stop  offset="1" style="stop-color:#1B8AB3"/>
+				<stop  offset="1" style="stop-color:#1B8AB3"/>
+			</linearGradient>
+			<circle style="fill:url(#SVGID_00000078724940861344981890000013518627556491349142_);" cx="943.7" cy="342.7" r="3.9"/>
+			<path class="st43" d="M939.2,342.7v-4.9c0-0.1-0.1-0.2-0.1-0.2l0,0h-1.3c-0.1,0-0.2,0.1-0.2,0.2l0,0v4.7c0,0.1-0.1,0.2-0.2,0.2
+				h-1.1c-0.1,0-0.1-0.1-0.1-0.1v-1.3c0-0.1,0-0.1-0.1-0.1H936l-2.2,2.2c-0.1,0.1-0.1,0.2,0,0.2l0,0l2.2,2.2c0,0.1,0.1,0.1,0.1,0.1
+				l0.1-0.1l0,0v-1.3c0-0.1,0-0.1,0.1-0.1h2.7c0.1,0,0.2-0.1,0.2-0.2L939.2,342.7L939.2,342.7z"/>
+		</g>
+		<g>
+			<path class="st12" d="M948.8,323.7c0,4.4-5.3,7.9-6.4,8.6c-0.1,0.1-0.3,0.1-0.4,0c-1.2-0.7-6.4-4.2-6.4-8.6v-5.3
+				c0-0.2,0.2-0.4,0.4-0.4c4.1-0.1,3.2-1.9,6.3-1.9s2.1,1.8,6.3,1.9c0.2,0,0.4,0.2,0.4,0.4v5.3H948.8z"/>
+			<path class="st13" d="M948.3,323.8c0,4-4.9,7.2-5.9,7.9c-0.1,0.1-0.3,0.1-0.4,0c-1.1-0.7-5.9-3.9-5.9-7.9V319
+				c0-0.2,0.2-0.4,0.4-0.4c3.8-0.1,2.9-1.8,5.7-1.8s2,1.7,5.7,1.8c0.2,0,0.4,0.2,0.4,0.4V323.8z"/>
+			
+				<linearGradient id="SVGID_00000170245327522444109840000004548168831804736896_" gradientUnits="userSpaceOnUse" x1="942.2001" y1="-474.8993" x2="942.2001" y2="-459.9535" gradientTransform="matrix(1 0 0 1 0 791.7148)">
+				<stop  offset="0" style="stop-color:#5EA0EF"/>
+				<stop  offset="0.18" style="stop-color:#559CEC"/>
+				<stop  offset="0.47" style="stop-color:#3C91E5"/>
+				<stop  offset="0.84" style="stop-color:#1380DA"/>
+				<stop  offset="1" style="stop-color:#0078D4"/>
+			</linearGradient>
+			<path style="fill:url(#SVGID_00000170245327522444109840000004548168831804736896_);" d="M942.2,324.3v-7.5c2.8,0,2,1.7,5.7,1.8
+				c0.2,0,0.4,0.2,0.4,0.4v4.8c0,0.2,0,0.3,0,0.5L942.2,324.3L942.2,324.3z M942.2,324.3h-6.1c0.4,3.8,4.9,6.8,5.9,7.4
+				c0,0,0.1,0,0.2,0.1l0,0L942.2,324.3L942.2,324.3z"/>
+			<path class="st15" d="M936.4,318.6c3.8-0.1,2.9-1.8,5.7-1.8v7.5H936c0-0.2,0-0.3,0-0.5V319C936.1,318.8,936.2,318.6,936.4,318.6z
+				"/>
+			<path class="st15" d="M948.2,324.3h-6.1v7.5l0,0c0.1,0,0.1,0,0.2-0.1C943.4,331.1,947.9,328.1,948.2,324.3z"/>
+		</g>
+		<g>
+			
+				<linearGradient id="SVGID_00000036931489558245520430000016782857638201521592_" gradientUnits="userSpaceOnUse" x1="943.6937" y1="-601.9398" x2="943.6937" y2="-590.4966" gradientTransform="matrix(1 0 0 1 0 791.7148)">
+				<stop  offset="0.22" style="stop-color:#50C8E9"/>
+				<stop  offset="0.47" style="stop-color:#4AC7E9"/>
+				<stop  offset="0.63" style="stop-color:#3BC4E7"/>
+				<stop  offset="0.77" style="stop-color:#2ABADE"/>
+				<stop  offset="0.89" style="stop-color:#21A5CB"/>
+				<stop  offset="1" style="stop-color:#1B8AB3"/>
+				<stop  offset="1" style="stop-color:#1B8AB3"/>
+			</linearGradient>
+			<path style="fill:url(#SVGID_00000036931489558245520430000016782857638201521592_);" d="M949.4,199.2c0.7,0,1.2-0.5,1.2-1.2
+				v-0.2c-0.5-3.9-2.7-7-6.9-7s-6.5,2.7-6.9,7c-0.1,0.7,0.4,1.3,1.1,1.4H949.4L949.4,199.2z"/>
+			<path class="st103" d="M943.7,191.7c-0.7,0-1.5-0.2-2.1-0.6l2.1,5.4l2.1-5.4C945.1,191.5,944.4,191.7,943.7,191.7z"/>
+			
+				<linearGradient id="SVGID_00000072268222888882007660000003012014579993808011_" gradientUnits="userSpaceOnUse" x1="943.3652" y1="-608.0644" x2="944.2032" y2="-597.6786" gradientTransform="matrix(1 0 0 1 0 791.7148)">
+				<stop  offset="0.22" style="stop-color:#50C8E9"/>
+				<stop  offset="0.47" style="stop-color:#4AC7E9"/>
+				<stop  offset="0.63" style="stop-color:#3BC4E7"/>
+				<stop  offset="0.77" style="stop-color:#2ABADE"/>
+				<stop  offset="0.89" style="stop-color:#21A5CB"/>
+				<stop  offset="1" style="stop-color:#1B8AB3"/>
+				<stop  offset="1" style="stop-color:#1B8AB3"/>
+			</linearGradient>
+			<circle style="fill:url(#SVGID_00000072268222888882007660000003012014579993808011_);" cx="943.7" cy="187.8" r="3.9"/>
+			<path class="st43" d="M939.2,187.9V183c0-0.1-0.1-0.2-0.1-0.2l0,0h-1.3c-0.1,0-0.2,0.1-0.2,0.2l0,0v4.7c0,0.1-0.1,0.2-0.2,0.2
+				h-1.1c-0.1,0-0.1-0.1-0.1-0.1v-1.3c0-0.1,0-0.1-0.1-0.1H936l-2.2,2.2c-0.1,0.1-0.1,0.2,0,0.2l0,0l2.2,2.2c0,0.1,0.1,0.1,0.1,0.1
+				l0.1-0.1l0,0v-1.3c0-0.1,0-0.1,0.1-0.1h2.7c0.1,0,0.2-0.1,0.2-0.2L939.2,187.9L939.2,187.9z"/>
+		</g>
+		<g>
+			<path class="st12" d="M948.8,168.9c0,4.4-5.3,7.9-6.4,8.6c-0.1,0.1-0.3,0.1-0.4,0c-1.2-0.7-6.4-4.2-6.4-8.6v-5.3
+				c0-0.2,0.2-0.4,0.4-0.4c4.1-0.1,3.2-1.9,6.3-1.9s2.1,1.8,6.3,1.9c0.2,0,0.4,0.2,0.4,0.4v5.3H948.8z"/>
+			<path class="st13" d="M948.3,169c0,4-4.9,7.2-5.9,7.9c-0.1,0.1-0.3,0.1-0.4,0c-1.1-0.7-5.9-3.9-5.9-7.9v-4.8
+				c0-0.2,0.2-0.4,0.4-0.4c3.8-0.1,2.9-1.8,5.7-1.8s2,1.7,5.7,1.8c0.2,0,0.4,0.2,0.4,0.4V169z"/>
+			
+				<linearGradient id="SVGID_00000110433054952002879530000004062588747768934826_" gradientUnits="userSpaceOnUse" x1="942.2001" y1="-629.7148" x2="942.2001" y2="-614.7689" gradientTransform="matrix(1 0 0 1 0 791.7148)">
+				<stop  offset="0" style="stop-color:#5EA0EF"/>
+				<stop  offset="0.18" style="stop-color:#559CEC"/>
+				<stop  offset="0.47" style="stop-color:#3C91E5"/>
+				<stop  offset="0.84" style="stop-color:#1380DA"/>
+				<stop  offset="1" style="stop-color:#0078D4"/>
+			</linearGradient>
+			<path style="fill:url(#SVGID_00000110433054952002879530000004062588747768934826_);" d="M942.2,169.5V162c2.8,0,2,1.7,5.7,1.8
+				c0.2,0,0.4,0.2,0.4,0.4v4.8c0,0.2,0,0.3,0,0.5H942.2z M942.2,169.5h-6.1c0.4,3.8,4.9,6.8,5.9,7.4c0,0,0.1,0,0.2,0.1l0,0
+				L942.2,169.5L942.2,169.5z"/>
+			<path class="st15" d="M936.4,163.8c3.8-0.1,2.9-1.8,5.7-1.8v7.5H936c0-0.2,0-0.3,0-0.5v-4.8C936.1,164,936.2,163.8,936.4,163.8z"
+				/>
+			<path class="st15" d="M948.2,169.5h-6.1v7.5l0,0c0.1,0,0.1,0,0.2-0.1C943.4,176.3,947.9,173.3,948.2,169.5z"/>
+		</g>
+		<path class="st109" d="M688.8,336.4l-6.4,6.4c-0.1,0.1-0.3,0.2-0.4,0.1c0,0,0,0-0.1-0.1l-6.4-6.4c-0.1-0.1-0.1-0.4,0-0.5
+			s0.1-0.1,0.2-0.1h3.7c0.2,0,0.3-0.1,0.3-0.3v-0.1v-8.2c0-0.2,0.2-0.3,0.3-0.3l0,0h3.9c0.2,0,0.3,0.1,0.3,0.3v8.2
+			c0,0.2,0.1,0.3,0.3,0.3l0,0h3.7c0.2-0.1,0.4,0,0.4,0.2C689.1,336.1,689,336.3,688.8,336.4L688.8,336.4z"/>
+		<path class="st109" d="M697.1,362.6l-6-10.4c-0.5-0.9-1.8-1.6-2.8-1.6h-12c-1,0-2.3,0.7-2.8,1.6l-6,10.4c-0.5,0.9-0.5,2.4,0,3.3
+			l6,10.4c0.5,0.9,1.8,1.6,2.8,1.6h12c1,0,2.3-0.7,2.8-1.6l6-10.4C697.6,365,697.6,363.5,697.1,362.6z M681,356.3
+			c0-0.7,0.6-1.2,1.2-1.2c0.7,0,1.2,0.6,1.2,1.2v7.4c0,0.7-0.6,1.2-1.2,1.2c-0.7,0-1.2-0.6-1.2-1.2V356.3z M682.2,372.1
+			c-4.6,0-8.4-3.8-8.4-8.4c0-2.6,1.3-5.2,3.4-6.7c0.5-0.4,1.2-0.3,1.5,0.2c0.4,0.5,0.3,1.2-0.2,1.5c-1.6,1.2-2.5,3-2.5,5
+			c0,3.4,2.8,6.2,6.2,6.2s6.2-2.8,6.2-6.2c0-2-0.9-3.8-2.5-5c-0.5-0.4-0.6-1-0.2-1.5c0.4-0.5,1-0.6,1.5-0.2c2.1,1.6,3.4,4.1,3.4,6.7
+			C690.6,368.3,686.9,372.1,682.2,372.1z"/>
+		<circle cx="822.3" cy="363.3" r="2.5"/>
+		<circle cx="829.8" cy="363.3" r="2.5"/>
+		<circle cx="837.3" cy="363.3" r="2.5"/>
+		<path class="st109" d="M762.6,336.4l-6.4,6.4c-0.1,0.1-0.3,0.2-0.4,0.1c0,0,0,0-0.1-0.1l-6.4-6.4c-0.1-0.1-0.1-0.4,0-0.5
+			s0.1-0.1,0.2-0.1h3.7c0.2,0,0.3-0.1,0.3-0.3v-0.1v-8.2c0-0.2,0.2-0.3,0.3-0.3l0,0h3.9c0.2,0,0.3,0.1,0.3,0.3v8.2
+			c0,0.2,0.1,0.3,0.3,0.3l0,0h3.7c0.2-0.1,0.4,0,0.4,0.2C762.8,336.1,762.7,336.3,762.6,336.4L762.6,336.4z"/>
+		<path class="st109" d="M770.9,362.6l-6-10.4c-0.5-0.9-1.8-1.6-2.8-1.6h-12c-1,0-2.3,0.7-2.8,1.6l-6,10.4c-0.5,0.9-0.5,2.4,0,3.3
+			l6,10.4c0.5,0.9,1.8,1.6,2.8,1.6h12c1,0,2.3-0.7,2.8-1.6l6-10.4C771.4,365,771.4,363.5,770.9,362.6z M754.7,356.3
+			c0-0.7,0.6-1.2,1.2-1.2c0.7,0,1.2,0.6,1.2,1.2v7.4c0,0.7-0.6,1.2-1.2,1.2c-0.7,0-1.2-0.6-1.2-1.2V356.3z M756,372.1
+			c-4.6,0-8.4-3.8-8.4-8.4c0-2.6,1.3-5.2,3.4-6.7c0.5-0.4,1.2-0.3,1.5,0.2c0.4,0.5,0.3,1.2-0.2,1.5c-1.6,1.2-2.5,3-2.5,5
+			c0,3.4,2.8,6.2,6.2,6.2s6.2-2.8,6.2-6.2c0-2-0.9-3.8-2.5-5c-0.5-0.4-0.6-1-0.2-1.5c0.4-0.5,1-0.6,1.5-0.2c2.1,1.6,3.4,4.1,3.4,6.7
+			C764.4,368.3,760.6,372.1,756,372.1z"/>
+		<path class="st109" d="M918.4,362.6l-6-10.4c-0.5-0.9-1.8-1.6-2.8-1.6h-12c-1,0-2.3,0.7-2.8,1.6l-6,10.4c-0.5,0.9-0.5,2.4,0,3.3
+			l6,10.4c0.5,0.9,1.8,1.6,2.8,1.6h12c1,0,2.3-0.7,2.8-1.6l6-10.4C918.9,365,918.9,363.5,918.4,362.6z M902.3,356.3
+			c0-0.7,0.6-1.2,1.2-1.2c0.7,0,1.2,0.6,1.2,1.2v7.4c0,0.7-0.6,1.2-1.2,1.2c-0.7,0-1.2-0.6-1.2-1.2V356.3z M903.5,372.1
+			c-4.6,0-8.4-3.8-8.4-8.4c0-2.6,1.3-5.2,3.4-6.7c0.5-0.4,1.2-0.3,1.5,0.2c0.4,0.5,0.3,1.2-0.2,1.5c-1.6,1.2-2.5,3-2.5,5
+			c0,3.4,2.8,6.2,6.2,6.2s6.2-2.8,6.2-6.2c0-2-0.9-3.8-2.5-5c-0.5-0.4-0.6-1-0.2-1.5c0.4-0.5,1-0.6,1.5-0.2c2.1,1.6,3.4,4.1,3.4,6.7
+			C911.9,368.3,908.1,372.1,903.5,372.1z"/>
+		<g>
+			<text transform="matrix(1 0 0 1 757.046 418.1927)" class="st110 st111 st112">Private FQDN</text>
+		</g>
+		<g>
+			
+				<linearGradient id="SVGID_00000177471155580933158060000007987956713217396406_" gradientUnits="userSpaceOnUse" x1="602.5" y1="-569.772" x2="602.5" y2="-604.5493" gradientTransform="matrix(1 0 0 1 0 791.7148)">
+				<stop  offset="0" style="stop-color:#5E9741"/>
+				<stop  offset="2.000000e-02" style="stop-color:#5F9841"/>
+				<stop  offset="1" style="stop-color:#76BC43"/>
+			</linearGradient>
+			<path style="fill:url(#SVGID_00000177471155580933158060000007987956713217396406_);" d="M587.8,203.1l14-14c0.4-0.4,1-0.4,1.4,0
+				l0,0l14,14c0.4,0.4,0.4,1,0,1.4l0,0l-14,14c-0.4,0.4-1,0.4-1.4,0l-14-14C587.4,204.2,587.4,203.6,587.8,203.1
+				C587.8,203.2,587.8,203.2,587.8,203.1z"/>
+			<path class="st101" d="M606.2,195.5l-3.5-3.5c-0.1-0.1-0.2-0.1-0.3,0l-3.5,3.5c-0.1,0.1-0.1,0.2,0,0.2c0,0.1,0.1,0.1,0.2,0.1h2.1
+				c0.1,0,0.2,0.1,0.2,0.2v3.3c0,0.1,0.1,0.2,0.2,0.2h2.2c0.1,0,0.2-0.1,0.2-0.2V196c0-0.1,0.1-0.2,0.2-0.2h2.1c0.1,0,0.2,0,0.2-0.1
+				C606.3,195.6,606.2,195.6,606.2,195.5z"/>
+			<path class="st101" d="M594.2,199.9l-3.5,3.5c-0.1,0.1-0.1,0.2,0,0.2l3.5,3.5c0.1,0.1,0.2,0.1,0.3,0l0.1-0.1v-2
+				c0-0.1,0.1-0.2,0.2-0.2h3.3c0.1,0,0.2-0.1,0.2-0.2l0,0v-2.2c0-0.1,0-0.2-0.1-0.2c0,0,0,0-0.1,0h-3.3c-0.1,0-0.2-0.1-0.2-0.1l0,0
+				v-2c0-0.1,0-0.2-0.1-0.2C594.3,199.7,594.2,199.8,594.2,199.9z"/>
+			<path class="st101" d="M611,207.2l3.5-3.5c0.1-0.1,0.1-0.2,0-0.2L611,200c-0.1-0.1-0.2-0.1-0.3,0v0.1v2.1c0,0.1-0.1,0.2-0.2,0.2
+				l0,0h-3.3c-0.1,0-0.2,0.1-0.2,0.2l0,0v2.2c0,0.1,0.1,0.2,0.1,0.2l0,0h3.3c0.1,0,0.2,0.1,0.2,0.2v2.1
+				C610.7,207.2,610.8,207.3,611,207.2C610.9,207.2,611,207.2,611,207.2z"/>
+			<path class="st0" d="M607.2,203.9c0-2.6-2.1-4.7-4.6-4.7c-2.6,0-4.7,2.1-4.7,4.6c0,2.1,1.4,3.9,3.4,4.5v1.6
+				c-1.4,0.7-1.9,2.4-1.2,3.8c0.7,1.4,2.4,1.9,3.8,1.2c1.4-0.7,1.9-2.4,1.2-3.8c-0.3-0.5-0.7-1-1.2-1.2v-1.7
+				C605.8,207.6,607.1,205.9,607.2,203.9z"/>
+			<circle id="e99c3387-15c3-4f28-bd4b-cb209b430e06_1_" class="st29" cx="602.5" cy="203.8" r="2.7"/>
+		</g>
+		<g>
+			<path class="st109" d="M839.5,197.8c-0.3-2.3-1-4.8-2-7.7c-0.4,0.9-0.8,1.6-1.3,2.3c-2.2-2.3-5.3-3.7-8.8-3.7
+				c-4.5,0-8.4,2.4-10.5,6c1.9,0.1,3.6,0.9,5,2.1c-1.5-1-3.1-1.4-4.7-1.4c-4.8,0-8.7,3.9-8.7,8.7s3.9,8.7,8.7,8.7h20
+				c4.2,0,7.6-3.4,7.6-7.6C844.8,201.7,842.6,198.8,839.5,197.8z M820.8,210.1c-0.4,0.4-1,0.5-1.5,0.2c-0.4-0.4-0.5-1-0.2-1.5
+				c0.4-0.4,1-0.5,1.5-0.2C821.1,209,821.2,209.6,820.8,210.1z M837.5,206.4c-3,4-9.5,2.7-13.6,2.9c0,0-0.7,0-1.5,0.2
+				c0,0,0.3-0.1,0.6-0.2c2.9-1,4.3-1.2,6-2.1c3.3-1.7,6.6-5.4,7.3-9.3c-1.3,3.7-5.1,6.9-8.6,8.2c-2.4,0.9-6.7,1.7-6.7,1.7l-0.2-0.1
+				c-2.9-1.4-3-7.8,2.3-9.9c2.3-0.9,4.6-0.4,7.1-1c2.7-0.6,5.8-2.7,7.1-5.3C838.8,195.7,840.5,202.3,837.5,206.4z"/>
+		</g>
+		<g>
+			<path class="st109" d="M912.3,197.8c-0.3-2.3-1-4.8-2-7.7c-0.4,0.9-0.8,1.6-1.3,2.3c-2.2-2.3-5.3-3.7-8.8-3.7
+				c-4.5,0-8.4,2.4-10.5,6c1.9,0.1,3.6,0.9,5,2.1c-1.5-1-3.1-1.4-4.7-1.4c-4.8,0-8.7,3.9-8.7,8.7s3.9,8.7,8.7,8.7h20
+				c4.2,0,7.6-3.4,7.6-7.6C917.6,201.7,915.4,198.8,912.3,197.8z M893.6,210.1c-0.4,0.4-1,0.5-1.5,0.2c-0.4-0.4-0.5-1-0.2-1.5
+				c0.4-0.4,1-0.5,1.5-0.2C893.9,209,894,209.6,893.6,210.1z M910.2,206.4c-3,4-9.5,2.7-13.6,2.9c0,0-0.7,0-1.5,0.2
+				c0,0,0.3-0.1,0.6-0.2c2.9-1,4.3-1.2,6-2.1c3.3-1.7,6.6-5.4,7.3-9.3c-1.3,3.7-5.1,6.9-8.6,8.2c-2.4,0.9-6.7,1.7-6.7,1.7l-0.2-0.1
+				c-2.9-1.4-3-7.8,2.3-9.9c2.3-0.9,4.6-0.4,7.1-1c2.7-0.6,5.8-2.7,7.1-5.3C911.6,195.7,913.3,202.3,910.2,206.4z"/>
+		</g>
+		
+			<image style="overflow:visible;enable-background:new    ;" width="208" height="208" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAANAAAADQCAYAAAB2pO90AAAABGdBTUEAALGPC/xhBQAAQABJREFU
+eAHtnQecFEX2+LtndzYQliggLIoEAxgwn/FAURSBRT0QBRbDeXeeeiYU9c6/nDmgnp76MytLUMG0
+C2JEMICY8ZSgoJIRRZC4aWb6/33jzjo7O1XdMztxd+rzqZnuehVevapX9erVq2rTyLi4U6Bz587N
+tm3b1t3n8/WgsC74DgFvWVYH0zRb85/PfzPC8+WZ/xy8B++Vf2DyXwXsV5638ryF5608b+Z5Lf9r
++V/jcrnWtmzZcs369et38Z5xcaaAGef8m1T2bdq0aVVdXX2Q1+s9iA7dlw6+D/89+O+UYEJYlLeG
+spfil1D+0qysrMUw1qIMY8W2JTIM1AB6tmrVai8Y5kQ66ACyORLfrQHZJSKpzGRfU9DH+I+YrRbu
+2LFjSSIKbqxlZBgogpZt0aKFiF4nIIoJ05zI814RJE/JqDDUj9RlDsz0dm5u7pzNmzevSUlEUxSp
+DANpGqZnz565iDwD6GR+hqGjHUD0Rk0z6rqYOj6fnZ39HOu25RryZECNvTNE28L5+fl/oCONJf1Z
+ME2baPNJ93TQ4DP8c8xMz2dmpvCt2ahH0/BVDh/atm3brhUVFWNgGGGcvcPHarKhopSYL8yEqDeD
+ddNPTZYSIRVv0gzUsWPH5nSGM1nTCNP0xyeLHhadczvMK2rpX2v+y/nP4z2g2m7Gs6i4/e/gmh3S
+lol69YLHOxT20M6dO8t4FuZqsi5ZHSapBK/Rno2nM44CkRZxRmYXnexbyhKV8lL+l6FS3sj/r263
+W/Zztl5++eXbJkyY4IsEj0MPPdT9/fffN0ML2EX2l8ivB/nLPlN3eeZ/L7zsJcXTfUOZd7PPNWXF
+ihWV8SwoVfNuUgzEPsje7NFcTwcTxon1CF5Nnp/Sob7GL6OMpTk5OUu3bNmyiveEj9IwpOv+++8v
+hMF6UOcDwOE48DsWvGK+J0XeP+LvZ0B45Fdcqnb2eODVJBgI9fP+dKJ/QsAReFeMCCli15d0yDn8
+z4E539u4cePOGOUdt2wKCgp6eTweYabjwF3+ZbaKldtORo/j7ysvLxfLiEbvGjUDNWvW7GBa8F90
+lNP5j0VdVwizCNOg5p27ffv2TeneQ6DR7igGjkMMPIm6nEndYqF1rIZOzzIj/Xvr1q3fpzuNdPjH
+olPp8k8KjE5xCAXfRGc4LQYILKczlNAZptIZfohBfimbhayrli5dOhC6jQTJInxD14eV0O4eZufb
+0mF2jqZhGhUDiS1aZWXlrXSAiyBG1KIajS5y/PMs9icxy3wYDWHTPU1hYWH+L7/8MhhajISeg6hP
+XrR1Io91+KvR2j0bbR6pmq7RMFDz5s3PpqHvxUe7SBY7sTcQZ0o6depU2lS1SuE6KntkBQxMwxDz
+/gr86HBxHIa9D33/ASMtchjfcTQ2vwsZ8I4Bx138L2Dg+8Vx4gZETHsGqlkUPwzjiEFnxA6m+ZlE
+/+H/SRp2Y8QZNLEEiGPHoJC5BnoPoerR9B8ftH6MTv6vWHVyRHZZ594IPn7NKvlvhVH/yh7f8/Fu
+nmgIEG+cHOVfY6d2HYS7lgS5jhIFRYLIG/AT2RN6JGPiH0QYh48w0r4w0jjoP4YkEe83QfstpPsX
+g9b/8Ry1mh8N60jwCCcaVsFEh5H/Vw6rFFW0tGQgxLWTmKofpsY9o6i1nJO5s0OHDk+uXLmyIor0
+mSRBFBAtHkx0GTT9G/+tgkCOHkn3Oh19bLTmQYhu71PQsYrC7kWdfpUCFpPgqBfaMSk9wkz69OmT
+Q4M9APO8SdJImed7Gusv3bt377lr166HMswTIfEV0aHlBjrptbRLVxjhOqLJXpBjB9OdQnv+j0Hx
+ZMeJgiLSpn2CXkMfDwoNiPV72jBQ69at9/zhhx8+gOCXRkIECPwjDXvekUceuQ+N/fjixYurIkmf
+ieuMAps2bdqOuHQHtN4bmpeQyrFYRpt2hIleZza5S1TpzkqsjZVV+1T/IWLRvn4W+pC0EOEY3QZT
+jUkQuq2+OnWgslh9BFP86zGnEZuzjEsgBWqOhPyXNjsskmJps0/ZcxvJntt3TtLRNzZThmrz90Nm
+x4ZoDW1RSOkZaPjw4Vk0xB0QqCwS5qERPsf/gRnn4gzz2PaBuESg4y5kRjqCdrgA7/j4gzBcVVXV
+F4h0ox0i5lXFo1zd7KRKFlF4yjIQI8vus2bNErP58XhHMyUE20bcy0477bQjYJ5PIqJEJnLMKUB7
+WLTDU0gBeyPa3UcBcsuQE9cSkW4yg2eJbOjaJNBZscedgRx1TJsKxBzM6CNHqKfh5Q4Cp246DXYF
+DbbeaYJMvMRSgHY9gDZ9Fq9b+Ici9SF2h0NUe0YMtOvJb/fQRPJOf1hEfzg4HCxWYSk3A0GQv4uW
+zSnzQKSf8achMpyVYZ5YdYv45CN7Mlg1HE57PRJBCUdhPT4fJVI3RRqlCEf8uM9AKcVAMM8/YZyH
+qLhTvOYT/2AYZ7aCuJngFKPA2rVry2kvsVU8A0aSzVQnbh/WRR/SP+rNJrR/hoEggsn0LnZstzih
+Zk2ce1BN92PmWRdBmkzUFKEA7fZyXl6e7NO87wQl+kYn/Lv0k9D9IuUaiPiNfwYSTRtEeQqx7Qon
+hGTUkqtth9EA4+bNm+d0Ueok60ycBFNAbvoZPHhwf9pT7Nh0M0kAM1EuzKK/FAcCbNL5beOC4sb8
+MalKhBp7tucYKYY5qRmE/pw9guGN/ZCWE1o0tjjY1h2LTZv0hS5O6oZW73rWVLejqVtG/H0UaVYy
+0O6lgMUk2OlaIyaFBWfSvn37luvWrXstAuZ5hMsrjs4wTzAVG88zWrYPEOmOYpCUix1tHTPRbayJ
+HrSJGHcRLikzEKNNe0YbYR4nu9RiEvIPRhI7YtnQMgNOBwqgbWvN2aNXwPWPDcUXZlyPwsLRjBZt
+WQmfgYRAMM87DpnHw1Q9JsM80TZv+qWTW326dOkyEMynxwD7uM9ACWWgbt265TG6iFmO3DFt5yoY
+QU5Hzp1qFzEDb1wUkNPAzBwja6wXGlK5xsNAom376aefnoMax9lRBMbZxonFgRBxll3cDLxxUoA+
+YDF4XkntxDu27A6hRtwZKGFrIBZ8jzPz/DmkgvVeIZwcsT4F5vm8HjAT0CQpwKnTEYj9JVQ+ouMJ
+MhDTj1rFk2hx15ML8jDPzU6Yh6irmXlORiPzTTwrnck7uRSgL5jcZbEPJjp9aG837zJTiHcFPWcF
+nmEeF8zwFu9yrMWxq0nvOH40EeM+A8E8F1EROX5t575Hp98v8xkNOzKlN5w7KLpz3bAYCssX/eLt
+KlBA2VlzNwiHuCoRUFfL9bEP2GHI6LKRe6RPzjCPHaXSGy5H8mGe0gQxjxArfddAzDydqcBnEKuT
+rtlFTgXeD1n1C128DCz9KUCfKKI/yB5PopyPGSiuTBSXGUjOtUOoGXbMAxUrUVUOyzBPovpTcsth
+sOydSAwoL6ILTqLBLS4MxP3K94GM3Vl0saIdzXVGc6NBPJMm/SiA+U2ilUMfx5tKMdfCYSk7BkJd
+bIc4o8OlzDwv2MXLwJ1RoNWsqW0qvJ7zfJY5jC2UHmyctDMttgRMayHfYSlrm2u8tHFgcVI/v8Ld
+5a9zR8UKatTTWa0aFEss9eWarbi6mGrh0Nf3QeUodxFoNR8wzxMwz4VxrVkCM8+fNfloj886y/QZ
+/S3TKKRouTprpWmYb7pM6+mKocU/xBMdd+mk88n/v2w3NlOXY+4wXdYMl2FOKh8y5j3aINrNSXUR
+DiDSRxhgxep6fwfRo4ki321ahHr8UrZD5keTQSRpYsZA/fr1y/74448/gjCH6BCgch9jVX18ul/e
+PsGyXLfNnHI69b3a0KpkTb4patx+dEHXf8/r3z/m55fcpSX3Uf7lOpqHwmgDGNoqYXNlUryZO7Rs
+ea/5jEpf8AgcQ5DvrjL2ev3/RJGzQbXPAgu8s3ck4UJHP1xgwR7G2YQ2VxRTCXExYyA0LDfSmSbo
+sKaiPwuDoRlZq4uXyrDCBdPzf/658lzLsK6kLo5FEer+Okw0JJZM5C4rOdfwWU9HTS//LGS9b1iu
+Z1q3yp3xc/8RO6LOq4kmjAkDwTwH05k+goZuDR29jA4npavSoOXMae0rfd6LYZxLGPHba+qpBDHi
+P15ZVPwXZYQIAPkzS/ZAbFyqF9siyNA0d9IZXkTsvK2yaEyiF/sRIJpaURvMQDWnSj+FgbQyLerq
+cRgH3pNa1bfHJnf2cz18VdVXIvKch9eu7exz81+1dGZVUfFLTuLq4uSUTnresvzffNVFiwbG5xld
+/ykwCm7eVFQUdzVwNAimUpoGMxDmN7dToWt1lRLxBaXBqbo4qQbLf+PZrt6K6nsYGM4Et9ip+03j
+51x3fp8dg0aI0WxULq906vFey/NuVImdJjLNT7oUdD1+Zf/+FU6TNMV4DeoYiG6HQ7SrdYSDebYA
+v0AXJ9VgOaVTRnvKq7+CeYaDW4NoVK9ulrFbVXXFI/XCHQaI8sJnee7XRpe1DXdMM985uagjfFaW
+dfj6bWueCA/MhAYoEHXnoHPJ7PUAXmsqAQPJfk/a3BaaU1rC19e8kxHXojODZ4aBMGsCBA73D+3O
+yCmdPCoczC7s9plTLkT/3FcXj0Z9qrqo+HC36d7DdLmuZV2zVBdfBQPPUTllk89WwTPhDu+cDkeo
+mg3TknCwQBjM8yLM86fAe6r/u2dOPsTw+haCp04ZErYaqKqX01Hv3b2g6zMbyjd28VVXfYmyoXnY
+yBLIzOw23PvvKjrb8eDSeu7LrXdu275cq8Qwje05hrvXzqJzNgaXnT9z6hEen/dcwkaSvk0wTPts
+mh/BjH/QxmnCwKhmoN12260Fo9MdOrrBPD+hdfubLk6qwUyv9Qw4RcY8prGQup55/dDifdGwPSJr
+hspBI79jw1Ir2kon9ljVj0dCg53btk3QMg+ZwcS3hDKPlFE+ZNTHMMLf93S33x18R+BfdSjiHVHw
++vS2keDZlOJGpURg7XMbDGRnJnEm+z0N1jYlqjHyy6b8gRH6Q0flscYwDWtmlsu8u3xI8Qfh0kAf
+E/HnTTr8gHDwQBjayb9VDh3zqLwf+umn7mXrvm1bbfnaGdk+l2Fle0yfl6+HW16yO8BnWC+SX3Yg
+beg/jfldr175vRf3GSGWELau+avTO3k8FaPA9RLEwm6qBNlZ2UcKA6rgTTk8YgaSA1HcU7wEoimP
+1zK6vYnoNjCdCJtbNnkcJiZ3a3E2sR63jMmG6ZroZK9ENHmeiuqv6fQFynyFGS1jHRxZoI2nzOB3
+gJnlOr1qyJiIjwvklk6+yGf5vzn7e2ZBTwwU/bBYeDcoKPNYQ4GIRTgORE0krZJ5gMlVVBGZlqRC
+a/h81h46PBCNJrO22LNy2NgLnTCP5FU+8Ow1hmXqacHUwuZsYUOZh+LmRMM8giczWx/5VzlQ/FEF
+a+rhETEQotuhTPen64gG8/wXa4OotD66fOMOMy05XqF0KAkWhFtbKBPUAKqHjXmaGTnOtwthD+bO
+cnS3eHh8LbVWj1l3/y77fR8+XSY0IgaCXDfoSEZH+Ymj2f/WxUlVmMsyl+twY9dfu5bRpc3ONcV8
+Z7MuTkNg0P3eqtNGfxVNHrJWI92BqrTMvIs/O+ywahW8qYc7ZiDU1gdC7KE2BEvbD/pmmYbY8ikd
+Ylb/CWxiKiNoALtOGbPBlZUl+ylx6Ijm+0cXFF6vKV4Lyiub0gN7upaaSIs0sCYPctwhWGD/C2op
+lQ6Mgv+75pprorcMTnJTXDN0zOeyN6NBo+2tr047WAPXgiqHjH4TG7PzHKqOtXkFgDTGm3lZ2Wc0
+xMKbCUgtvlEQOo4MAwUIHubfEQNxCGo/0opNmNIxO908YcIE7TpCmTgFABNM00eHnKtDxfT5ohbj
+JN+qojFTjSxTvlz9ua4cOxjpV7tc5hXsO52yfcg5m+zia+Eun56BXK4MA2kIqNxTCE7DOad/8q5k
+Nhp0MZbWL/IfnCztnpH330ZUO0OFOIOEMNCdKriT8OohYz4fbk0/YmZZ9fFewzcYHdhhpMtBjHJR
+/hbm+E3gsAnV3E7U5W6e2di1soFtZ+9pEzRexInSufyzeCl2UqQ+jqUxC6KMZi7zy4w1qZqEtj2e
+jyl040L4FWShtHnD4mAkmrfn1cWkByR35tRe7Ft+q8TWNCq6FOzRpjFZKHMsYi0Kki7h6gyTfs/R
+ix7hYJmw3yignFUCBGLTVDRISuYBtmzcuHEzAvHT+b9yyKjldJrVyjpYRt6PO9Ydo4SnGUCUIirm
+qalKRnyzaVMtA8nZddKfr8uDfZ9b0nntU69upjWnXlhQgM/nPS7oNa0fH3htagt9Bczv9PAMVMtA
+S5YskZskO2rItHLQoEHPaeDpBzLNt7VIW2Z3LTyNgO4snxd0lYofy/JdIDaCaVSlhKOqZSCw0VpT
+M/s8OmPGDGmERuPQxWmNJjG67NpYKiv3xKH3+VpTn7Yen+8dzkgpFSuatE0CpGQgPj/REwqcoKFC
+FeuFpzTwtAMx26JUsa7VIU6EX3TwdINxidocPc5WPnSZkftKSQNMhfQlpDNUqcbGaPSvVEynpXsJ
+zdtP6Vz5UNw5JXo/DHRBaHidd5exrM57mr+4LffEaqMaSUN7YYoLg9N7c14paVY1rPhWJ1VuX1ra
+cqe5vY/XMnpaTOvZhmt5fraxZPOg0ducpE9GnG58gpSvKI5nwBjF5NABHMQ65V+cLPhEhU9YBkEp
+4LrrrrvW69Y/qK7/CAO9p8o43cJhnruQ+fWH4KhUtpl1bHnR6PnpVj8dvjDG/2O/6d+6OAGYHBGv
+Gjqm3l6YzN45s6cdZFZ7T2EePwXr8qNJI0qoIGeWMyY/neWyJibjQscgROo9Cv6Yq83if1AIsJq+
+PkDV18MykHzXhxsglcwBdy6BK7Um8CFIpPQrB9/GWz7fHbZINtLjzdJ58somP+6zbGbfGgJxv904
+rCDukZOqFdXlJxk+16noIgaiEu9kS0OJwLFzV5Y5vHJw8RuO4icgEicNhkCHsnBF0d+/pr+H/TB2
+2DUQdm92ZjuPhysoFcI6z5zZLBI8cl7xX897u30asyo7y7zSPl76xaCDWEOH5v0VxnjSCfYw2kRm
+rZXlFeU/W16De659Yx0zjxSA8Sr6v1m5ZZOwxEgNB/Mcr8IE2P4wWFg7yLAzEHe9rSYzlbYJRZTR
+lePa61QFJjJcjiVXV5dfjtXjSYghvX6zLDbL0S4tNS0LA1HX5+wWft6xVdcvQy0IuJRdiPIBaeyZ
+zjTOrS4aOymRdUtGWczG19NhbkEEC9s3YokT5kkbmjfP22/LSSO2xjLfaPKCQaTeyvUdg8ytzEJi
+UF3H1SMSzHMEMWTxpHILYJ6U2I1n3XKjZfiugwF0J2R/qwcXkmNfthRG+1wYi+6BAsSaaLMT70/r
+N9wcWvwfFUEaW3jOzJJzOF44CSZSKpliVmfTuJ+B6fKY5RdlRqx/BiB5vaVKDgMthYF6h8LDMZCs
+BcaHRgx6vxIGkg9oJc31mzs3e8HWNY8z45wbVyQQbfg8ySWVQ8c+HNdyUjBz9n5GMrhMYZDRmXE1
+HHPT2JXX3Nhj+4CxSd0eqPm6yE/MQm1UlUKZ0BtlQp3T1uHWQLr1j8UM9YKqgESFwzzj4s48VIar
+qS5uiswj7YgR6XMQ4DwelZYKEq/BDvG5cqfx9wbn08AM5s2b5yGLsEqEQNbMUGcEngP/dRgI7dve
+AGQDNaxjGvs42V/Sznvt2W5cw3FDWARjGMjULDfv/F8Ms0y7rKqHFk+mzUehNnN0TVbdCsq1wuYC
+1jk3ylcp6sLqvrHcuqTb3Ll5dUOT8vaSTan1Jpc6DMS5nz/qMoCYSZ99rKrq6x0t+nUVsYFRz9Lr
+i4p1YqxNDo0HLDNRdrbZH6XM/+xqBd1W06GeYK/oT81btWxfPaz4GDZeb2rnasMax9SIaFaHDdvX
+jrXLP97wDh06vEkZO1TlIN4d3LZt2zrKtTprIMQzZF6DESe8w/btIA7O2RIyfOqGh8rHrTb+VLEB
+uTy6e6udoGAa7+3manvq+iFDdjmJHsc4I8hbrCIOx8tO+JP46fikOA4BZpXNqhhk+cwzUVvvT8fp
+gBnQjxzy+wHG+ZDbIt6oGlxcZ30QjCgKn5tIp5QcmKm+vb5ozH5yMjg4XaKf4QGh8XBVufBAMTww
+OQCvw0Co8tbAZYUBYPA/RPqFhLvxL2rspDi56JwNz2nKwms0bYh4ezvSzIVkRCPObJNvnJ3kj/Hu
+D1r/xfcLQU9e5+EvxesMQAGnnmvxRkmHygprFe2iFNWivRgylrXl+oKRSGLPqvKk/z+JNu7PAXit
+CCc3jqqYpybyvGQyjx8Hn6Wd5mGA+xAZDjywS5+WRparL4ekz2PX+378e6ivtwUqHfpPuq8QO84h
+7dAkMk8BeIl28wt8P3w4149AgUs8iZ82bsfA4p9gnkk6hLnA2NaUSpc+RrA5unzgkTrLnNoZCD34
+eWgZlNbVMM8lcN5DuszjCWtW+mznaqtqDWXUMn1oeWa22VslRlBxM++157tbnuq+3KHYnQ/oFKDJ
++8E03J9WFZ2TNLGUOkgbFOPFvqwj3qnbSERZp5XgkyYVOEVW4uW+OmlvXzV7cZo2zM52HVM+eMyC
+SPKNdVwksSX0l/00+RYGDAmyA5FCOSsQHvhH9psbeE7Gv8f0jKGbKJmHGeYTFfMIvjWz53c8ik8V
+J5YQD+LF8DJSJ8z2DP4v+EvwMjOltKs8bey33MFQyv7S6SpEvR7/LKSEq9LFOPxd8lMyELwgs5B/
+KVHbIWEgZSPS+TaygbQkxkhGlp2N+MaG5zORZZjU2G0pXTZnP8Ur6e4QQ0kv+Uh+km9Ku6ws10Qd
+gkgFQ+VyF12ceMNgEGEgpQuebPwMVFhYmE/sHsoUhrFQA4s7SD4OBWGVIwLzS1VuTv5zcUek4QUI
+vWXG+BZ/Eb52AOO5IU7ykfwkX8k/VvmSVWzdb+KZuUCTq8vyeUWkTZpjKaNlIBA7JoCcn9BsjoqN
+j47oXwYSJOPf4/WN1ZWLYrBs2ykjNuvipADsSHD4GC/fAmrnBB/zhGON7PtvNeTfoZN8JX8pR8pL
+SWdmmXfrEGNBN1AHjzeMtT5bJcZyVTnMQPv06dMnR+B+pkFE218VWcJJkLRFds/Zs3OxJhmpw49N
+vkk6eJJhHShflDMf4g91govZo5uRdecNRvY/LjTMPQv9//Iu4Q6dlCPlSblSfkq56wePLkPzKbNl
+eGcZe4cHJC4UntDNktkrV67cV7DxMxBTlpaB3G530mag1VWbh4CnWrZnfXZUyz1eTxxpHZeURUzZ
+s/kGfx7exOtdy+aG629jjay7bzRc+9S1qJJ3fzhwg3gOnJQn5Ur5gofgkxJOrtNCJN+uQSbpuMJA
+X2nwE5CfZ5zMQDu3bt2aPM2V6Rumr4g5dV7//mIImErueJARrdgD+Na2iDGFugb2N7IfvsvIOuUE
+jjD5m6VeMgkXuMST+KgW68UJEyDlCx6Cj+CVVJf3yqQBO6q8shGsnI2pViqcNdNuVjPpHCCEDKix
+lTOQcCIesTRJzrJqF2zhMGDv55lw4UkK60y5It+f47R8c58eRtZfiiMRzwyzZQsj66JzDdfJ/Qzv
+YyWG9Y2j8U0a/F38NLxsWK7HJ8x1fKOk+eYK426vXJVmc1iPziZ4JtXBIFoGgif8DOSq+eJ2WPOd
+mhpoM4p3LTn4truqDEaq/0X7YSlVnlGGu0knnVLEJWfM06rAyLr0z0bWHRGtbeqg518rkV7yMcjP
+oRP8BE/BV/COu8ubNfm4LRUYo1rWRXbMAzI+V7Z1T9yRsilANkphki2qaOgFfhPhKioqZNTUuVU6
+YNxhllmhKoOBrFPezCknquAJCm9BOXPxd+HlWe8Qw1yDT0YMu9NwnXicbPDq49tAJb3k48+PfA2F
++BeSjeAp+Are9jiHJHb6KkcU3GUl93o9vnl0uO5O0lGdF2TD1UnceMcB58WaMvbs3LlzM64LsLQM
+RAOt0WSSAJC1Ql2I1QHDv7e54OLlvFlTHTWQOq+oIf8hpVbMDORs9tnHyL7vZiPrz6MMs3mzQHBM
+/iU/yVfyl3IcOsFb8I+5yymb1mf9tjWLDJ91BZmHX9SFlmqan+ZnZf8tNDhZ7/R9rfSFcUFnYaAu
+NgiutYHHFcxX3WbbFYBGZ5jX61mSU1Zy+25zp8dtRFXgMUgR/nuwrFmuusjIvvV6v1r6d0Dsn/xq
+b8qR8gzKdeDs8XeQSXCU/NIpx1iW5336lmNORke5sEWzvAFbB49Sik3BZSTiGQbSLi5ZJ3WRkUE7
+A2HWkFQGys9y3Ye66RdbgnGxiOWzrt26teJbxIZzabyGyUa2BdZGUK7RamPs2GlYXy01rG07aoPi
++SDlSHkG5Tpw9vg7yCQQJf+NZ7t6LN/rrHXaBMJs/uXLgBP57lL/VLidJwRXraJFpDdbBsIyNakM
+JCMSR4InhFRM+cpstDtiw9OcHfqoWdmUw5UREwnAetL35jzD8/drDO9rcwzONMWldMnX+/o7/nKk
+PDpxXMrRZeqtqHqQgh1NfYzwK7jp9fiqYWOvDr1yTFdGomDgt8GmrC4upiHlDEQGv27cuNHRMGZT
+UIPA1w0d/TCr7chkdcs6vNrnnc/lfZc2qPBYJmZG8D1aYniuutHwLV0ey5z9+fnzfWSS05knpuVL
+ZlxS2RueHWqbsWyLmMaD7V1tDkrla5Lp/9oZiHp2MTnC+i4Pqg22b1HnOZdjbSnXsAi5ZZP/yq2Y
+DzKyZkeSE5qdf1cVjZ0QSZoI4kY9zJv9jzGyxp5lmK1bRVBc3ajWr1sN76TnDWvu/LqAyN5iIu46
+uSIZE55VKArP527sdyJDMfGx27dv35JT2Ns0JU9HOjKV6iBguzSJEw6qHDrmUdPM7sts9FYkhTMq
+3pA3c3K/SNIkIq50es9FiHVlbxiWly3GCJzEl3SSvoHME0GpNlEt6yhdDPrTUwVmqwPSgXmkHps2
+bRJzI50E1lHWQPkSOZxjkZRSDCQ4Vg09Z3F1UfHJLtNVRINoVNx1aoSomuDNuVYtnZnalFcYvqem
+GZ7LbzB8svB34CSe5wrik84gvZ1DEWR02XMPu2gNh+vuOzDNH7jh54JNRUU6G7iG4xD7HJTrIPpf
+c1Fj56nKJIKO+1TJEhLOnW1lvXrm9QHH8cjTto1CPQ/JKZ12YEKQk0JkL+bcEUjJnZwVuWad4b3h
+DsMz8SHD+iX8yQwJ90x82B/PWL3OUb59jzzSeO7ducZpZ4FLnB16T7Vlg+40cZzxakj2NjyQLyKc
+cgai4JSbgYKJsbjPiCpGtbtyDHcv02U8jWinX4+Y3lOD08f9ueNuhjHmT4YxeIBhONw4tT74GC3a
+eMP74izDqvb4UZR/eZdw64OPHKHdrkMH49ZH/88oefM1Y98DD3CUpqGRoL5yvcBNSW0bmn+S0iun
+eJl8ZDGuZKBUFOHCEXFn0TkbCT8fs56pYpkQLo6EcS9ZTPc8VOXUC9+foyO9uvMdiI85fM3JEDv1
+cmWV4Zs8w/DNec9wDeLzO7NZ8q2XKto77m82zvnbX42Lrr3GaFHg2D7OPmMnMUxjs/J6Ez5pInea
+p6DlvLZm8ICSgWTyERFOyUBESOkZKLTmFUNGz9HNQqiaOoSmSdh7bo5hnHgsVyWebRh7dnFWLEzj
+e2KKY+Y54vjjjBcWvG9cfdstiWceqZFlhZc9a2r7afnPTjdXndEnAbHggUpNMXy1EvW9JkLSDzZp
+cAsP0log8KnOZLv2SDJnn24Yy9B/zPnAMLY33DqhY5cuxrhbbjIGnkG+yXQuBlyfWor2VXvVa6Rk
+4q0vWzkDyeQjWrgqVXoiKBUMqjTJDAffmOxnJKQO+/Y0jAtHGcYfOFfmzIK6HlrZbrdxwZWXG6Wf
+LEw+8/yGnXbANbOz4mOCUY8ysQugT+lmoJxspqhyFaMASysGGmHMkAEhfVwOA3K/owzjwP0M4+33
+DOP71Y5xP3bAAGP8Xbcbe/bo4ThN3CPaaNrM7Iq0YyBoptugq5QOV64hbK4GlnKg6cZwGkg+q6Fw
+mn0KRYrEBLfl1PWIoYZxJobRsn+kcbKfc/+zU42HX5yeWswjOGNmoEGdy8ey046BmER0OoIKUSLo
+ZLy0moGoLDZW6oVsyqtSRVMnYt1u7cL2w169exuvfLzQ6D/o1LDwpAdahvYoQqXlPSnpOEaOgO4G
+l3LZB2o0M5DQxrTMTSoaMTyG75mqBMkIz0bPkRd+4i/AZi43L3XHNJagP+tIJl/W4NOR0/Nenbqn
+Ll4qwZhglKZuwMq1IhzMpeO+VKpnLS7ogJQMRCRkpYyLFwVcbt98u7zpdMO91d6l8r2gzjNnKjun
+XT6JgsMDShyB+UU43V7P7olCNGblmIZOaxKzYjIZ1aeA/y4DTpbWh4SGWPnysa1N3i3fyDefQqGp
+9K6bgcDTPwNtVCFM4vb9+vVL/t6JCsGgcPmCGo3B5x+tE4KC6z5aRnXdgMxbrCngcpk3O82Tw4+F
+Ita5Syd94J41FX1+6jmdFAZ/7MJQ16U7NOT66KOPOqVetepilDOrZL9Xyio+pDFuBSJiqcLZ3jap
+SJcJdkqByiHFs9HF3e80vj+exaUsHs/HuaWTrowoXQIiyySiKWajdLZ1mghYxpgpK8ZNsCwXh+zG
+8WWzz5l5DtfVQ2AcrJtpFycDbzgF+ELg1TARR7sjci6MGO7JLS15TGzmIkoZp8h87hFrYCO8RgcA
+k886YSDdDCSoKY98CzBZLrd0cs9bSye/z5H0uzFgtFdNmeam3Ny86cnCtymV+9lhh1VXF429VD6b
+CSNpNXOhdOHE8YUfblv9j9DwZLzTtwptyl0vamztDEQGKTUDMaWacs+Bz/B9ifXi0TYV/B1smVel
+wSdQfse3ETxVDR3zbPOCgr2Z+uU+C8frT2aiG1rOnKYTnRJFna42Ba0TBtLOQHTY7jaZJAwsUzsi
+2zQun3mAWUepXqyHEDJ59bAxJfXC4xkgZjm/aPcV41l6nbx/WL7cmP/2nDphiXr5tf/pv3KC+Aoz
+y30gfe11h+W2rvR5UmE9pJ2BhHdcXFulnYGItL/DSsc12qGffupesHXNczD0SOcFmV7wH484cbnz
+NDGK+eNPhvHks3yYfgHmukp73RgVFj6bXTt2GP+58d/GmUcdayz+/IvwkRIUWjXknGUcfjyVo/iD
+td8G+h2fU35/TNqTPQPVXFu1RoUiHTYlGOirtUuuQ+15pgrP0HBppGyX61g5sRoKi/H7BmV+cv/b
+ws8N47GphrHkW2W0eABee+FFY+hhRxpP/ed+w1OtlZ7U+McBMY7iv3pAYe/9EX3GsT5S7kGyIZ50
+K1n6vtZiQiYfUSKIpu1rDa26tm3btkADjztIPo0BQZ0tLMUezmU+0KFDXt/yoaMdbOo1GP3ZtjnI
+DaFlbxrG1JcM4+dfbKM3JMLyJUuM8wYNNsZfcKHx0wZHvGGPf0MQCpNWlAyVRcX30FIfhAHXBFk5
+alhiIPCF7iz8Gpl8/AwEp+kYyKiurk7qLPRrpXU+CgNbOzZs3VZmucwTqocWX7b26BE6G79YtoCI
+h/MdZbiG5eZTz3F04X3DqIitwcT2rduMO8dfZ4w49o/GZ/MRG505wTvx4i2FipKAQbG/Ck0kCEfc
+r0rf0HD5Bip8sa8qn8Ck42cg9NlfqSJKOPcM9NHB4w2zfOYf7cpAJHi8wGx9YMWQMfPs4sYYvoP8
+pCNcg5dnvZP7EORehMemGMb/uMbK7n4EfW4kt4zSac8aQw493Jj6yKPSVjYp/GDBU/AVvO1x9ieJ
+7U+V13MOObo1uTLKJM/xDVQOaanxC0w6/g2rwIsGXd1UpkkWGxDnTAuVl1VwyoQBYFjl0NGvxXZM
+jwh3WWTcjWex4/ALdbuYIGejGVu02DBOPt4wOnWIqECJvGTRl8Zt464x/vfJJ5GknUbkq/FMh8lz
+tOlYdZuCl2kh7ybVHaQrnT73tcD9M1CHDh0YCrUn747WZRZ/mOVRlmFaVk4z78dKeGIB0ilH4WXG
+1M7qtWit/9EwnpluGK/Pc3RJoqTbunmLcfMVVxln9zshEuYRfAQvwS+pzIPp1f4M2oeAR3jHpvcB
+nfskfG0WjAybqFoGAn9/+/oZiOlKDtUtD84g+JnIfZOpSOCMjxI3RrHcyh3mxcH4psDze+BwMP4y
+/K+O8FnEgPYoYt0X/CvEOm5XNWY89bQx+JDD/P+0i5OspXzBQ/ARvJLuLK9xrhYJ05gmigZtnDgD
+WeMcqCnCWzPp/G54SYIFmgRZfAryGA08viDTeENXACdNL5HPCeriJAEmi5EH8Pvgn8bb9/YKxrE3
+5hnG2vDr5y8WLvTPPFu3bCE7WyflSblSvuDhaHFEvLg6sZo3DWuUthDLekYLjzNw+PDhWRRxhKaY
+FTWTTh0GeleTQBarf9TB4wnjMxhl5L9ZWYZl7LZh+9qxSnhyAeyoGufjj8J/liBUpBwpT8qV8lPG
+lc2qGMjE2UmFENq3r9j4/kIFT0T4rFmzDqW/F6jKYrL5MABzBR7cbreWgYjHSjc5bv2QIbtA+mFd
+6RzQumoC1tm6OEmGfUT5Mqr9Ff9LnHCRfCV/KUfKSzln+fTiG9t4zyQbaRQEop1UOvpiLa+YwbH4
+VtAq3vcIDgt6rm7Tpk3r9evX7woKS9hjizdKOlRWWKsQhJSimmlknVE1bPTLCUMq+oLakvRW/F/w
+sWB6H/k8hv8nXj1TA4yVE9OqxeuXFNLhO/l8rs27FxSusvvKXKtZU9vs8no2yLo1LB6m6ckxsgtr
+rmoOGyURgVgYvMEMdLKqrNzc3L1+/fXXlQIPZaASwsYIIJyDM0/lg0Ovh4MlIsxdWvIosqR0OoUz
+P6weVpxkjaECtfDBsrB/CC/iVrROxAlRoiRE7HG/OrWv6fFegVnV6TBCy1qk6fxYFixD/bwIMWwR
+RxkWufO9i7YPGFs723IE5SKf5VNKEozsr2J6Nbg2zyQ8HHrooe4lS5bIIrO5ovjVfHRuzwCsDgPB
+eRfAeU8EgKH/VPCxXbt2iYiQFEcD7OMzLL7Wq76BNDvbdUz54DE6hUhScNcUKm1QjL8T31ETLxS0
+kYDxeBn0rFBgrN9FPL6ttOQ27g0bR3GyyHbkqNwaxulFDNVf025ng2g3VUIkiOFIEC+o4IkIb9my
+5bEej+d9TVmTYSBpL7+rw0CtWrXqUVVVtSIADP2HgTZec801nSdMmCAiQ1Ic1yK9ApMXqQpn9Hul
+aljx6Sq4hOfPnlLo8fj6mz5MNUyzOw1cyci5Ksu0Xt81uHgh9Yx7hwyDXyvCJuAvwfs3uPkP52RP
+7EH8BPxWfNzdb8wz+UlmnXPjVphpbtnT3X73FYMGVcatDAcZM4n8m/71/1RR6Rt/ZhJ5MgCvw0AS
+SAZfk0GfQITQ/+zs7OO2b9/+QWh4ot7zS6cc47G8uvJ9Lrexn/+GmBqk2rw1vdXO8vJ+aH8GUOEB
+/KttnAxzKUS6EqvhZImqYnf4X3y/GvSD/+bxcimezaLEOS79+A9z3GVxLdE0H+LckAweSXX0/8X0
+/94qJFC29dq2bVvtJBOOgW4igxtUGbAOuo910JUqeCLC3a+UIKKpv8cJA8xwmcYjTJMnUJcTDcs8
+PBKxQ+pgusybqoYW35iI+ijKGEH4BXhwNz7By6iHyUJiHWLzJaxbhKHj6Mzy7Hz3PuUDz0bcS57j
+DoTe2BIu1mCwHPFt72C4K/hFnul8L4WGBb9j4nBG8Hsynk3DdbeuXJhmuNdnzbF81j8ZOf8QKfNI
+3qT9fzDqA7py4gwTZhmIF42d/CeceXLKJhXBPPdTdlwdXxe8N9nMIxWkbw+3qeiLofB6DMTssohI
+P4RGDHrfk2nukKD3hD9eXzSqlBt2lse/YOtSd+nke+JfTuqVIMyDFbwwbb0+EktsaccXevXIuymW
+eTYgLy0DMbnYM1BN4dpZiDiyUZc0N8Fk+e9y3ZUQBCzflVxDm5iyElIh+0JyXpnyJzY8ZzAP5+hi
+0/nlUg05WfogossH/G/XxQ+B+UjzUNHQ/JHyrdsQWMJfEd/2Q3JRrv1BaBXKg09DEau3BpIIqPKO
+RpUnh63COtZB1zNT3R4WmKBA0QzdWlYy/zcRLf6Fot2btkdO+/OTrSWKd01zZ5UM9HmMV23FXtPc
+ZmYZx1QNLq5VaNABzbyyKT3462u4fH1pm77kczBKm85+vNFu0uHWEP6O6bZuD1b0xLtedvkjVd0I
+/hNU8VRr/7AMJIQgw+/IbK9wGaKJOx5NnE5XHi5ZzMP8ZvFeToNq7JZsC/Wfy+cbMJq9pdo8TGN+
+nss9bPuQczbVhjWiB7nhlYMjH9LpRaWucabXlW2cVjm4+A1NpFrQbnOnt9he4W3f1tPiJzHLqgWk
+yIMYj2L/9j3o7KFCiT5/LH2+3qQSVr5F1rPwl5OZN0yGz6cC8wheMvrJKAiuq8PgGT5ILp83jbns
+lP8zOyv7yGFD8wtchjkM9Ym9GMEVtJVezzsFr0+XhX2jc5bHQttmxzwsikzjEqfMI0T6uf+IHRWn
+nr0yFZlH8Hv11VdP40/JPPSvDVdddRUDS30XdgYKRGvevPnJaCZElXsQ/icyemKvvfaauHjxYvvO
+FsgkAf8t357UrnKX+Q/k9ovpAO3qFPmb2IBixHwb1fTbu7XLeT/cfQmoa4eicXqBtO466cO9mOYn
+bPod15jEOfZ6Dka0+jxcdYPDYJ6rKovG3hsclu7PSFuvIXWdoqnHXaivxeqjntMyUL3YKR4gZ4LW
+7Vjb2zR8vSyvq1mW6frO3dyzONgeS1eFnJmTh1len2iebJmosXWknFcm3Yr5xfU6+vAt5H9UDh0b
+5z0hHQaxh2F9073G+kbFC1ZOTk6vrVu3ypKmnlMlqhexqQTkziwZ5PMazzOTtbCp8+a2+eYeGwcW
+77SJlxZgTKReZBQ+Q4UszHMxzKM0BFWlS/VwTiCIhvVqFZ5IXW+hfTtZBQ+7BlJFbgrh/s9zZJnH
+onVba1Pftr9WuY6xiZM2YDRlu6uQZZRd0xiZp1u3bnkwyHmqeks4g8ojOniGgcJQp3rImC+zTfeR
+dBzWTmpn+bxHq6HpBWGpuE6FMRqlwhazp++mgqdrOBcjXgiDtFfhL8qDI488skwFl/AMAymos6vo
+7PWWO1s/OhmmkviKbFM42BQ1bniHir/KUzkgPDA9Q3v27JkLg4RVDATV6Ml58+aJ9bvSZRhISRpG
+F5/VQQNmIz2inXddVkmHYY+ms3AHP99JSUcyhghwslrOvnXRZOnl5OnjGrgflGEgDYX4ZGRfDdgw
+fal1YYcOVztYS1+reYwI6tHWZzSaGUiu7YUe19nQ5NktW7astomjPbhll7YpwOXItdIxan+pBEYI
+kL2sih2uoZj57cmCvhN558CgXh+b2fLMHk071MztWJe1JmsvJ0MrOabxiSvbKjuqedc58/r3V3d+
+B7hsKirazl7QR0QNqxih7K5yIphzUt84yC6lo/zwww/nM/sUapD0YXlwqwZeC8qufco8hKOAloFy
+cvIWVYRLFUFYs9JnO3uM6nsqdhiokH1caP5bYjaF4ZnfnwNZBsJ+g1qHY7f29wVbVy/iK9d/rh48
+6rNAvGj+OSbylmX4wjJQTX4ixqU1A8naZ926dXazzwysbZY5oWFGhFNQyf9JFcvqpQBjDWSuaugn
+I8Vws9qoWsRoOBKG0Fo+q/CQcJiqr+HxfpRTNvlsXTw7WFaW8ZYuDsyV9uugDRs2XEEdlWY7wKys
+rKxbdHQIhmUYKJgaQc/bqk0xX9LR54ug6BE/MmMc6vNapfT+GKmHrSzWbJMQs6Lu5Ec2L/yYddA2
+VWUQG/ulyhe0VTjqwjHZ6Yxp2j91cdDMvbxjx45aC3NdXIHpOohd2kYNh9BaBQIdTbtHpCOO3I9m
+er0vwTy5unhRwNzcWjRN7tCLIq0h6yjWWHOVabF6X7BzjfI+CWW6FAEw098NKloLExjo5kjQzTCQ
+ilo+/2XsKigiXPT3sO3yeOXmF50YoSzXFsDGYFW58ahtPEUE7iPSinGGz+qhSJrSwXJdFQieo0MS
+5nmh5kS2LlodWIaB6pDj9xeOS/b+/a3+kysvOyoRjtOeveG+i+rnGLsQrp8allM6ZXSkOcrMyBLA
+ZubFjDbNHNewubgs5AEbtCswGlXaxKnSZhhIQRk2STspQJyMMLdEfwmG9z4MrCLVfqKTMzbTc7+j
+7E/wnypxqwGw4H9ANHx28QSe9+rUPbn19T5mxtUU9GddGo7Sr9TBUxF21113/Y0ZX6tRZfa5O3Bd
+byR1iLQhI8k7zeNa5coKWEYB1su3oYl7in2RFcp4IYDcskmD+XC30rLXH9007zmmoOu1gX0dGp62
+rX/RY25pyWM+y7owpIjfXy2rjceseoKAQb8H1n2SM0Aw5dVej3e4Q6befGDHfRY3SFdeF4W4v9Uc
+V7hTVxD0Xdu6des7sLrWRQsLy8xAYcniD/xWDULjZVnXcQBvOZ3wA0bvC9vOnlKgjm8Ychk7ezza
+g2g05OqOu+XdEGAeyS8c80h4S6PVVXT+lfKscpR3qrus5IJQuKjP3a9MehslxufEOdsh88i676lk
+f/gqtC66dxHdOOsziThaxQH3HVwd7UcToEnGhaOAu2zyX7goLILFuFkOMV82s1yTrhs86u0JmBQE
+58uMcRUzxsTgsNBnjqePrBoy9vnQcNV7XunU/l7DOwcGULcjaulsl3FA7917b/hq3bKzMGK4GqY5
+UJWnKhxG/obvNB2Sqseyw+HNieqr0abKeR+de5/TpsfrIuhgasLrUjUBmGykbq5ghNeYu6vIwPpp
+HVPHZMPMnlQ15Jxlv32ahXvsdJefcC0UV9sep8pTFf7b5Y/WpSq4hNPInKY0c1EuFOriKWHcI+E2
+zGN3FRXbrr2UeSQYwDVV+6M4EHx1WwUeZp/DI9W8BVclI8IFUyPoWU6aQtxRdLxwF6sExaz/yAjf
+hZtNr7W81UsR7xZWlluztcyDDQ83dVxWPyf7kN2y2lzL7KBdh2Gp0CNa5oH5FplZ5mHpxDzyiRJm
+nhKop2MeEY9vbwjzSOtkGEjTRyuHjH4TAkWs2qyTpWUdyfuhdcJCXmjIZzjE93lIsKNXEamyDNe5
+RK4jMjpKrI1k/gJeNxxQ2OeI4LvftElSBLhs2bK7HGjdvthvv/0i2jQNV72MCBeOKiFhctkIG4j3
+0ih7hYAa/sqZohzD3auhX2XjUpC7mWnGNRQhmOYHlH73tTPbPplO651AvVn3nMPsMzXwrvivxN7t
+sEhMdhT5iHiccU4oIDf+rN++9jIUCxeKSOQkjZM4bEtewzVRYmLSIOe/kWjbmvcQFQ+PKiP2lmCe
+u4uG5L44wxwRsdgaVZkxTgTzHATzLCDbZrqsEc3HI7rZKRd0WdTCEsZAolJ86KGHmnFlcBaLuywq
+Kqpg/39eXl7tO2HZEh7wYOp/5nxGVuBZYIFniLFq3LhxyxL50a/8mSXHsp9zLjKT7J9o1de1lA77
+YM4bVpQ3IFYdtnnptI7VVvV8xwwud+ZZxmsuM2tiRdGouWFRTJPAgoKCttXV1aI0sJMS5o8fP/74
+WPWXuDMQo8IBdPiJeLmAo0Wc2mM5+RajjlwYp/zDZtt55sxmm3y/nu7/cptlnUAkx2tKNHXL3Yb7
+uIaKbqGItZ77cutd27Y97N/fCQXWvptVNPw0w5U9sWroOYtrg9P0QQZnrA1m08cG2lRhBx/IOjj4
+A1k28W3BcWUgYR5mmk/AQqsNscXSQQTEj81EO4Dd5PUOosc8Sv4bz3b1VnrGsFYaC0PtrSsA5nmh
+hTvrgs2DRiuPDujSO4HllE470DI857FZegQTzZ78VzAzreQa41ezTPfzcmmKk3zSIQ53u4kI7GT9
+9ycG2XqfKGlIHePKQJy/eN3BqNAQ/OukhYluhIFuqhOYhJf8mZOO8viMsxCQTkBG6iYoYPbzPR2Y
+I9PWI9VFY6MyRE1CVVK+SAbpKxmk73GA6B0wj91JVAfZ1I0SbwbaDANh4ZswNx0isduecU2BAjDP
+GJhnEnXV9mMG1rf4OPYpsVr3BNNWW3BwxGiemVpFm+N4XRBNGcFpINRtzEDaE4fB8TPP6UsBpJtB
+DM6l1MDOIHol655DWfeIiB9zF+/OnUh16C4I9WTMKZTJMOUoIB+Ag3lmgJgd85SjpT09XswjhGkU
+DMTM8zN+ODfof59yrZ1BKKYUQGzryzbILDLV7vUA5+iS64KGmurYIW/HwXbp7eARz0AwwkJGl3n8
+S1rxYqLiDX5H7vXDJAy/AlFxwaZNm7bbIZOBpzcFMBA9nrYvo3+0clCTK2GeZx3Ea1CUuK6BkFO3
+UtlINxqrGDnOp/J25hgNqngmcXpRgL40hL40Hazz7DBnUE3YWjjeIpzHrrJh4DmMMpOZqmOucgxT
+ViYoDShAXyiGeV4CVSfM83giFUnxZqCIRbia9jRhotsYdR6RD8CmQRtnUIwTBRDPr6AvPEP2tssN
+Zp6XTzvttLhe2BJazXiLcBsYOdSXc4RiE+YdosxC6zKSb7nsDAPOBDViCjCA3kr/ud5hFed26dLl
+1BUrVlQ6jB+TaKk6A9VWDgIO5p7iuSwgo7ossDajzEPaUEBs22CeRyNhHoxJhySaeYSgcZ2BmH5X
+UcYe4VqOmWUt4W9DpHPDwcOEfY9F9qkwk+ayjzCpMkFpRQGxqsZiv4R+cZoTxOlHb7Rt2/b0tWvX
+qm9RcpJRlHGSOgOx2DsPAtziEPfu6P8XMBP1dxg/Ey3NKICofhRHEuSyfafMM7Nz585FyWIeIW8y
+GchfNkx0A0wk95vZKhwgbDuY6G2m99vk3Hua9Y8MugoK0K4mmrarmXneI0pXRbTQ4OkcyT4zGWJb
+MCLJZKBa7RpM9ARMNBTEnCgKXBD8uqVLl85nuu8VXJnMc/pRQEQ2mGcmmjY5IWqraZMask94H4fi
+zv7ss8+qk13juK6BmCm+prP3CVdJGGYTjLNbMIz4cvnGq6TpGByued5JPv8gn6c0cTKgFKWA2LQx
+6zwHek5nHbFKuRyL+/+mSpVSYgYKEANG+AyD0KN4/yYQZvPfHGZ7EsabwRWuiTw2YYNWBqyjAG0W
+ENneJZ5T5tnFYHlGKjGP1DGlGEgQwiD0B5hIjn/Pl3cnjgb5E4vP/6Fg6OckfiZO8iiAuHYQA94H
+kYhsYLsa5jmeAVaOL6SUSxoD0elr10ChFBHz844dOw4gfGooTPVOfoUoGObQOA8jGrRXxcuEJ4cC
+bdq0aQXz3A/jyN30MkA6cjDO22xfHCrSiaMECY6UNAaintqyV65cWcF0PZoF41jiOrW0FgXDRTDS
+cjEByWjqEtybFMXBOKMrKyuXwTz/IIpy4AyT/E5Mc05h729TGFhKBMVViUAnFjFMNdpUwSCOLhth
+fdMDEW0azHFEhFT7lhHsKkYvOT+ScQmmACK13E/9EMUeH0nRtNkW2voC+sfLkaRLRlztLBADhHR7
+O45HItZF3x1xxBHHQNjbwEk0MU7d3jTETMS6N2jMsNpApxll4jmnAJYBBQye98A8cnlKRMxD/Hdo
+swPTgXmEIvGegd6mjBOloDDOA5HcYcK1QaIoQBSYDJELtRHrA+Xw3SNc6TohlUWC+minT4isPWGa
+y8D4EtqndYSYyzmw67lu917aiQuM0sPFdQaCIItVZIBIS1UwXTgEnsei8iDSy/mQSJzccHox+w6r
+mJEeymzCRkI6fVxmm0LWOfcJbaHxvyJlHtpyEX3lCA5R3pNOzCNUiSsDMVOIFi2sGAeRn9I3ixoq
+WjrWNWdC7Avwv6hjhoU0o+y/s6ZaBiO9wqh5XNhYmUBbCsggBA2fIOJ3tPXl/NvdUxCa5y4Y5xrE
+88Nhni9DgenwHlcGQkT7mA5+CYSoCCYGYTwzXJcAAAQOSURBVI9himH31eTgJGGfYaKn2DPqRSNI
+Xp6wkdSBorErEvsrOsEniIYj+/Xr58iURJ1l04Aw2/Rl1nlOBiFoeAG1zom05vSBN/kq9v4wzt3z
+5s2LtO0iLS5u8eO6BgpgzQdcu/GtyhMhdgsI9x4dXxaXMXUwQG9Gwfso4+QGZLxamBEcSxAVf25A
+Po0uKUzTCfqeDW1GQ+NDGlDB1axDx0NfMeFJe5cQBkoklZhN5PIJueq1VwPKFbFTbgaaTmO/1FSV
+DmxmN6ejnw49hWlkY9ux5jQM7XdAzzs6dOhwj+zxhYGnZVCjYyBphT59+uTQSJfR6LKgLWhgy4j2
+bi55CDO93NiZSe6gmD179gBmm9HU+XR88xjQ72loeAPi2o8NzCvlkjdKBgpQGbGjIwx0I/48wmxv
+dAmk0/x7aphpBmuvOY3lIkcUKfuifu4PnfpTP/mPhSmUzOLT0JjewqDTaE8RN2oGCjAC66MOjKgX
+8/73GHUOf9Z0NhlR55OnWFzM79279xepcEbFj5zmp8ayQxjlBOrQj//dNdEjBfkZhwHmZrSl8t2m
+Ru2aBAMFWrCwsDB/8+bN59JhriSsZyA8hv9yLl80j8JQC+hESw4++OA1ydIy9ezZM/fHH3/syeyy
+LzjtQ73FGkPU9l3xsXayxnmGGed+GGdFrDNP1fyaFAMFGkFufbnzzjuH8T4OL+eP4ulERbsaz8d7
+ze9r/A/MiN+zpvoe8SbSfSw/rjCD2a5du5a8tELD2Yr/duQppkv7UMa+/O9LWDd8Qxb+JLd1q9Bc
+PohK+vEtW7ZstY3dyCI0SQYKbkPk/6MZoa+gww0h3JFxa3D6GDyL2Uo5nV5mr3LwkOddQc8STrBV
+QHgr/lvV/ItyJK77eOSvcrIWfA3gU1hLz5wxY4aIbU3SNXkGCrS6GEBicj+MDnoW/iTC3QFY5v83
+CsA0S/FP8za5MWrUomnnDAOFoZpcdIGFwhkw0kjA/fDxFoPCYJEyQd/ANC+CzQvx2ABPmVpGiUiG
+gWwIV6PB+1MNM8nZpsbOTD4Y5jPq+SprmxfYSFUaBNuQrkmAMwwUQTO3b9++JfZ98nW048STVA74
+xWJ/KQIs4hJ1FUzzFnV6U/a3xFg3LqU0wkwzDNSARhWLh9WrVx+O9ivAUMJckZ6DaQAGUSWtJNXn
+zC4LwftDjEIXotpfE1VOmUTxPVDX1Ogr6vGJEyf2Rqu3Dx20J8zk94zu8t8FeiRywBL1+UrKFhFs
+Mf9fy3+3bt2WLV68uIrnjIsBBRLZoDFAN32zoOPm8RnK7oz6PYWhqMkeMFUL8bzL/Xb+f8LrhPEu
+RyyqiCOdXnwlceWOtF943szzZphVnjfiV/O8CjFs1Yknnri+KauXoUVC3P8HkxreY0LG2KgAAAAA
+SUVORK5CYII=" transform="matrix(0.1408 0 0 0.1408 739.2327 186.0836)">
+		</image>
+		<g>
+			<circle cx="673.6" cy="200" r="2.5"/>
+			<circle cx="681.1" cy="200" r="2.5"/>
+			<circle cx="688.6" cy="200" r="2.5"/>
+		</g>
+		<g>
+			<text transform="matrix(1 0 0 1 588.6659 234.1507)" class="st110 st111 st112">Azure</text>
+			<text transform="matrix(1 0 0 1 589.2659 247.3507)" class="st110 st111 st112">Load  </text>
+			<text transform="matrix(1 0 0 1 582.2659 260.5507)" class="st110 st111 st112">Balancer</text>
+		</g>
+		<g>
+			<text transform="matrix(1 0 0 1 810.9133 231.0197)" class="st110 st111 st112">Config</text>
+			<text transform="matrix(1 0 0 1 812.4133 244.2197)" class="st110 st111 st112">server</text>
+		</g>
+		<g>
+			<text transform="matrix(1 0 0 1 881.6721 231.0197)" class="st110 st111 st112">Service</text>
+			<text transform="matrix(1 0 0 1 879.2721 244.2197)" class="st110 st111 st112">Registry</text>
+		</g>
+		<g>
+			<text transform="matrix(1 0 0 1 740.0609 231.0197)" class="st110 st111 st112">kpack</text>
+		</g>
+		<text transform="matrix(1 0 0 1 578.6876 171.589)" class="st110 st111 st114">Service Runtime subnet</text>
+		<g id="Text">
+			<rect x="184.9" y="479.5" class="st92" width="145.2" height="13.2"/>
+			<text transform="matrix(1 0 0 1 184.8867 489.8904)" class="st110 st111 st114">hub-virtual-network</text>
+			<rect x="565.2" y="479.5" class="st92" width="145.2" height="13.2"/>
+			<text transform="matrix(1 0 0 1 565.2439 489.8904)" class="st110 st111 st114">spoke-virtual-network</text>
+			<rect x="411.5" y="101.1" class="st92" width="44" height="30.8"/>
+			<text transform="matrix(1 0 0 1 424.254 111.4908)" class="st110 st111 st114">VNet </text>
+			<text transform="matrix(1 0 0 1 433.854 128.2908)" class="st110 st111 st114">link</text>
+			<rect x="517.1" y="101.1" class="st92" width="44" height="30.8"/>
+			<text transform="matrix(1 0 0 1 529.854 111.4908)" class="st110 st111 st114">VNet </text>
+			<text transform="matrix(1 0 0 1 539.454 128.2908)" class="st110 st111 st114">link</text>
+			<text transform="matrix(1 0 0 1 97.5004 114.3272)" class="st110 st111 st114">ExpressRoute</text>
+			<text transform="matrix(1 0 0 1 120.1004 131.1272)" class="st110 st111 st114">circuit</text>
+			<rect x="484.1" y="424" class="st92" width="61.6" height="53.5"/>
+			<text transform="matrix(1 0 0 1 494.7974 435.8995)" class="st110 st111 st114">Virtual </text>
+			<text transform="matrix(1 0 0 1 488.4974 452.6995)" class="st110 st111 st114">Network</text>
+			<text transform="matrix(1 0 0 1 491.1974 469.4995)" class="st110 st111 st114">peering</text>
+			<text transform="matrix(1 0 0 1 210.8258 176.8271)" class="st110 st111 st114">Azure Firewall</text>
+			<text transform="matrix(1 0 0 1 232.6258 193.6271)" class="st110 st111 st114">subnet</text>
+			<g>
+				<text transform="matrix(1 0 0 1 222.8352 260.427)" class="st110 st111 st112">Corp Firewall</text>
+			</g>
+			<text transform="matrix(1 0 0 1 352.5334 176.8271)" class="st110 st111 st114">App Gateway</text>
+			<text transform="matrix(1 0 0 1 370.6334 193.6271)" class="st110 st111 st114"> subnet</text>
+			<text transform="matrix(1 0 0 1 583.6872 327.6888)" class="st110 st111 st114">Apps subnet</text>
+			<g>
+				<text transform="matrix(1 0 0 1 354.3466 250.389)" class="st110 st111 st112">Corp application</text>
+				<text transform="matrix(1 0 0 1 373.1466 263.589)" class="st110 st111 st112">Gateway</text>
+			</g>
+			<text transform="matrix(1 0 0 1 654.1141 23.032)" class="st110 st111 st114">Monitoring</text>
+			<text transform="matrix(1 0 0 1 647.0141 39.832)" class="st110 st111 st114">infrastructure</text>
+			<text transform="matrix(1 0 0 1 814.2615 23.0318)" class="st110 st111 st114">Security</text>
+			<text transform="matrix(1 0 0 1 796.6615 39.8318)" class="st110 st111 st114">infrastructure</text>
+			<text transform="matrix(1 0 0 1 970.6857 28.3318)" class="st110 st111 st114">CI/CD Pipelines</text>
+			<g>
+				<text transform="matrix(1 0 0 1 221.9416 382.7889)" class="st110 st111 st112">ExpressRoute</text>
+				<text transform="matrix(1 0 0 1 233.2416 395.9889)" class="st110 st111 st112">Gateway</text>
+			</g>
+			<text transform="matrix(1 0 0 1 204.3353 313.2886)" class="st110 st111 st114">Gateway subnet</text>
+			<rect x="338.6" y="301.4" class="st92" width="108.8" height="38.9"/>
+			<text transform="matrix(1 0 0 1 358.351 313.2886)" class="st110 st111 st114">Centralized </text>
+			<text transform="matrix(1 0 0 1 346.051 330.0886)" class="st110 st111 st114">services subnet</text>
+			<g>
+				<text transform="matrix(1 0 0 1 362.3799 396.8885)" class="st110 st111 st112">DNS services</text>
+			</g>
+			<rect x="454.8" y="17.1" class="st92" width="123.2" height="35.2"/>
+			<text transform="matrix(1 0 0 1 459.0429 27.4947)" class="st110 st111 st114">Azure Spring Apps </text>
+			<text transform="matrix(1 0 0 1 462.6429 44.2947)" class="st110 st111 st114">private DNS zone</text>
+			<rect x="606.6" y="289" class="st92" width="153.2" height="19.8"/>
+			<text transform="matrix(1 0 0 1 628.5444 300.0872)" class="st110 st115 st116">Azure Spring Apps </text>
+			<text transform="matrix(1 0 0 1 63.8869 28.3316)" class="st110 st111 st114">Ingress</text>
+			<text transform="matrix(1 0 0 1 63.8869 47.3316)" class="st110 st111 st114">Egress</text>
+			<g>
+				<rect x="790.2" y="89.9" class="st92" width="32.1" height="32.2"/>
+				<text transform="matrix(1 0 0 1 797.6548 99.2828)" class="st110 st111 st112">Key </text>
+				<text transform="matrix(1 0 0 1 791.6548 112.4828)" class="st110 st111 st112">Vaults</text>
+			</g>
+			<g>
+				<rect x="843" y="89.9" class="st92" width="52.8" height="28.8"/>
+				<text transform="matrix(1 0 0 1 850.6082 99.2828)" class="st110 st111 st112">Security</text>
+				<text transform="matrix(1 0 0 1 853.7082 112.4828)" class="st110 st111 st112">Center</text>
+			</g>
+			<g>
+				<rect x="628.7" y="89.9" class="st92" width="60.2" height="32.2"/>
+				<text transform="matrix(1 0 0 1 631.7684 99.2823)" class="st110 st111 st112">Application </text>
+				<text transform="matrix(1 0 0 1 640.3683 112.4823)" class="st110 st111 st112">Insights</text>
+			</g>
+			<g>
+				<rect x="698.3" y="89.4" class="st92" width="52.8" height="28.8"/>
+				<text transform="matrix(1 0 0 1 710.9604 98.7828)" class="st110 st111 st112">Azure </text>
+				<text transform="matrix(1 0 0 1 705.3604 111.9828)" class="st110 st111 st112">Monitor</text>
+			</g>
+			<g>
+				<rect x="933.2" y="89.9" class="st92" width="49.6" height="27.1"/>
+				<text transform="matrix(1 0 0 1 944.3231 99.2827)" class="st110 st111 st112">Azure </text>
+				<text transform="matrix(1 0 0 1 939.2231 112.4827)" class="st110 st111 st112">DevOps</text>
+			</g>
+			<g>
+				<rect x="1053.2" y="89.9" class="st92" width="49.6" height="27.1"/>
+				<text transform="matrix(1 0 0 1 1061.1042 99.2827)" class="st110 st111 st112">GitHub </text>
+				<text transform="matrix(1 0 0 1 1060.4043 112.4827)" class="st110 st111 st112">Actions</text>
+			</g>
+			<g>
+				<text transform="matrix(1 0 0 1 1003.1092 103.1317)" class="st110 st111 st112">Jenkins</text>
+			</g>
+			<rect x="2.9" y="479.5" class="st92" width="163" height="12.8"/>
+			<text transform="matrix(1 0 0 1 2.8981 489.8904)" class="st110 st111 st114">On-premises network</text>
+			<text transform="matrix(1 0 0 1 26.4203 254.9852)" class="st110 st111 st114">Gateway</text>
+			<rect x="253.8" y="17.1" class="st92" width="132" height="53.5"/>
+			<text transform="matrix(1 0 0 1 262.4539 27.4947)" class="st110 st111 st114">Azure Spring Apps </text>
+			<text transform="matrix(1 0 0 1 278.6539 46.4947)" class="st110 st111 st114">Management </text>
+			<text transform="matrix(1 0 0 1 288.3539 65.4947)" class="st110 st111 st114">Addresses</text>
+			<g>
+				<text transform="matrix(1 0 0 1 588.666 391.7931)" class="st110 st111 st112">Azure</text>
+				<text transform="matrix(1 0 0 1 589.266 404.9931)" class="st110 st111 st112">Load  </text>
+				<text transform="matrix(1 0 0 1 582.266 418.1931)" class="st110 st111 st112">Balancer</text>
+			</g>
+			<g>
+				<rect x="982.1" y="151.2" class="st0" width="125" height="279.5"/>
+				<rect x="982.1" y="151.2" class="st26" width="125" height="279.5"/>
+			</g>
+			
+				<linearGradient id="SVGID_00000005949570720691572520000005046824957099781515_" gradientUnits="userSpaceOnUse" x1="1034.4265" y1="-570.5148" x2="1052.6083" y2="-570.5148" gradientTransform="matrix(1 0 0 1 0 791.7148)">
+				<stop  offset="0" style="stop-color:#005CA1"/>
+				<stop  offset="7.000000e-02" style="stop-color:#0161AA"/>
+				<stop  offset="0.36" style="stop-color:#2571B8"/>
+				<stop  offset="0.52" style="stop-color:#2E76BC"/>
+				<stop  offset="0.64" style="stop-color:#2973BA"/>
+				<stop  offset="0.82" style="stop-color:#166BB5"/>
+				<stop  offset="1" style="stop-color:#005CA1"/>
+			</linearGradient>
+			<path style="fill:url(#SVGID_00000005949570720691572520000005046824957099781515_);" d="M1043.6,214.1c-5,0-9.1-1.5-9.1-3.3
+				v17.5c0,1.8,4,3.3,9,3.3h0.2c5,0,9.1-1.5,9.1-3.3v-17.5C1052.6,212.7,1048.6,214.1,1043.6,214.1z"/>
+			<path class="st88" d="M1052.6,210.9c0,1.8-4.1,3.3-9.1,3.3s-9.1-1.5-9.1-3.3s4.2-3.3,9.1-3.3
+				C1048.6,207.6,1052.7,209,1052.6,210.9"/>
+			<path class="st40" d="M1050.5,210.6c0,1.1-3.1,2.1-7,2.1s-7-0.9-7-2.1c0-1.1,3.1-2.1,7-2.1
+				C1047.5,208.5,1050.5,209.4,1050.5,210.6"/>
+			<path class="st89" d="M1043.6,211.1c-1.9,0-3.7,0.2-5.5,0.8c1.8,0.6,3.6,0.9,5.5,0.8c1.9,0,3.7-0.2,5.5-0.8
+				C1047.3,211.3,1045.4,211,1043.6,211.1z"/>
+			<g>
+				<path class="st118" d="M1084.5,385.3c-0.1,0-0.2,0.2-0.2,0.3c0,0.7,0,2.5,0,3.7l0.1,0.1c0.3,0,0.9,0,1.4,0
+					c0.7,0,1.2-0.1,1.4-0.2c0.6-0.3,0.9-1,0.9-1.7c0-1.7-1.2-2.3-2.9-2.3C1085.1,385.2,1084.8,385.2,1084.5,385.3L1084.5,385.3
+					L1084.5,385.3z M1088.9,392.9c0-1.7-1.2-2.6-3.5-2.6c-0.1,0-0.8,0-1,0c-0.1,0-0.1,0.1-0.1,0.1c0,1.2,0,3.1,0,3.9
+					c0,0.3,0.3,0.8,0.6,0.9c0.3,0.2,1,0.2,1.5,0.2C1087.7,395.4,1088.9,394.7,1088.9,392.9L1088.9,392.9L1088.9,392.9z M1081,384.3
+					c0.2,0,0.7,0.1,2,0.1c1.2,0,2.2,0,3.5,0c1.5,0,3.5,0.5,3.5,2.8c0,1.1-0.8,2-1.8,2.4c-0.1,0-0.1,0.1,0,0.1
+					c1.4,0.4,2.7,1.2,2.7,2.9c0,1.6-1,2.7-2.5,3.3c-0.9,0.4-2,0.5-3.2,0.5c-0.9,0-3.2-0.1-4.5-0.1c-0.1-0.1,0.1-0.7,0.2-0.8
+					c0.3,0,0.5,0,0.9-0.1c0.5-0.1,0.5-0.3,0.6-1c0-0.6,0-2.7,0-4.2c0-2.1,0-3.5,0-4.2c0-0.5-0.2-0.7-0.6-0.8
+					c-0.3-0.1-0.8-0.1-1.2-0.2C1080.6,385,1080.9,384.4,1081,384.3L1081,384.3L1081,384.3z M1071.1,395c0.4,0.3,1.2,0.5,1.9,0.5
+					c0.9,0,1.8-0.2,2.7-1c0.9-0.8,1.5-2.1,1.5-4.1c0-1.9-0.7-3.5-2.2-4.4c-0.9-0.5-1.9-0.8-3.2-0.8c-0.4,0-0.7,0-1,0.1
+					c-0.1,0-0.2,0.2-0.2,0.3c0,0.3,0,3,0,4.5c0,1.6,0,3.8,0,4.1C1070.8,394.4,1070.9,394.8,1071.1,395L1071.1,395L1071.1,395z
+					 M1067.3,384.3c0.3,0,1.6,0.1,2.2,0.1c1.1,0,1.8-0.1,3.9-0.1c1.7,0,3.1,0.5,4.2,1.3c1.2,1.1,1.9,2.6,1.9,4.4
+					c0,2.6-1.2,4.1-2.4,4.9c-1.2,0.9-2.7,1.4-4.9,1.4c-1.2,0-3.2,0-4.8-0.1l0,0c-0.1-0.2,0.1-0.8,0.3-0.8c0.4-0.1,0.6-0.1,0.8-0.2
+					c0.4-0.1,0.4-0.3,0.5-1c0.1-1.2,0-2.6,0-4.2c0-1.1,0-3.4,0-4.1c-0.1-0.6-0.3-0.8-0.8-0.9c-0.3-0.1-0.6-0.1-1.1-0.2
+					C1066.9,385,1067.2,384.4,1067.3,384.3L1067.3,384.3L1067.3,384.3z"/>
+				<path class="st119" d="M1046.6,395.6c-0.4-0.1-0.7-0.1-1.1-0.3c-0.1,0-0.1-0.2-0.1-0.3c0-0.6,0-2.3,0-3.5c0-0.9-0.2-1.7-0.5-2.3
+					c-0.5-0.6-1.1-1-2-1c-0.8,0-1.8,0.5-2.6,1.2c0,0-0.2,0.1-0.1-0.1c0-0.2,0-0.6,0.1-0.8c0-0.2-0.1-0.4-0.1-0.4
+					c-0.5,0.3-2.1,0.6-2.7,0.7c-0.4,0.1-0.5,0.5-0.1,0.6l0,0c0.5,0.1,0.8,0.3,1,0.4s0.2,0.3,0.2,0.5c0,1.3,0,3.2,0,4.3
+					c0,0.4-0.1,0.6-0.4,0.6l0,0c-0.2,0.1-0.4,0.1-0.7,0.1c-0.1,0.1-0.1,0.6,0,0.8c0.2,0,1.2-0.1,2-0.1c1.1,0,1.7,0.1,2,0.1
+					c0.1-0.1,0.2-0.6,0.1-0.8c-0.3,0-0.6-0.1-0.8-0.1c-0.3-0.1-0.4-0.2-0.4-0.6c0-0.9,0-2.8,0-4.1c0-0.4,0.1-0.5,0.2-0.6
+					c0.4-0.3,1-0.6,1.6-0.6c0.5,0,0.9,0.2,1.2,0.4c0.4,0.3,0.5,0.8,0.5,1.1c0.1,0.7,0.1,2.2,0.1,3.5c0,0.7-0.1,0.9-0.3,0.9
+					c-0.1,0.1-0.4,0.1-0.8,0.2c-0.1,0.1-0.1,0.6,0,0.8c0.5,0,1.1-0.1,1.9-0.1c1.1,0,1.7,0.1,2,0.1
+					C1046.6,396.3,1046.6,395.8,1046.6,395.6L1046.6,395.6L1046.6,395.6z M1051.3,389.1c-0.9,0-1.5,0.7-1.5,1.8
+					c0,1.1,0.5,2.4,1.9,2.4c0.2,0,0.7-0.1,0.9-0.3c0.3-0.3,0.5-0.9,0.5-1.6C1053.2,390,1052.5,389.1,1051.3,389.1L1051.3,389.1
+					L1051.3,389.1z M1051.2,396.7c-0.3,0-0.6,0.1-0.7,0.2c-0.7,0.5-1,0.9-1,1.4s0.2,0.9,0.6,1.2c0.5,0.4,1.2,0.6,2.1,0.6
+					c1.7,0,2.5-0.9,2.5-1.9c0-0.6-0.3-1.1-1-1.3C1053.1,396.8,1052.2,396.7,1051.2,396.7L1051.2,396.7L1051.2,396.7z M1051.3,401.1
+					c-1,0-1.8-0.2-2.4-0.7s-0.9-1.2-0.9-1.7c0-0.1,0-0.5,0.3-0.9c0.2-0.2,0.6-0.6,1.6-1.3c0,0,0.1,0,0.1-0.1s0-0.1-0.1-0.1
+					c-0.8-0.3-1-0.8-1.1-1.1l0,0c0-0.1-0.1-0.2,0.1-0.3c0.1-0.1,0.3-0.2,0.5-0.3c0.3-0.2,0.6-0.4,0.8-0.5V394c0,0,0-0.1-0.1-0.1
+					c-1.2-0.4-1.8-1.3-1.8-2.6c0-0.9,0.4-1.7,1.1-2.2c0.5-0.4,1.7-0.8,2.5-0.8h0.1c0.8,0,1.2,0.2,1.9,0.4c0.3,0.1,0.7,0.2,1.1,0.2
+					c0.7,0,1-0.2,1.2-0.4c0,0,0.1,0.1,0.1,0.3c0,0.2-0.1,0.5-0.2,0.8c-0.1,0.2-0.4,0.3-0.8,0.3h-0.1c-0.3,0-0.4-0.1-0.4-0.1h-0.1
+					v0.1l0,0c0,0.2,0.1,0.6,0.1,0.7c0,1.4-0.6,2-1.2,2.5c-0.6,0.4-1.2,0.7-2,0.8c0,0-0.1,0-0.2,0s-0.2,0-0.2,0l0,0
+					c-0.1,0-0.5,0.2-0.5,0.5s0.2,0.6,0.9,0.6c0.2,0,0.3,0,0.5,0c1,0.1,2.2,0.2,2.8,0.3c0.8,0.3,1.3,1,1.3,1.8c0,1.3-0.9,2.4-2.4,3.2
+					C1052.9,400.9,1052.1,401.1,1051.3,401.1L1051.3,401.1L1051.3,401.1z M1061.1,389.2c-0.4,0-0.7,0.1-0.9,0.3
+					c-0.7,0.4-1,1.2-1,2.4c0,2.2,1.1,3.8,2.7,3.8c0.5,0,0.9-0.1,1.2-0.4c0.5-0.4,0.8-1.2,0.8-2.4
+					C1063.8,390.7,1062.7,389.2,1061.1,389.2L1061.1,389.2L1061.1,389.2z M1061.4,396.5c-2.9,0-4-2.1-4-4.1c0-1.4,0.6-2.5,1.7-3.2
+					c0.8-0.5,1.8-0.8,2.6-0.8c2.2,0,3.8,1.6,3.8,3.9c0,1.6-0.6,2.8-1.8,3.5C1063.1,396.2,1062.2,396.5,1061.4,396.5L1061.4,396.5
+					L1061.4,396.5z M1030.9,389.2c-0.4,0-0.7,0.1-0.9,0.3c-0.7,0.4-1,1.2-1,2.4c0,2.2,1.1,3.8,2.7,3.8c0.5,0,0.9-0.1,1.2-0.4
+					c0.5-0.4,0.8-1.2,0.8-2.4C1033.6,390.7,1032.5,389.2,1030.9,389.2L1030.9,389.2L1030.9,389.2z M1031.2,396.5c-2.9,0-4-2.1-4-4.1
+					c0-1.4,0.6-2.5,1.7-3.2c0.8-0.5,1.8-0.8,2.6-0.8c2.2,0,3.8,1.6,3.8,3.9c0,1.6-0.6,2.8-1.8,3.5
+					C1033,396.2,1032,396.5,1031.2,396.5L1031.2,396.5L1031.2,396.5z M1011.7,396.3c0-0.1-0.1-0.2-0.1-0.4c0-0.1,0-0.2,0.1-0.3
+					c0.4-0.1,0.5-0.1,0.8-0.2s0.5-0.3,0.5-0.7c0.1-1,0.1-3,0-4.3l0,0c0-0.2,0-0.3-0.2-0.5c-0.3-0.2-0.6-0.3-1-0.4
+					c-0.2-0.1-0.3-0.1-0.2-0.2c0-0.1,0.1-0.2,0.3-0.3c0.6-0.1,2-0.4,2.6-0.7c0,0,0.1,0.1,0.1,0.3v0.2c0,0.2,0,0.4,0,0.6
+					c0,0.1,0.1,0.1,0.1,0.1h0.1c1.1-0.9,2.1-1.2,2.6-1.2c0.8,0,1.5,0.4,2,1.2c0,0.1,0.1,0.1,0.1,0.1s0.1,0,0.1-0.1
+					c1-0.8,2-1.2,2.7-1.2c1.6,0,2.5,1.2,2.5,3.2c0,0.6,0,1.3,0,2c0,0.6,0,1.1,0,1.5c0,0.1,0.1,0.4,0.3,0.4c0.2,0.1,0.6,0.2,1,0.2
+					l0,0c0,0.1,0,0.6-0.1,0.6s-0.3,0-0.4,0c-0.3,0-0.8,0-1.3,0c-1.1,0-1.6,0-2.1,0.1c0-0.1-0.1-0.5,0-0.6c0.3-0.1,0.5-0.1,0.6-0.2
+					c0.3-0.1,0.4-0.3,0.4-0.7c0-0.3,0.1-3.1,0-3.8c-0.1-0.7-0.6-1.5-1.7-1.5c-0.4,0-1.1,0.2-1.7,0.7c0,0-0.1,0.1-0.1,0.2l0,0
+					c0.1,0.4,0.1,0.8,0.1,1.4v1.1c0,0.8,0,1.5,0,2c0,0.4,0.2,0.5,0.4,0.5c0.1,0,0.2,0,0.3,0.1c0.2,0,0.3,0.1,0.5,0.1
+					c0,0.1,0,0.3,0,0.5c0,0.1-0.1,0.2-0.1,0.2c-0.6,0-1.2,0-2.1,0c-0.3,0-0.7,0-1.1,0c-0.3,0-0.6,0-0.8,0c0,0-0.1-0.2-0.1-0.3
+					c0-0.2,0-0.3,0.1-0.3s0.2,0,0.2,0c0.2,0,0.4-0.1,0.5-0.1c0.3-0.1,0.4-0.2,0.4-0.6c0.1-0.9,0.1-3.3,0-3.9c-0.2-1-0.8-1.5-1.7-1.5
+					c-0.5,0-1.2,0.3-1.7,0.7c-0.1,0.1-0.2,0.2-0.2,0.4v1c0,1.2,0,2.8,0,3.4c0,0.2,0.1,0.4,0.5,0.5c0.1,0,0.2,0.1,0.4,0.1l0.3,0.1
+					c0,0.1,0,0.5-0.1,0.6c-0.2,0-0.4,0-0.6,0c-0.4,0-0.8,0-1.3,0c-0.6,0-1,0-1.4,0C1012.1,396.3,1011.9,396.3,1011.7,396.3
+					L1011.7,396.3L1011.7,396.3z"/>
+				<g>
+					<path class="st120" d="M1002.7,400.5l-0.7-0.2c0,0,0.1-3.6-1.2-3.8c-0.9-1,0.1-42.1,3.2-0.1c0,0-1.1,0.5-1.2,1.4
+						C1002.5,398.6,1002.7,400.5,1002.7,400.5L1002.7,400.5L1002.7,400.5z"/>
+					<path class="st121" d="M1002.7,400.5l-0.7-0.2c0,0,0.1-3.6-1.2-3.8c-0.9-1,0.1-42.1,3.2-0.1c0,0-1.1,0.5-1.2,1.4
+						C1002.5,398.6,1002.7,400.5,1002.7,400.5L1002.7,400.5L1002.7,400.5z"/>
+					<path class="st120" d="M1003,397c0,0,6.1-4,4.7-12.4c-1.4-6.1-4.7-8.1-5-8.9c-0.4-0.5-0.8-1.5-0.8-1.5l0.3,17
+						C1002.2,391.2,1001.7,396.4,1003,397"/>
+					<path class="st122" d="M1003,397c0,0,6.1-4,4.7-12.4c-1.4-6.1-4.7-8.1-5-8.9c-0.4-0.5-0.8-1.5-0.8-1.5l0.3,17
+						C1002.2,391.2,1001.7,396.4,1003,397"/>
+					<path class="st120" d="M1001.6,397.2c0,0-5.8-3.9-5.4-10.9c0.3-6.9,4.4-10.3,5.2-10.9c0.5-0.5,0.5-0.8,0.6-1.3
+						c0.4,0.8,0.3,11.5,0.3,12.8C1002.4,391.8,1002,396.3,1001.6,397.2L1001.6,397.2L1001.6,397.2z"/>
+					<path class="st123" d="M1001.6,397.2c0,0-5.8-3.9-5.4-10.9c0.3-6.9,4.4-10.3,5.2-10.9c0.5-0.5,0.5-0.8,0.6-1.3
+						c0.4,0.8,0.3,11.5,0.3,12.8C1002.4,391.8,1002,396.3,1001.6,397.2L1001.6,397.2L1001.6,397.2z"/>
+				</g>
+			</g>
+			<g>
+				<rect x="990.7" y="159.7" class="st92" width="109.4" height="35.4"/>
+				<text transform="matrix(1 0 0 1 990.7248 171.5887)" class="st110 st111 st114">Data Services </text>
+				<text transform="matrix(1 0 0 1 990.7248 188.3887)" class="st110 st111 st114">subnet</text>
+			</g>
+			<g>
+				<rect x="1015.5" y="237.5" class="st92" width="56" height="34.9"/>
+				<text transform="matrix(1 0 0 1 1032.3987 246.814)" class="st110 st111 st112">Data </text>
+				<text transform="matrix(1 0 0 1 1025.0986 260.014)" class="st110 st111 st112">services</text>
+			</g>
+			<rect x="1008.3" y="324.1" class="st92" width="70.5" height="34.9"/>
+			<text transform="matrix(1 0 0 1 1009.4583 333.4669)" class="st110 st111 st112">Azure Cosmos </text>
+			<text transform="matrix(1 0 0 1 1036.5583 346.6669)" class="st110 st111 st112">DB</text>
+			<g>
+				<g>
+					<rect x="957.9" y="370.7" class="st11" width="16.7" height="1"/>
+					<g>
+						<polygon class="st11" points="973.5,367.4 979.9,371.2 973.5,374.9 						"/>
+					</g>
+				</g>
+			</g>
+			<path class="st40" d="M1032.9,297.6c-0.2,0-0.3-0.1-0.3-0.3l0,0c0-2-1.6-3.5-3.5-3.5c-0.2,0-0.3-0.1-0.3-0.3l0,0
+				c0-0.2,0.1-0.3,0.3-0.3l0,0c2,0,3.5-1.6,3.5-3.5c0-0.2,0.1-0.3,0.3-0.4l0,0l0,0c0.2,0,0.3,0.1,0.3,0.3l0,0l0,0
+				c0,2,1.6,3.5,3.5,3.5l0,0c0.2,0,0.3,0.1,0.3,0.3l0,0c0,0.2-0.1,0.3-0.3,0.3l0,0c-2,0-3.5,1.6-3.5,3.5
+				C1033.3,297.4,1033.1,297.5,1032.9,297.6L1032.9,297.6z"/>
+			<path class="st40" d="M1055.3,319.2c-0.1,0-0.2-0.1-0.2-0.2l0,0c0-1.6-1.3-2.9-2.9-2.9c-0.1,0-0.2-0.1-0.2-0.2l0,0l0,0
+				c0-0.1,0.1-0.2,0.2-0.2l0,0l0,0c1.6,0,2.9-1.3,2.9-2.9c0-0.1,0.1-0.2,0.2-0.2l0,0l0,0c0.1,0,0.2,0.1,0.2,0.2l0,0l0,0
+				c0,1.6,1.3,2.9,2.9,2.9l0,0c0.1,0,0.2,0.1,0.2,0.2s-0.1,0.2-0.2,0.2l0,0c-1.6,0-2.9,1.3-2.9,2.9l0,0
+				C1055.5,319.1,1055.4,319.2,1055.3,319.2L1055.3,319.2z"/>
+			
+				<radialGradient id="SVGID_00000096751805888137251260000007020487897600822916_" cx="894.5027" cy="-508.3271" r="10.5496" gradientTransform="matrix(1.04 0 0 1.03 112.4334 827.6106)" gradientUnits="userSpaceOnUse">
+				<stop  offset="0.18" style="stop-color:#699CD3"/>
+				<stop  offset="1" style="stop-color:#2E76BC"/>
+			</radialGradient>
+			<path style="fill:url(#SVGID_00000096751805888137251260000007020487897600822916_);" d="M1054.2,301.6c1.4,5.8-2.2,11.7-8,13.1
+				s-11.7-2.2-13.1-8s2.2-11.7,8-13.1C1046.9,292.1,1052.7,295.7,1054.2,301.6C1054.2,301.5,1054.2,301.6,1054.2,301.6z"/>
+			<g>
+				<g>
+					<defs>
+						<path id="SVGID_00000120546029515945036490000006875141155128099488_" d="M1054.2,301.6c1.4,5.8-2.2,11.7-8,13.1
+							s-11.7-2.2-13.1-8s2.2-11.7,8-13.1C1046.9,292.1,1052.7,295.7,1054.2,301.6C1054.2,301.5,1054.2,301.6,1054.2,301.6z"/>
+					</defs>
+					<clipPath id="SVGID_00000159459603225358681500000017969435211184390562_">
+						<use xlink:href="#SVGID_00000120546029515945036490000006875141155128099488_"  style="overflow:visible;"/>
+					</clipPath>
+					<g style="clip-path:url(#SVGID_00000159459603225358681500000017969435211184390562_);">
+						<path class="st126" d="M1037.7,311.5c1.6,0,2.9-1.3,2.9-2.9s-1.3-2.9-2.9-2.9l0,0c0-0.1,0-0.2,0-0.2c0-1.6-1.3-2.9-2.9-2.9
+							h-2.2c-0.1,1.4,0,2.7,0.3,4c0.4,1.8,1.3,3.5,2.6,4.9H1037.7z"/>
+						<path class="st126" d="M1054.2,302.1L1054.2,302.1c-0.4-1.9-1.2-3.7-2.5-5.1c-0.2-0.1-0.3-0.1-0.5-0.2c-1.7-0.5-3.5,0.5-4,2.2
+							c-0.1,0.2-0.1,0.5-0.1,0.7h-0.4c-1.7,0-3,1.4-3,3.1c0,1.3,0.8,2.5,2,2.9c0.3,0.1,0.6,0.2,1,0.2h3.5
+							C1051.7,304.7,1053,303.5,1054.2,302.1z"/>
+					</g>
+				</g>
+			</g>
+			<path class="st40" d="M1058.1,295c-1.1-1.9-3.7-2.6-7.4-2c-1.2,0.2-2.4,0.5-3.6,0.8c1,0.3,1.9,0.8,2.7,1.4l1.3-0.3
+				c0.6-0.1,1.3-0.2,2-0.2c1.8,0,3,0.4,3.5,1.3l0,0c0.7,1.1,0.1,3.1-1.6,5.3c-2.3,2.9-5.2,5.3-8.4,7.2c-3.2,2-6.8,3.3-10.5,4
+				c-2.8,0.4-4.8,0-5.4-1.1c-0.7-1.1-0.1-3.1,1.6-5.3c0.2-0.3,0.3-0.4,0.5-0.7c-0.1-1-0.1-2,0.1-3c-0.8,0.8-1.5,1.6-2.1,2.5
+				c-2.2,2.9-2.8,5.6-1.7,7.4c1.2,1.6,3.2,2.4,5.1,2.2c0.8,0,1.5-0.1,2.3-0.2c3.9-0.7,7.7-2.2,11-4.3c3.4-2,6.4-4.6,8.9-7.7
+				C1058.6,299.5,1059.2,296.9,1058.1,295z"/>
+		</g>
+		<g>
+			<rect x="478.5" y="406" class="st11" width="18.1" height="1"/>
+			<g>
+				<polygon class="st11" points="479.6,402.8 473.1,406.5 479.6,410.2 				"/>
+			</g>
+		</g>
+		<g>
+			<rect x="1017.5" y="120.7" class="st11" width="1" height="13.8"/>
+			<g>
+				<polygon class="st11" points="1014.3,133.4 1018,139.9 1021.8,133.4 				"/>
+			</g>
+		</g>
+		<g>
+			<rect x="839.3" y="120.7" class="st11" width="1" height="13.4"/>
+			<g>
+				<polygon class="st11" points="836.1,133.1 839.8,139.5 843.6,133.1 				"/>
+			</g>
+		</g>
+		<g>
+			<rect x="689.7" y="126.1" class="st11" width="1" height="13.8"/>
+			<g>
+				<polygon class="st11" points="686.5,127.2 690.2,120.7 694,127.2 				"/>
+			</g>
+		</g>
+		<g>
+			<rect x="106.7" y="151.7" class="st11" width="17.6" height="1"/>
+			<g>
+				<polygon class="st11" points="107.8,148.5 101.3,152.2 107.8,156 				"/>
+			</g>
+		</g>
+		<g>
+			<rect x="149.3" y="151.7" class="st11" width="17" height="1"/>
+			<g>
+				<polygon class="st11" points="165.2,148.5 171.7,152.2 165.2,156 				"/>
+			</g>
+		</g>
+	</g>
+</switch>
+<i:aipgf  id="adobe_illustrator_pgf" i:pgfEncoding="zstd/base64" i:pgfVersion="24">
+	<![CDATA[
+	KLUv/QBYXBACCi02VjHAbGqbDiN3gQfxowL0o2fR3rNF5sC9M9/SSxuRxraLSpLdZDe/sAP0oFEU
+RZdLFB0IzQbEBMIECKGEGqRQoizkIEuXMGXStKmTp08opdQklVZykjXXYJONNttw040336AmNU2j
+mtU4jalTqFKpWsVqrbPOGh8fIyMnKysvMzM3Ozs/PyNOnLhhxYmieLHDDltbX2NjZ2trb29zd3d7
+f3+jTp266aZVr17ttLn5paerr6+zN5be3Nza2HhNExPlTjMT89LSwYUNJkT46NjIuKiIeOjcOnXp
+0v0lil8fn17end2yZMjc2NbU0tAShSFRCpAoDlpoIdWghBJCCCFHjRox2kWaCFGiIDpkyJDz69Wr
+bz79v39/P//+vn4+/r2948uXN548OXJ393Z29nX1dHT080RhcEgLLrYkCoOHxeGBUDQaDyxYGkQa
+z8JB8TBAIy26ibLAAgvxRCAXIjyMhkXkoYAAAVkwHBQgLkR4JFgoAOLQeBgNESIPFHmgChEFhMaD
+CAuDx4KiQoTFoRHhsADheCKLiAjL43FoLCCoEFFAYDgcEhgOh4SlAiTikZaGRQULisfDgsFQNA2I
+PA0FA0KksVAo4KFoKBgQCgsFVGiIKCaI8HBEFg5raTyeSESxSLCINDwWII8HggUH45GgsSAeDgge
+tWBhsDwPBcNhYGGhYBYsDB4aiwbFQ8KyYGEQaXgkQOHB4vBUYPFwRBqeBSxIFAcEDQcWIhwPAzQW
+DxEMCBPcQgORxuIBoeFoYMJj4YKEJ+IhYXFoLOUBEhZLJCCQKBOWBg+NhYOjobHygYiASJiAgN0l
+IVEuRC5EJBIlIhGRiHAkHoeFBAsHhyORKA5HI1Eh8iwSi8Ri8SQS5Uk8T0PiUSgUCoUioUhAGBQc
+GgqIx/OQaDwcFSQkHPDAAw88kKgAUTAgDxIXGBYWEUYExIPEgwcPHiQSpYFEhchy4CDhwMFaiURZ
+iZVoEgslHhqLB0IIoUSioAT+LRAIGIoKT8OReDyRhyJiAk/DkXBnRDRAFBAOD0fDkUgUBYOxcHga
+Gk+DQyL9lgiIxBOJaFA8z6NCJPFwLB6PhQiIY4JIAhLRWEBAIhgWEony0Fg8Eg3Ho0EBkXB4Hs8j
+0XgqWLhQIRFxNBiKhsWDg5HAvuVpLBoLiAcCh8cFC46GRML5EuWhoNB4InA8KCSYb7nQ0Hgej4iG
+hPItT4PCAiSxQBaQ5/EsHByQ+L1lAYE8jIjDIfE4IIlEieChgHgcFI9I4nFgLCIQT6ICROHQeBKR
+h8GIoBCp8LB4JEoEgoexest6kIhA8DAYi4iHRMPxUDRESDg0FJAIR4XI47GQoMDDgAAiouGxaEgw
+KDg8nocHhUMiUSALiIUFg/FQcGgsHg4GBIkHoqBgeYvjEbESjrc8EigeDwn+5WE8NBaQJ+KImEDi
+M1EgkCgWIiJPhAcHw/GA0Fg8PJBI44GAcDQOjaVAQaJEYIAxY6CZgI0nElEwHNTzPe5/fMO/M2N8
+wXZYPAwwofUWWHixQWPxsHg8eB4UEBT0BM9iAevwTHBorAn+iSgajyfCQBP6Em9Zv+XtF0u/ZVH9
+Fw//GfvzJX098x6fGfzzxZbE3z7mFm0GlRd+vTTX3jMGDxdYGjyLBTgkNB4LDybY6aLYIPIwQYIJ
+ECwmRBpPpOFoJjQWD0+a0Ad5PBcUCoCIaMAjEQwH5HEg8jw8FBImrILhMB4HBwN/S4OHoWiI8Dw8
+FAqYoOgARRaNBx4PI8IBM9UIkQeasE/D0cDSYIJnIcGTv77b/78M6y7f+szrL/2s58aM6wLLtarh
+9r82o32MxTKuuCxzvE9EwbAA8Ujw18X9+m7/vwEkgocCwoLjwSACDcdi8fA4AIEFtgTgwvMwwBLB
+Q6EWP8MFC/+vsvba826amfmdM6+b22e65h4nMrY0SAZwYGkAeWgsIpEnwvOggHAwoZcGz4MC8sCE
+dIAUJEr/LQ0eDwWIiAYcGIuINAHPAbolooB4OJyHsXAmrAPk8Dg8TwMODEdaIAAKFCSKgwcex8MT
+YWkAiTQcTgQNCkZaJnAwGI8DFkWk8TwoGFgaigvN0gDycDAcDQTyNDgeECKNByKiwaEUKEiU7dRE
++1dmjO3TlhnFu2WR9zY3GVy2ndX81RiDPA4sDmC7LN4tuNwCSwMKONJDY+HQiHAkBQoSJT35lgZP
+BRYQiEKChoIBCEtug1wQDRN9iV0aPBGFajgWDBYKxuGhcGgoIpAJT0QhweJhYYHnERFpeCKLCg0P
+xYKlwcOILCQoUJAoDBYsDCCAQAFhaTwRyOKRgAVLg4fDUaAgUY5BhnFp0HAsII9nARPcAVKgIFGM
+UVwYOLDg4YgoHhFIBIPhYFkaPBwRxfNoFChIlMWYXOCh4HBAC0SAAAAFAcqX/mudyNvG2OL6ima/
+yshtvuynnnie+c6YHuP637/eNW7rcjO3NTP2zljj36Wh8jMuq5+uXqq2Oj47Y8tmp7KbtaMmqnq/
+eTOf+mEnKpu6OTO2x8rK7IfcZo/JaPi/3oht3+aOjC3Yvdqd7tf6t+n3v+28eG2e/8uPu3/ovv6d
+uYjMaLm5hqan+W4LLqeMbZ++L5pr5+k1/rLaXy9uOk7nM+a925h4z3bZnH9//LxojCXKPuKZb6s5
+pzFmzqGz1jLnHHQShcHYeJkyx1W6PLxzbNlyHHULF9U11/SlQ+fX28uXr1+/0EIrrWY1Sy211vq0
+EG9RMRGVo5xbt3DlyqVL165dvHj18lS1rFq5cvXqk2pUo5RSaqnVyitV6qkmU2eiMKCl6tm5m0XG
+uriXKAwopZTS6bf7fu61tZ87rbrZzmdPFIZ39kb+3s6guzMN8cyMMd1T5jc9ztvk7cxPbHftV01s
+N8dfa/v9fD+1Q+ZlZrxt1W7dxF9mbNnbt3+8Xf7d1L5UxpbTfTZ+e+e3u73twz5sxpbT9X7cNT5/
+VXvkxc07Pn1rZm1GXHZ95u1c7GbX3v1EjRYtatSuXevsN++LKDXrNs1BCqlHCDlitOvVLQelS5fS
+/N6RoXbekIM+NbtaddKky4nCgPr5G627ubWzsR1erDgx4kRhaE+N/XLHlyN+ZlY+7WMMue+w8RPN
+Xxlb+Jn3MRXv/K73nLElu63z3i3zzrPb1l+9SU1STnOYTaJoo9uOmnUKUyknUZI39vaX3+ig5SXK
+KTaqdKmjtre4ydurUKP2RYcdXtxwojScfDlX2mbR+j6v7q5umjLlNKtRTdOkBjXfeNNNN9xso002
+iYI6tUK3MNi9Ozv7TET+5d7L6+095GVs4dz093TkxEfGFk32Q0RHXcaW4z9+8/t9NVt+R87kxbU+
+fGzXX+5H7Mdea2tvY8aW7Ey15D87Tfv2Pz9GvDxTW/5r1G58Y2/GmrEFlclH5+RjPtZkbFE8fmzW
+5tuzNWVPRdPtNXd6NZ0a9bd3w+rdvdW1lXVRT02dXKmyyZQoPz05N9FwbTtZY80yx+yOr7dZ9cJ2
+90/euPLljjv+iDBhgwoXWl5qbnJ2en6iTNmkypVOmp6iqqaqqusr0qSJEkqfPHXidMnSQgo17Oxa
+tc2mRfvr28u7m4t7a+voUqWNJkX6yreKF7JkypbZ4eXp7fX5oWtOnXOGh4iKi4yNj+mVn6ZEYdik
+KRMmSw5aDNhcY42TVlKpSSk5NzMvJyMfGycKg+8v2rRL2drc3pDl6++zqmYi3im+LjK2sDG2eNv+
+/tmfbV6qH2NLN2MLqt72dW/y/nKfPh5jS3YyY8uvKWPLPmonqndaPvOm+WuuujG24Hp/4+unOzKq
+ZPVsdZYolyjmypU3qBOFgROF4ZQ1a3rp0aP35/x7SxSGXLSUYfPIE4+B3WK3ODSWSokCScjYcnv4
+6Ywtl+pt/Gevi8t89rbionGvLWOJAkkTFCRKhDRBwWJ2i+3Cyy242DG2tHLf6eMmui9jC36av602
+snMytqS/qZ31P7caY8st+OrshmnNaJ/Kx/fox86MPdIEBYvqcvtjoqDUqOWgHSZ/v/8/+vTNq1/v
+vKFDiJJRI0cf6q+ctM0mSmpQ0yjlnCfKodZPjWVm/qNy+j/Ti4/sfr6JZ2qobP2+iaq+bmjI7++r
+uKrc22iaht6g51uLzi7VoPdOlNXDRDlPeA1Sz2kRo7VJE6PUOIeoSZTGadYyfzI+g1437Aya7t15
+996t98jb3LjNh51pmMq4h7qJAkmMt78aY3a6mbUy2JaZrszeiZIKVaI4nSimiaKSolfXRGnWTXRy
+qZSokxUTxTYhJiq2k8faiaJsfHqbFHuibFB/U3I63cFH/847f+hQokX7KFHUpfWmweY0UVTTLKcx
+hay2kUqJ4ixLJx111lmHHXbaceeROdlYsVHNrJvhtWVZLFEgYHect3r2jCXK874vKvOrNaur8l6j
+/n0zv74262G/NmPutMPOOuqkg4nirIWcREmUTBQnURoZzzkTZTX6JqtcqausrsjR21xNFOTscb7D
+19nb3d9N+ja+3D5/m19vCJEiRo+Sgy7lp2QNNtpw06aum0P8RFG41tFEUelsb6/eb14lSuqyI2Qp
+LU8UTVa6EqVJFM6knHSQ2x+lJlEa/kOXrkmkMFE8UTZRUP36damJwoj7VbanXGxhsKvfiKiZfdun
+zWeYlta7egzi8yKi6TvvfjKjsiu/ZzKvzuxvqvh3e6fZr7b915jG/7/HfDf3q2rmdyrn2fvrp3Zj
+9t6vdzO24BpzH7P7J3+zVDuI1TfNojr6ctRSSynVIPXKVStWrCoVJgoDmjbZJJQ+FTnrpHOOOc5a
+zUrrl69evDYXrlu2FBUz1T7zjBeTW5PPWNVZNRlbzMf+xUfcu/1uxdTPzEbL9WPGt5N/L7kxvVXz
+Hc3Q7T9ft/fWjFFuPXNmfDy8XvvmXu7UTjdOc+oaWylRGIz1GalUDXpvDrfZxtjS4ZlSZWa41Dnd
+RGFQicKgSFHSRGHY50NHxhAPl7tZW/mzW5ON1c/2DDf9970vP1vVD5Pbzs+7/TQ7v7fVd29/j3Ov
+31dZP38bn5Wx9lNva23VT37Xs93G1u3u/ly0c2Ww+Xsz11NX9U7P1h5Nf9GU0a3T+PTUrl/RmL3/
+Pm0xUxM3jRsZ2+7te3XdU4+5l5szPdtV8yz7uNXJRlWmaqp1Fj3/KtUoVqyq2cmpmY2vvdUqPTq+
+3NtSf996lfxb/7sZV1/DiVMzuDXW1srJaHt4aIiYevyM8eZZP3Pzodpvoubl6e69WT9fN/eftXaq
+v6VtriXqcrJh8mofnzJse4n+qe3dz9jCju+pi8zud7+6+HaKZpptf0yjPsN2vLtmjC2+fdy4eHq2
+zfZofYaGzp3zTqIwvIMcpGpVg/6ubxUvNclJSDnKWY5yGic5Cb3zDrK8Y7DGWU6iMCDHaZzGcRA6
+8qGd/j87M9Z6+9tvn+iprv+7h7mqb/5oqN+nvKuNqfb6l3vs34wtibdobsp5doy6bQ==
+	]]>
+	<![CDATA[
+	67qMpbc562/eY18eYi/vojOWfslumej87K3bx7za18jodumX186ex+1oj3+Kaqv8+ruSt2XTC522
+vEYOK+5P7PzcyuioBjWpcXVJId9T6m4dtXUUMWLnFSZFvtzCwP0ZW5bE5tz/Z2xB535O/OfU5Evr
+xjXMa87U33zG/w310TwvDXkzU1n9sT2Nd13d9Xm9nTHr5lxzfA/2gISIBBIggQoPaIAoCP8QoQIF
+HgmN4GEABhRW4cECHhAJVLgQgAgiWH0y0DzggQYaEgjA41Af4EAAcYAHCWg8jAEUJmA4cKkl3ATG
+wIMHZIN6NCQGsEDwqMSSKANIJIpDAxxowGKKw2IRgMDCwGK3TLDcIoHFFgQsligXGrBYoigagP3X
+eIrpjXyHyHr9mOnazPn/YLGHYQFiESGRKAJYHghFA4mFAQEiwDUBBiZAwYFzIQBLw9FACxKlwdKY
+wNFIQCJRIA/jQiRC5IHe8JZbkCgMFiTKAgs4szBIVGiIcEhYEgwej8PjwfJ4HhQNBQPLv3vr6ubm
+Ji7utq3t9uvruncjNtqyaqY762/6slrjGmPLdq9j/m/2ufPaWqZitpk5Jzd3O+5pn+1727uyLtr+
+pil7tjY3Y8zYMZ2r/p5r/3fa6W/YtnyGm5/7z/wvy7Is3p8oDIuXskyIU9MgpjpDQo6P3dw7thKn
+5g5Rr97uO7kcXI2zl4aY/Zgo53y4+4+fiemYjueMNSur8WKKbMp21/1/l8n8zsgYn/mi9pnl2qmj
+6vrqMZaeftapiLhtyFiiOLN6MyPvtjNjietwKmrS4iJz7iZKekVb6RtVidKLtmnUONbodKJ0q6pq
+JiLuWSb+6/o/3xlqpt7qc3qa/nHyO98r96fqsn3jmmWvWmIiZyZb8yna22U+W+qa+Zl+3m0vN+N9
+s7pZI+Omb5q2t6KlvT/DZp+ovmyJjhKFATXIWX4nURguV9uY3bd8u2VPNFs7xT12ZWzkPfa7zc+1
+e3Ruy/7jzUV+XLtjdGPU1V1l9/5udn9+277F5u39VE3fVcZMnR/vnl211xbt0R1xLf1XP9WM6ePF
+W1NrO3XV9N10xnTDxm37feuEeqG1zDFe6Syx/f0dd/gX0+1avVZX6KeUP9P7r1tJoURhUP2b2nn1
+6xt1ktvUdJuxpY89lTftLi93bVH37pYvlc0zWfOMURftTw35nJGxpRX3HG3X8/DeH9NM9f54TU0x
+3zz3MDdXf9XxfNN7+c742P3XVY3zNlMV+Xc3X/sPGe81FVk61EsUhr/F18bmLS03kf4fOsNsreqZ
+aHjrl25t3vl5n9hpt+jMyfpu+m7ZaN2YTCeq+eE9OgQ2KWdOFAZO5xpNrp0oDN4sp607LvK5o31q
+dy9+Y3f/aTt2/jE63mP+vm+i9OsnimduSq6Q/V99oijsVkUN6uZv/fpEYUgUpC5RNFH09hY7ydXY
+EgV1poRWE4UhURjcHHV7s56zllkZY8tTZ7x7/15nfm5VXmZxf3OT2V2xv1890X39+HaPWxNP77Ab
+H3kd+dvBR32JycC7f82e12yLaJvf1mnGia3utuu8vm+enH7fuKjt1rt6nMq7yIn5/Wrn6W+myWy3
+3Llt7dhunor+74iazmeuvb4KKW/e1+bm9u5E2aVL0VFKIYXUJ8q9ZaJsoiCfcn/DjbLOlCipmoW8
+kS0u+iJba9lKa1U1MxOTsXU/1+fPTMvG7/Z3Rl5NzfVfb19cZaw5V527L9cejXk0NzO3fD7m697t
+W0t0e+1dRdY1bMaWxM7tz8Z7129kM39c5Uvb7WXfVP1EueWJopCDCxeqhBg0UTA51mullPITsqRU
+pdp2lVSTnE0Ud76xvLbESROFoUlJES8vnd2xDxudD01Z3be/SZSVfBG13kq+uIfp5Gkmyi48zLRY
+KaNEWfvNfX4GkZKohLJskyWKKYSMck7NCIAEACMSgCAwIBYNRWIh4axM7gEUgAZ2ZDp0ajIeTCVJ
+kqQoiMIMIIQAAAAAwAAADAFEphFsg4/F14rMfu40nyu4Pd3v+66k+Xbj9n/lncFfeqB+G3KnpO+k
+6iitnW5o//ZU1eAOEDeYjjbFolSvVDQBfhoCgO38Axzw4IdXb2B84NdG06supX8q1x2EDolXv3vf
+9HofQdR4602h5IFL4633CFP4rijXl+hc2+56PfsUNOEkR7xKR9yTjlQMOYrROMpV6ciXxkHq7kef
+fOXPG7uI/C3we3l41PT9a9IbOqVITuLQMnmuwW2nqDsHBuyUUVqkraxq91DicCuAH4cZq0bnbqyK
+nIhSKVpBZGU2/OebfuZhb+5G0sI2UTCKPaST4QNTw895UXl8tuo91iUPPyi+BGwUbip9Q6mqFuce
+qTeRqjDWbT6gkG4yjn260QjpPK5Ia1KGl7pc/2IcWJazzT3+IHVtVutWNO66sptOGNATJQRh/Ddc
+bKTDuaWqUBdMZHjDCgKAzhJMSfarKnK/qTmw0lp483SBnZ20QSxuV7DrWg4KvhXPnaIFEdZMywx/
+FxCjBBqDHHEg1pCpmjxKsmmWGwdXZdQ0qzCmKFgWl/CuSGZAxMVjQhk1v/n/keTq1aKtyBKfJyop
+acrHVFeekzAPJc5bUtBzMemhtHoLzla+lX9aJduWwsT6qWZQgyuGAPGcUUsR15fWac2jZR8RelQX
+HWVKR8ESpHjMgjyO5OfTHG7ShUrFiwPOQgvpIMOiDEuc1Udeq+Zn8s53Fa8z8Pqr4TXb5GGhfSyX
+jw0sh6GVo3F7h5PqIS7DpWzuIfTyPIxWpxWZtMVNiio6qEEY7ZqjQAfwl42/lByOkaj1uxbm7xo3
+1xF16L6gBL5QndZxOy0O0yGgthUz4RFaaehm4cxWlvFlefxegwf4osyCGRgmBm79W3TGrc6+hjri
+ItEoptKCLkYATRs8WAavXBOgQlaaWy0D163r5rXrupZj44pHy22tzU/+J52s7MBzl1YghrwbhEcn
+ejaISDoN6Y4DYIvhR+EnSPm3B3PjA5jQpdso2ZkqayuEZEP6g9nvK3lFAKBDMl1QUlVhf1YBrphI
+VzGedo91+bh/ua1/RnX9ndGBZ5Sddf3xJbQQy9RRiJNZYC5AC3Or3T7XlNc1TXXSlySb8X/WwNLx
+rMOD3L1Ty4yzXrfzpnQc9gqQrvM/MKow9ATAoM3ZQpTfPHntm96YJc8LvtBZfYuwJKyFBes66K/a
+ndLV+E7KBlQAUCxHsT3gREoYtS0w6H3h6ROCuJnvEQiXSaZsAm4MepGc4ObGhg5a9CLkiWXsiUsk
+Z2FH8Q7hTDO5kgZ0YJvU8vKqHf9wA1TUs6YQcpOK5xfea6NoRUTqUJDiAtmRvCF7ffWKAM64izrd
+7sXJybnwcv3dAvE+dmHiVtPpwJSNAJO0fQRU0iMBq4zhbBqJ2NVyCUKNAZeraqvu3MOceyrQgAHT
+OAOqG6sCQxLSahQ/FUwncET509L3PjPByMX3GveDubQ1f4IpElZj0fLS0Hu6A9Cv4J2ijwsZBmyO
+UCaEaP8UsGgyH0BwTYAAEgAuAtDxr3yBO4tykyHhqKY2ESU2ya8blbWNKp8m96zgcsnYqXU7mCkS
+jN1EUOKHvpvSqjZLFyE8QX6E77mWMrV9km7WCe9qqb+r3e+pLr38Jy7gqeLzLYWatqWw+ldoFabi
+ScYmuPFfGBkZZyQ1DphkeCtklcG0MkxYX2Rzm+QZKI7XzwvAPslqI1B2CbQGTYqsefDW0VMYMn6P
+0ZsBn7AxSdW+G0Cuab8NIC4yPWJjQYM1OYeJeuVEf1x8RXgdsUtDXDIsGZeIK3WMldgezog8TOWD
+sTHNkMLi2TfQb5RTUYkDUV0dPYrcH1BGJFLRi1WvYuCvZI9f+i4cuDZXrZEuEWwOcgR7FyoUsSWw
+AAssjHaJqCtZpbg+1rWx3ErSJQlPcJ72Ib1EFTSdtXUJ8Ccg2PqTaA5k34mHpQfZ2Nw8IMArIOl0
+38v9KFDufQL15+Z4nZSg23N1z9LpcJvmsjJ8o1NBv/BGLz4i3QKaMQYGUbd78BiOn5a/G1/U3fMO
+tM+3WGOsOW6zYKwDzBozOm/xqqZRb3v5VOX2UtxB7sQ1eh+M5UdLh94d2Ku0ZexRptDuwniEtPXj
+Komeiipoq9j0E2JIVpr2DvLvIqvrVBOkPDoiuHyzyK7XhKcFUab+Q7UwBmk5kTQtllmYtPnEyJWj
+R2BLah1MlFi61cE0hNSJz24cPl9TzhYK3xbUSeXSw4lVR4znGnUl1tHTOTHSriLt8QSTGTZW6g0r
+afV5QjEoB5BkyOuXAfcuEgR3PJkDeSv3ohKlr8oHJbLSyVKnxjz7rGK3o8eZiVeAgyhBHZiZtvAB
+ArTOw+UH1SOjiHXiawaGnrAaIfe//wbsF2n79ULXr12OuexNdHAG1pK+GhdhG/4cSoGs0y7ox570
+FKVOAMqJUvGg9Lmprm1AIlDOyv3rLx3dsIGpNbXBsVqgxXyyA7F8/Gv4SBtF5vagOe+eRD1QLeD9
++Hdq1BJwWo7x3aJ9xLQfkbnbYVGU9vRbQ4eCFRZaANmKirBguB/tyrlk+CFgGu2Dw9BQ3lxZMtOm
+Ml23+8zjogsiVp/u58SV0VlbGW1rhdJ8cHmLgHh1Ors6V8TRrQhg+atvEgPElR9quNf/wuD84vNf
+WJgIa7r1PAmzKyg8FuGN7UisfPsqgQM71teT+zx6Hx7wdnjkjqJrdAP0KOb/hXS/RmxM6DG9tBA5
+xwgXhZRfuBboDKxjufa336LAsiIkUYGkx35ToKqxUYpcHETBUF0rAuLQgftnw7tB7W2XThL991Jx
+9ZKglAvt7/WZKjRInCZnEE13cdbi75PpziX3DKBwZPNMmESMl5l/3xiTwwer7MavjDhJn4UtKihZ
++zZDLo4GucjdorIUwlM5TH3p10HIjf4MhS4IZI761nUgS6aSVG7G2kT8c91nTuor3RWw9PNZ4Xhx
+mhKmpMspBF6cHdA4fxIUWMRXsby4FBGPd4HMhIA1gw0+OlKOiWNq/pIcpgSJqaaj9iczg+bc0l14
+0iL6PDQk2ntL5gnosJhh34lmT9/N5227HBCSf+lgPZKPVoBOw5MAc4Bw9IPi+E848uU8AHPt2H7X
+Tgkdmflbu6vnvTBeQmeYDUf64Tkxea24yvn8yQE/a0HpIHUegPh6GB+RjEqYjiSGaXezgvyZcp2e
+oBHCLlRuxcyylKxc6NcpVHKgi7LgBW6WWW+zcFplVCccAcLazaqqD7fC0GCpG2SyhrA1RKNZcx3q
+giSvjhdbCpQdGlNVG2mlac7smSV16u1wXKWzgHk8J1CfBfbL2dqF8lXQLvA3BHE7/2gRNt73ung8
+mOmJdVVMZzAkJ/TlkFpT/Q4a4nhBqjYp8rIs+9vBfASMqNE+H7cEPSE95GkPvyUcSwVRnr2eyLMD
+0LavgfYrQehvfm6XjzjlprBEJKcZknhi2uQ5YfOfCA4St5yFma/mCNqAqsU7YCH4jg==
+	]]>
+	<![CDATA[
+	M+BJHQ382EstEL7DLVSgaSD8WmDCF4IKO4p20SKF6jyinPFwH9RNbf/RgEcoC2CzIsVMyMB7Yxi9
+JHQ9y4m5Mo9W7demnLkeJLeyKJHoUlfd3tydUDh5F2py+g5QsuE5in4xAzadeBgRQtjn477jAgK/
+donjZYkuXEX7Rmvnl23DqlgtxlepILnp6UU3JhKdC/LdxKNvk072JuiTl0BrFXdeoB8aSK3CyqWB
+1I0lU47pdVCosmPVVmO9jZ+ZuoJ7FyiW1FrLDzOk2B+sapTiCCqiQrBl4fhbb1pA0rwUHZP3SMRZ
+so1AqTxGKBieWfry1Ie661P4jDUtA/aPgeEKAhFe/bVT8QpVKiUmgkQmswLa++XjrwMYCIdYaXvR
+ImoORc9Nq57Wx32FUNEx0mi81HnwjMh+0d3ZHvBEsQ5YjRmpcEkQVvIksXiTwoOQZaCo4ASfoXQs
+yxGMRm2Puya5lfphppVpZu21uDKzS0eF0x573It3CGVAuObVfGj4leixFeVNRw3NhYjgyL0n+eK6
+gpbcRC4L0fgT4fnJw9ZfM8Jpco1kHPQ1WrLTUNP/wM4NM/5ZuM8qU/j19VNJpNz4dbU13FQkz3OE
+7gfee2dSyIRS6R4eXaVfgksUYea7u86tDoiZCFQsty4SwsV6i22xIJDTLccwO8wXtC5MCgeJvGDh
+DEitnJiJNsA+WBMmnxWRaUJqQgtFLlPxUl4Bog2t11YBPusEIiRIyFGkirsiEJmz1C4W+R5C+mYg
+YtHC1AyckPG7SX0zOyhMIjCX52drwgjvl/+uUKG/d++duq1hhiW4mhKZkZcEQdYQSwZnPj9aM8iR
+lzzp1EqYqw7mrbiy1YsYyJIkcisP96aqY7tUqtbfe7Cy5ZEfc+JiMYbZKFWrodVJDVa2LTfLc5Bd
+5rmyvhdaiM5oIb6NhVcjRA/VAksXhDK6wWNbVqAtBRiD8Qu1JEkYSynjSL96Gc6k1CEphY8K+Ojv
+QN8SZuyXTwvxqFraVCtLharunKe+Nm3Im5kAtCFtTCgDbygjXQMn0xtwjPJz8A9JvdFZ2nU74cQL
+oPqI/XSxQ5RUCTkyc+/4jkv51/ckUAeE9wbbhZTO9njq9bjjgcZ7roVEIoIJrsnbJygbie5CAynZ
+Hjm9pEBaZGuUtqyC33rgxkuAR+EqJS64jCnphNHB4ZjLzVHLg0HJBvrs1oeqamBr0YIYM7bncf6Q
+vT+4Gtyqs4PrYfcBEseMIV+9bgZ6ne7bVlaN1ogGk4nBjlp6aTOswCtR80hg42CjBfM03mWCp5Tk
+ZgjHQPMLCmy0ed6hKx+zCa9xNuYbTcVijn5WZtG0Y9XT2kZL+Vuo5HswYyCfgXF6IMeJk3ITLKKL
+2Wg1DQJ6t+FclQK/Lx0Pj7cV1ZVyfaWvNtp+z6nOAVo6js1wevTp4r0Z5b/DbbQ7cGbKz+8b2Y78
+7SPHozzaaqaN0SLniaO9O60/mlXNZZb5I/dPsUJTTv+YNUOgP766lgmT6ofmM8XgWQqEQamzjbbl
+P5UtbW0x5n0qAH87TxgWnQP+nn+uY6FrdRutGfElqesEB79K2p+RE8cfJT1LmQXnk9Ys8HKDLotG
+L1vqa5dHNlA4gLeLNJHa1AlvEvBahk2/oOyfYHKQlavEFdwdRnmQ70qomD2w2ut95YjFL32HTIR6
+Uj22lNQokeJQBJqmc60Uemoj2DIiUMeavGTsCPlhESfwmwtMIZhqEjCAQqZW7b4PRIUmJT02sKZU
+iX9IDtfpKWVTOOsPGlBFy3t0uEf/TCGAPT6zsGI5d7mD6jkInrulA1oSgXRUNYyc8yupkffcB3s4
+DBRbEGPErk1Nap1UrsF9gPr2/MhZI27Dqm808kKlbPt/19m768lDJqfD5Ugl/iAcgO4AsL4Biz2e
+2QnqYbxHTvAs4UTPuAHjRFSsl8WlhLP9UjjU8WJSHQmt0PYSrFxniaFXByfnsjvHsvHeCGDrNWZV
+WUwV3DrIRBO9rkfsXTUmuREf0znEqmdx8XKs6ZQ3pnh4iapqoaJ5x3xnE/hFLb4ahf0r9f+a4VPH
+zVrX6scBEQBtDiDVBDdJ8FONO7W3cukFOnAvQc25bvpNSzo7qD/A3nSfkDjmyZwCdUDoMcSh5nBB
+mAcpDlSicCfT0ChNoszTPxNwTuOmmv4PnH2bqSfULrtftrLXJcOA5MWPucgCQxqPHOq3zRx5mTcD
+S5XhcUgTsbRzRQ7Lf3VweU1kpJLpyKada77WmE9vRv0S1WzJSsLXyaKK1bPMObgoUB00Pt2kxLBY
+vnKSPAgI1fOC9pbowKFcySQmHvr+oJsDorf2ZFfJ9gzVLs4nFjoGgM+o8PBov78brJSoYFUzJ2Iq
+DHAGGvmV2Wl3W5tsTuxVUfZ1c7viYGdYrcYW0IkF/maOSNCNulQs5aGCBXoY2cMimsUasiBTsWre
+SC/WnW6dytVdTKzT9mbzmposuXcyhSU3922MfQRY8m8MNuclJ8EuYXxG1fX5YMIHdR+DwHaBrr10
+P9FdKrxLDuAl3guFCd5PBqorpVwPcdwSaAIG4WEzjpcY5wvW8XqbBQVDucnX8YsuaUw50mSqOJnT
+DrlxDzZ2Q1YLX+JL6vtrQIZDseLzYzYcBhQ9yqI5sUlSomyxehfh72HPA6iK+j9RDmfqy1B9Vd0v
+Ia64tbtQ0wGrtrcDnzRfhS8vlj/hWfpLoS9uwjDoDfy15lf11Fp1BtkYI80YYZLElRnayrcNWQ2I
+JHgzaWwIKFbuvUrRHShv438/Z80UjT/PilZlJi6kDpZ+MG0mRLxlKxVzW7lwIwXqmQ0aUofIGAu7
+6Wauv2XY+XYSrF3iBFTDRxxdD1Jdw2VSu4irLuhz1EjiTomnKeGQzeeoPpe4zTCn9tKwCK56oXwR
+LFwDGv8t5X3r/S0kYhHf6fFbUEKaU5lVTiZrG177X5hEtt3EVUa41E9VrBJB6euOdgUp5gsz3s12
+fecmkWHKH4Da3CpXQW6W3VnvQirRNTXow8TldSx5zFmOXPCfZWkeaqXlKeAhDL+VXMVrt5fIgDZd
+6+Udy783SvR5oct9dNyRmpZfwaP9ok01i0I5a39vmJsllrMgX/sX1Qhe56LxjCf4n9UpStRWuRvy
+yL5Kf5aHhzwbf+U4BZmAOBPSEW70UNQdUs9y/1zzYz2hjiKeYGlIUB5y1FCwK36rpRCcp0sYtRXS
+mlZ1exCSXsTNyzLfhiRl+LI6ZmHpRa4ghV+cBGOg2bJEm9XcH6VehqGQUX1dRGWySksHNrzD9GDI
+HWoRNkuml4QrM/utrBCKRQWTg8rmlPXfBUSv8XbO6SFrQ9/Xs+g7o/XHsNRofK31aKXWp9WdZmwI
+tdk3fOWFn7jBbkVUlLomjwa5gys5FrxgYsFcN9CQ0RSHaMvC445SgsbA/qAMoKiEdQnQSpRgvuBY
++j6KebKNJaUXLvuT1i+1BF/5i88B4pJU+i/K9eolbg7+xZTAPkiV0KGEtLqy4RO+kio2SDLqvEwj
+oeXrUaZ3+Tt0jSklVb0B3/xjokv5cEXi32GngutBc0kiVDrfsDd2y+tNkAtT5NkfQipCNd8P+9Fu
+I7w3Mc30Vu/34X/ORZYQyfNBdn/El4HPCFPvpmoQKKdGhHMwrZE9mcgfhlUjV2HI+BuJrtm/0edv
+sV8b5giVGBNnSoco3lengGwxglApTJA2HeKZI5keORyxLL2VHTl3zSehYkH5xcmw3yYT40VYI8ic
+4OPEs06ExImErQqNLTJbkchM989ObybxpvKGHt3AT3dDZo+YJVyYPkCaDtszXnDKOA8aj/9kNwh6
+2uuQP6cmvwirjHtL2CadcxRsQ/Yf/EAfkmZZwVAvOfgbcpc5EXC4eqyVNmqpgevUgWagUAw6laGs
+ID8hJTbunDC4xPmWUJtDbuQgBcRbnrEcpYpZzaP/JQt7Zj43y62HnGFhM5DSpxQeQqJgnEWBiPTK
+HQNXGhic+UgzoPD/38J4pwgpCLahFasKse5ynQbF7ZRtgnRHZa0Pe89h2o3gRkVc78Mo79uJw2bI
+u7eFDf1sGZYaUsTKslkT7g6tVNyWkvLRbrK7Xdgdv8Ks7CgrkdP5/FFe+Kyrs4AAOqtUWECOzNoF
+jyziyVId3asquV91r/XeKXOXvb46lAZkRXlPYJaDHEGBOhRPlqZ2noYyFSpqBCKvhoLXO9xKJMch
+rATOBuCQFny093UoqXNTQrkJUP+zrwCj4/JaJjcF9Zllk3Hi88uNO2jhSepIQA0hwLv4J+jUZ3QK
+ZlPr3OOf1fB0yfMK3ZkJYhUmDafU1J/mZcVufNMKmrN9Dr3JOyytPnILOWCj3Fa7uSllzXU6DSXW
+VsK6W+SSo0hLa7zmKaeKJSjsABUkEaKX6+h8yJLYBUpByq4v8+ZsZokpHvnfhLn3f09hiz8kgdGp
+2TLVhICR4CmHXI50ZJOA3SSkFyRRl1/8eHd6spRNUDjVnF8VVyWIxatEXXJdDG7aXs9w+rJIEZpB
+Cr7zl4FkYAGS+Au2hPzSLz5nbAdp8rpIDY2eIYkNpVRZUIcwgAbx8SePYgaBzy04vcDIXmf/sYLt
+M0LMkSTChdwS4nYJOEIIOJdeLhLDxUu5MB8DpmUgSIPDNGZd76Qjtst/vb8CuOHlbHSVUeisl3MV
+lRyChp7AkAU+joK+DEu3MwH9TIqyhBWKVMlA9uGQL1gfOxLczVcG+nnoupzm3HXapeF6M9I9/Xko
+fIdGrTS71SUQ4Iq+OR/fVfjvu/A6pmmp3K1F1FxY0Zdv2yJTtemkY/+Ny57sJIp6imZGz52IdaeK
+dV2bQEtc93eJhUVooHYrCQn9LBlTvms184+L8el607ENMWI2pBWgQstV4CsD0fthByA2CHkBLCX+
+QjARNsaURYbbjGd5+g3wPgPWe9xx/IIuawcv1E26VwZZFdSLQ5g0fncPTB7fF/EbVBNGDDh0joC+
+Hi07CzOPJgnvdMvk3cmAwna+17lpAd8EnO85mYJBGTWlaJhU9j3s+q0XeGa5WPMlmdatiOsQ5/tc
+AqpuLFoHSmXjxQKGayyRAV8O8IxfzRNkdD8KzsQvdfBvKZyfD9+1gODdACUQ/P0iSc2KMXau2AVa
+8T9uHlgeJWX7DIk13bycf8dQWv2Vm/y4CY9Vc/Xyf2MOi/cBBMzRa6+ynFJPMnh9FFHCKLejMJIg
+W1jKVrMUtG/b9b2QCdYXJeRWGDBbZ27nyu3l8OAEusVoI7AFk7pfrQPFxrBYrHAUq8ZIdrfxDQiX
+/kNINdQeF0MIY0LsXt+VV2BFGWBKFJYSSaGU+GfsWNw+BqIETGIpbBUo/EBjnAT6W82+9Wcg/XmN
+0J/0hpU2ZAguXB5oWoST50d6Lhxf69DVpBM35pWCZWrD1VgnSjew4hI5w6sWLzlCxBAsPvMDfLdr
+cy5/+xzz57sbZBmepBQn0/E9bxzXUAPjunikOvEN9csxWzyhCoM/jQgcVzSNi0NdDA==
+	]]>
+	<![CDATA[
+	qtzAHGdDRsQNhTG7aAOjRtnc9YDwuu05NPaOVOKgweRUZsgaMxUYFfvVZWEMdsoSnO3z91io878Z
+GMfIg8JaHFHZW6filtYuqoGr3uYkIzU6NV4PGcBOhh57FOmfdVGjBm+AFHQ0IUcAAxCfAGQLgJSF
+rvPMcw3cJOMfpkl/MXloAwxgwGC1DhOsPA5O5EyqItlo7ne/M0fLlm4MD4IUx2HqkZY1y1Q5vYmi
+YbvNe4spp7stWgApN/HgzIlw7OnJd4cUxFNWGqdovknuqONsb8YtFcpN8stRzHW4puep1RL7ikvg
+wjDRr/JBcT0fmTRnvJGogTfywq4NnstbhNdAOweI9pO41oiOzPswjygG/HDmgXqPwEQ/IirmQNy4
+uNpISz0o5jq9OOpXktdqs60XcY6v+b5fN/fTJAWhr9rWLrfZDhAXoGU2Q4aIBTWAZxwbKwKuSDCF
+Fj6Z6zi7W0CkS5RM8SWpFnSZZdhVjZCGywYAYgojmrGzehLRkIZW8OxBFNJNG5i+CoUi/TAYpWUl
+oMVxSeqqWVOBu1+a70vlpkf1XvKKV6A0weCKVzJg+7XE2TDNRcDMH0Dfh9erTIzzLWQvdYeLo1CD
+nEH4ymVtNduDRMD13Z/nNusCGodnHbmUjnK0X6Xz8ODFwlBFIsrlMLL+JDMj2ZCRWmYu3GSfnYQY
+zvmQTKgWM4F8+CDP5wCJSTBWZ2gqgHpiRNkUgmRuMEwsXQaC48hR/xY/JSPUk8/CTBIgpmEVXuYi
+B+/8O3g7NdAfth3BL42PRJ+FpoIR3oGOGz+0pvwdpSLnl7GFt701BFjt/Nt5/AK8hocWwrwPFHdV
+0iuVrTDfR7gviGENxH7dPyx1hUrWMFxs45BIil8q23fpYD7HFAOao7qUpI0vhVLyzgcbURULlfq+
+XaN0LeVUPJzJjYvXjvJW7Sswgc16Itxit0v8DJyGRMQCMSDdir75V0BIRu4wGspZ1j6rNScZ4n3m
+r36sKVnQttGgDvAj/ihUFAnC8TDa/mZIWhuLuQLbUcf5TLtO3IzAiV2oMdO5vFCpj+4SA5MTYP1q
+MFYcGSqOTIHAmE5XA98a0y/soL5E4EkFIT55UFwgFAsU6YiEAcQ2vyQsQo7Kq+J3oYj+041XOSIy
+jLrSDexEsK1nWpVxHMC/u/oZJZtD7g+1AGAYUFKS7wg9dFpXBmIgWKcPLx3axCyTJhDbKs7QvVEJ
+SccnAEFvgAUoQHTnONaCZTsGS6N0hC7NvKi2clYJP/+VyWhB23C9wAyoJSUG7CVzW75DapvoSsQN
+3kkI3lCUo9M643VfhnEM9ulcgj201asnarh1A0uTOWm9HJiRXoAGA1CxwitrlAqxRs1tOKsaHf/7
+tv+chvG3BOOz+FrBFub9eWe/1l0Xzd1+So+j8T6bSMztb2Cjpol8fMCa1lnmjm2KCzAPWzDe8knB
+EUkBK/H5ZNPf2cRBWdJmUMpRg50u6/cVBgW2aQGTQcFHsszsFbGnK0GVBrBJgZzQ8UxVfapmXxR4
+EfaA/Htf/AdYr8vp1fZ7TnL1mzkDweg/JZHYxJyDnplmPYMc+/ft1iBUxO21wNkIYN7GTJnYnnLL
+ZDLuzXlgOj9rpt0COuBpLQiOLfaRg0rBRmemw+fejjM2OTkN366UmWtILbLYZpZmj5x/Uv0qXzdX
+YihPZ9+DAzuDKoEkrhjQt1L5zZLsJ2Ixkf46KheupnNmiBQFRpCTt2g5e14ALYu2iVqqJFLlEH2D
+ta6QaLbNo20FGDncXjTNuM4PJOxxlAhtHafR4O9Q4XkxCgyYKjujGmoV4tpef0aqpfc7taWF134v
+b3asfXC2z0SqeDHlcj+ranNSM7lKLbLl+kp5uWV0c2rsIimmIceBanLY4ESycWSk0YI3Px2s7QdQ
+2wgYwpYzbcn5yFe2uF2clM/MiCw49lUE2tTxxJE0fCsQCyyRyfT46GfCBhChLCfK9P1ELnB0JE07
+Zlz5yGnADZCDDdZGV4Wip04jZAVYXYVEHPgxYApjzeKMPQ3xm6E5OUaUejkNMfDLgUlJKFza5bbd
+ZB/z63Fu4+GUmmexikBzaaa7VYKDDt/L3zIzzSAixhEu9VSMMqkHAaBmUJoxJFjwfGn9/EDntdti
+VXvQlU1WVrFFhlXU+whp7o92BXolzDThfbx1LNel3u8F6XLBgIdiZU0SmaB/PanVTtHGvQVWOcUT
+ih1j7lDtto+G4PjpOxBDMDc5V0y8TGzRbMHXplELwWPaGuLhSe+J6PnnCqksIU7YtRVPDQ7GP6oq
+Y1VihQKzHVPqSt+p9faq5yNIHdvqmHsdXg7hCMl9aSiUvPuhpBXlhy+VYga1KElMDEeVl5eHjRWW
+CPbfgWw2sEbcA3QNjMsV6hz9tnggPVgCbQrs51JQxebNz+ALDehtivCpKSgU01+g8eKnlIrJIk4/
+7aCfAGgTKMtZQCxgXoFn4OOGoKerC2RW8Q0q/JcIOmm+cXYwoNs8o2J9Pco2kKcHjo1jeJvLaEzi
+r0b8oyVh9rh5td6wsVPC4yZvG3dexTEEUMqZ42lVpgXn6WEPQhzyLoMOxIaXrGQgSpX5L2JL9ULq
+IzNxDyrYEOpGFayn6pmqsIfcMQJlPuj4UyizqD84lhcAbj6LEIMgTPKVV3K1iEvqrrtn0tjIzi5U
+7s8eMw8XWwLbSPVLmFRbyMJznSg0Bzg1EXN6UGRkUQqVL82NPNhweakQyBtjCWWoBjPc7rkn/Pdh
+uO3iU0KrRfMBBlcashRgjO5GONdp3gzudjkB2M1fcd5Az2ohtl/aTzKAFA4YKmAVVAkD1D2RazfT
+etuxNWgBwaAE1P8OYhQIfYA4FJXcKFSDO8GKxJm2QMWX3bF1a+HapkLeiTnAtre69NAaJaOKy1fO
+B529lULVQiFmTmE0oDMCVCL8oF0UGC4PCaZh1YhKWgZOqIX9aBcHIb2ZF+mYNhGPubNEV8jT9+ot
+QVwXvAhxh6WG2KEKwJw1ptQSQYcFL4j0USyaVrUo0mo0vBP0FowVdrPeR1vV+sepDRXuWRhkGIqu
+Gzete+TONw1qrysZdM9jjRrjmT0mRgPedi8Eo0p2qL7luYnPkno/JndEPjlfcbe12sziqdugf2K4
+cfagIhzF2eVTgehqOSrLGrBk7epx3ctHUBqzLnriy0CQ0OYQcf2FREDwNI53OJtVVPSFiymbbNkC
+SpFX1LjVixs2cet94g9sIgjvN38jJJTES+hBu6Rp5g2fjvUvfdn2v3kQvfpwLnTrHPrSf3lO5pzF
+AC3tYusPbRuyKaCmX2+j36v6GR1Knc+9WB8LwU1xIfD7IVUxKcts/biMDQ1QxDCW6zKESrMEb56o
+877Jc2sNcbluV1zctjaGh0+Ew8h+yyt4pd1DaxldPuOkozHdjRnPGuQIeO64YJFjSU+yupIGWug0
+G7ox0f6L1s2oXz+ChdKAxBOwc8D0y9QHcjzTFl1P5JUvropjiHX6GmFopuiuX/F2Ezki4tCwWqTU
+zlkte8ji7AhdHcep49hBPQQIDW+ll4LYdAo6zy8EN2wsyTTZpbgsFm8NtqIqcjcsLODzsBiWAvtQ
+mBGaCbvAeU2OJp0p9dBFEHxckl4Fte7yZNds77JUlCq3k7B9hMaoG2LrSB0crTyri4SdQEyvZ6k/
+TabDXbYbgrYNd0qqGz0Sy+FJ7jYztD43vpJSq8HtYZhwuBLHh/XEDQU5tf8dCywV9OOwGDOiv256
+MZa5fibPwVr+tCDp62wx3DTB5xvaaCGhjInu84+2Aw8NlALZpn3jPWi9u5ZawoPSjE2GqniH2Us9
+35Y8BOzCjf9MNmWzGS97CABVO/FGaPpjwdVRrM4VwCZ4En4n6Z1Mo88rNUufzPA8/RpxsQFFjOup
+RWgtZ9kivDMWG6jC6v6GA7cgD+ji2Jn/nYtaVebGKItvs/Nlu5kzkEty7Wv9p92l2gnNyzaezn7Y
+5SCW44gO1u7s8hRQ5u2ec14sjYUtE6nqxKqyc/JaR02P1Who+0gWFrYIz+1lsv1SnAX/dgltiDqp
+glZCR3FnFRG6lzjUUY/j7xHttuGkEtj7i8gq9M/HA3EYl7UZe5EA4DnWwGk6lzjOASkIxbuzfcqG
+YDygPHeX2qlCpMnzJ52mO1algwXKajNpD7UnJuihAGZoj3iuTo3twGzqzCrqAFtJq4XS2YGSKjpF
+jYSuMebnEk1SR8VqEc6VGOjD7VLYDebDPgb155kchRjQj03zib1NrUTFHkpC2GSCTQGbmEDfykPw
+u7ryaPcyhQeGvNkdQbNN0MYz39n+zs5ZvA+2QYEGDSEGyaztYNV6sUwGy4ZuxwywOCGAjQBgAHgE
+uIag5saItbE9s/tCG8wUCjQ5DWgfeRSrHBNpLhRlOqWUo5fS7g0mN36Z8WNmEyXbu4H9IcXtZGgi
+aljlaiAeVzQzUoWFiqI8QKciqF8/laTQPLxHIhGNoQEIJCBW4wzRDnA2CUL0Inh+G1TexE7CcTet
+B2zx/gzs57SDON17tUApa0C55wvzMutnw1tP86+M7ye50EgIwaCX/xUjhLEDnzv+dq1rELYpp97R
+NE/+nxYpvfTnaJScbyel9GVKA5Jzy3U7QiUb5lCgSlHDvmJ4NYzEstM7deBQit/Wim9e4jcHd6eN
+1rOh7tq0YWA8BnzZRlo31Lb2sPuYAnrEe6dHhW0imFzA77LUW1nGwfcVWah9/+aFJP4EJBKyEU7n
+MR2h7Ajl+hAxe7jwZp2izLIRCPifXg0D85eM+Mpg0ootkx7HZHomgNNEcYnzMY+n5YE9D5JGHICm
+W7qs6tUXo6O8eaLX5jemtsk7pryThfyz9Dz/CUbTr+SJiOgv+uaw/rxhVPUvHXP0YsCspJIhBXLh
+EMa1VouDAGzCN9i3mil4EykKDmMiSUwa8AiFLhmzOja9+89M4dNUI3NArMzFUixH/6HpdXS52MsS
+pUUvoN6FBJ7FSUWwFgK9qUvaz+JC4eHEChpKRJrS+lyrOVggm/BehTHtVKo+n/XvOUA93HEiF0Ou
+bn4XaUGzoLPeHRcVZkJdAxUbKRTvKpgzKFQrgFtPFAKTkhqIZB8pRVmLDoKeeytRQQypWitqf+h9
+OR3Mc1zO85vz95y3Z4AGO7o9OdjA0QHGhJzGkjOcigNLAbCWOTxgcQtgLrrcDlRvEPKCUActG5UT
+ZCasi1M3i6WijZuo0DndHVU5R2VDWhOSiV/0TzKB/sMGQOx4d0gxrw92xrGmpoZqDzrwHx4x1pI5
+I2mq5W3//IjJlBg+uzHsL9Lg6o8br3pXRdeg4s6rJJIAJaVBnNtt2EzIBmkOjBp6Cn1hMvaG76Tx
+smz96ipYPLk0WLUuduYkBNOg5nE28E4Lr5Xq9BcnE2wfpo75ILvosh/cPETpv3cZUDOB43Y4qrLK
+Lj0of36bNrCGZKSCPud6fbYUJ9mK8TRClGau72MHfzPxIR+z0xr27I1FFudhTYGbtQ==
+	]]>
+	<![CDATA[
+	yNE4It/yx1Y5xFB3cowb+V/fohgC7AseKUG0N7v3H+qXY3Qdd7l8g0DUgBULgX0FoWHFfSkScFWq
+cQ2Cix1+bawheBCZtfLU39bp6zgT4T8nsn4Fmdw3a/nVCsEUNgd6aLX/E+RyX5JIkI9pIRvYjBPZ
+y65zwJ8AeALi5VFK5+Ui6jtMVZDSlxAtFBDO67l4O6T8sREQx7aSDSSVWiBeNvp0FjrHMZVOEJUb
+gLvJppRnFVUS8lzoz6WPqS7PgJumeb5bk3U99YG+/Jq3hZYYPfDoBXHjRNCb4Ls9McJagKoICHYM
+TQTgamy30VWmdpdOgAVi8Hiy/xWNzHpORAvS7UN3PPOXeRf95YJMMAkAJL+NL31D7HP8YeMUJLvg
+4Wfmf0kdB96/t9ihw1vLPe9dlP3e4Jl+8LLyn/sfSuCNJObqbuxdmyfJ8ra2gf6z5IMzmJTOhyiy
+F6yV57jp//f5Wd8O2CCX2yh1iDKeTAZjmlcai25DiS8GDHsyZ9M5QyvhvqN1sT173uN6+EL/lLCE
+qy/uDJngw+SJirySQo7ynoPbLpFQGucmpbk15Btjh/XxCi6Ys1eBf5Pg6aZTboevvCLBKann7LoA
+GDSNVmdwOxHA1Dh3h58zHTWehx75gbXk2tr4+xVbzeNsStyY9dD67JiqkvCgqAtSbwQ3oL8Fn3qj
+JVNQkr+xXn/LoVc/7UwvClVGb9xzA74QxBMNJJBEpPn43Xab2DpLZyACQgxDlEkIGQRKtdrNsQAA
+AACwSCIAIDENEw3lDBrDNiB8HRVnt0SbsLkhFtVFxGsheAh2YurAyNz3NiBYNrnI4D9rilFR/W1x
+Fbk+iUymvg0IX2aTvOZPxkPFBN1ROjEeQ4HJ85HQG1KGPPWsMEL9tU8yBzo48BDcBgScYgIJLE4r
+z4GBMeARUwf1dKCxDQgoj+PtWGaLR6usK8YkXgz4TIbpdG+g8dky8NLKMA1ENcJAZgaL4bGJYfpJ
+apBAcHwcHBxjRJCxYOxH7NQa8G1AWOBfqcA7w2R9lVQXqDESLQQE2bB9GxA+LhmToCBYj6de+2lU
+GSHjdnCcm8vatwFhjFdD5gMT8EZdg+TpX2m3AWE97QP+zhyyw0LNiDzEdKsOAj3j2AYEt7UZHzBv
+EDQ6GJQS3ANqylx4Vwi6RRaiUMCSmKJuJFZ9S3nQ/5Gto5tl+zYgrNRR4ydaFWvtsIBIIyAFqwHf
+BgSN41w7adQYMyTQ4eCYNFQCnjuASshtQFBQNvAIdMAHtAkpTMEOLUxymG6Xg0Pp9kI2oigd14ng
+NtEdTt1IaCzpzSAYEdwGhHKBEty0T6w6x21KUbSxEByVT1ynEfYLBFa6QbjAfeMYGDuSnqk9VD4L
+KUC0ETI1kIqfKgg0/DPTLVPGqV5ToXglZeywZcLOBydEWqHBfWLBsD5GYeW+8aBYj/q4ZjhwLoPX
+Z2NECbvdodpIe6gFp9MIO+drdCNK2Ocz7zTYa+60cXX6NNUE+jQIC9VpHVDlaRAGhKFtA4LFBPq0
+xn13msvBoXifY1FpOoeS8V6jigkxbZy86XZMnPDSLSo/C7ng12YsrPQYoE/JLS4Uz4EaSW/VxdCj
+XlGMCSnmIDkgIuQUtwHhxT/e2IBcis9rWg31wxHVdpQDu/0TjEjvI2vCTj/MhVdRTMrqGa2ktJNK
+twpqkOoVDE1aCIlHLqWbsT8zRSHvexsQLp0ymzApcYoi7bWK2g1/E1EfXjOV1G/YOXWs6MbgplSI
+SpbPbQMCCqNafJKHpahR8awXktmGIgMaUr21/kxz86LOVAEIxtKxqrpN8VPQkL9l4OV2jIe4/DYg
+JMjtNTMI2RsyBjIJEZaKl27xoExRRHq+yeRCrqQUrTha8r5R+dR2EqWpNGAX1+UXrhJWImq3+259
+cJQIFoE3XYXsDd2Ipv5ZC2F8qfTOJvjiBB9vqJP14zFpTK3EstB71H2HILq+DQhf06HamI4Sqx5z
+R9KzZxYClLM50XFSJC3Em8bWfGdYd4YmhiTQjngIvtKR9Couqu2KfNxEkABjUyJGUv1rR3HCA0VL
+iC/kA/5tQFAdE9SXcKzcDTL6+Rj35QwHzvVOjjorjSmcQ/tiI6z0zD0VUWAjSjaTxn+9sIu5q+KF
+rxf2MAWqeA/USHrbqlbJ6QixWNCOGRYkhQEhHyB7vLeYAmi+pjBXEGjMYCra8vM4Vd8q8/8/2zGq
+ehz1OS2vLC16jmcbD1vqlCm34pilput3bMix+naparp+X3ctIL/NWH2vAuQZlJJDOR6vfobV8Pf2
+fKtwOQVpATX9omcFfGbVBRmfFWAxndKWAh4XXKoZXphhth0X8lkNQAwrxHNBVsUwu1DnhZUs04VZ
+DcBdF765QM9xq0XP+bySC3RdoGOYXZjVAMg4/imAawrTcQGPCzJsZhXouNCi5wAxXqBll4ACXijI
+rrwg33FBxmWXx2MaFrkVwy2Zc/bbRAGIb9bPGM8BIL5Z245vz/fIsNkDQHyzjvG/7vi9Zb+ia3RG
+GwB45gstoE5954c8Mv75cx5zcrpeYXNMp2Izl0fO41umZdbPOS6npzWFv7eYrzt+Y/PtOa0p7L3F
+LAxwrjy2c7pe8Vkl3/AA2aOqMTldr3hq1snpepVjcYYFdW75Uuczk17JqZjKgjoy65ZhmDxghvu3
+mDCYicuvHCDuWMyWjJ9a9BygfmXY7ArZMd05rWZYDDrNrPmWQWsKc3MroHZ1VnRMz5izEM54Tc+F
+Qk0XIhy0YM8w1K/ouJDjMcaLWFCH1YJZUMeTsqBOx2IWvu/AqscszDltFixmzaItqdqVWzEdw1L2
+/MJrGb/lAPINg8UtOr7BVF0Ag9UqTaEDq141pwWzkNOzgAvyqG38hqnwGCav6tjKtmE57sXuqAXQ
+rRmXV2CqLuhyK47N4G2LIOSWYTmeAlN1gR3H8jkFpuoCGQarVbYNy3EWPcut2HbJ9AxjySvwXsky
+7FTVqYzPArhrlz3DWODqvlUxLAXesJyW5/s/bHB1q8a8Zt22HcNuOUANru58zlN1wR2nWDIsBrJY
+9ZzTMWgPyGUcxO0btAeIsFRMywDEVHcLtAeMsiuv81sOQNcq0B4g57NLAI7Lt23PcNAe0LprWuVn
+Vn3bYEz1AxS6EqwJdbhSYSXncY0WUnKoAHbADyfn9AzGVB+AHHelZjiY0yzQHvC45VXswkHcFnO6
+VoG4jct0HsNYIG4HAGVY7AFQwWwVDq5u1R3TcwrE7bgl0yBuyzhMDiDDQFyMqbw9QIalwFes1WEr
+MKdZPlUXqOgZC7xtGzbn4OquVXYN2gPA27ZvOcB8pwUAUoWVTM8sOeXA1l2Dq7u+VeAr1rJX4G3b
+qzoG3rDYjtUqDwNx2zvA27Z/5AHetq2i6RjE79XNzVZ2PcNUoD0gDPM6ExZW8uquVTInPMR5vIpz
+OSaAhQtg4bLqntWd1BcgwItjxPf++AC4HJEPQiKNAdwA1QzDfS535M4dB/BzaiW/VDVMpms6lztx
+HqcyzI7FuKSL1Tk+U/0AEpyGxQYI4Hcc4ITTCe57AVpe1TQuw1LxfMcBuHyWmu88j+MA8qqm7xVs
+dqkEfC6vapohr2oaFhsQOW2rOoN5Ra58NYe4AfVp1zcKiTRGogH1yYI6Ba6QrwSx2byS3wFupj8F
+bwPgYcmYcXTIAeY8hsmckcGSMXmcd2Z8BskXPJdx3JRhqTi/a3uAGuaqOeUKArmrNcd5J55hcWHO
+6dgBa9GmrIrXnCVjGvKrvnMcFqcKARh393Q9t+S7MECG2bFaVbBnmCrvwGCz1WK+uMajOx4OSE7P
+t33LAWrbrj2Rh4qOc3xOW/QsQJ5BkAZ+zytdq+TOAHlFW2ScxdKoYluTs2QMZ4Cc57O6cMusQm88
+IGPDPxwRsQHpwGAyOqtRGExG/V3XsJUlY/w4+t87ZGz47/isnA9QYTAZdXgRUnD48TFGHrE6z+tT
+pmMY3GhACo3ICGHJGA+JQMYzd7VmToueXfhMx6CcJWN8xEMKEbHhGEXw+8fD1Zrllq4DmO+6Pa3m
+m/2tQj6rX6qafsmwVEHOY1iNz6uC9/nMzmeaLhZcuPwWIhazjx4vrOa7Fds4Hd95IWIxP+Q3/ijL
+d+uewVIFXxjFcXSIENEhIK9q1Ux/wkLnCxwTvuMXgBhm43PaY3EmtXw+XKFFz3feCQudSvRyBJJ6
+qFhyigGJ+BRDVMUNRrxSrRjxauUfju/gbhk24/xG5FHoouMh5yoZJndM3OIhkcan6zmf8RrmCqdt
+QODUHpjMyem5hjsA8X2bZizfpl3faA2rVYXVHdep/I4LEYspBzDfco7HnEKdz8yCxeQKAuBsr/7j
+htWqBj7D4ry28Rcex1ar2OYKsFjmhAWHSNdzHsNmsRkv3LId24VIByCfYXMqzueVWsgHyJ6CHOCW
+cfmGYXV9hgV/2gaEr9DZM7uGC3IrnrXoGFMoeG8xuUJOW8JCB+CO6XrOVbOkEJ62ASHO43RFq6fG
+b/wcnzGREx4QXv53iH+Mj4jocPj+8GJk9I2GY4T0BkR0dFGEiA7wIUYeYxcfX+wqeEAYEAIQpWA5
+z2VYDK9o1ZsiDkEOm8UsOR3orMXxirgQAFYBmQBINKuRQwLAKzmC4wDA8OwTmsnmeAOzcq7KPHOB
+JQ7XUC5ARC8pkkjjqnELJre9dv6YIxzytgN+ZsbSYHDW+gGIrEb+NnMNaA1QEIAAmQwA03Zt3G63
+ZOqLdVfWC0DoZaeOUVYgaiN0LUCOBDAPaHjqDI0/OAJWM0vcSsVqH/HMzcs1U5gAT+sFsCKf8/VS
+41AAoMcqc70FLToU4ytPAHxujX4A3JG/mxnNqr0AeKjR5RSHZZnd6wUAjEPmyo00djedUX49q9Gd
+qT8hmvFiVQ2AyOMKmD1jqgEJAMVzWTuT4xoCkal8SM9G0uuKDAhgXcEAyEYflsxhop7Lpw1BRAAG
+uCQvvaShbrbC+eU4Axh9cC+FhEKdUZx5XgX2gNddXTS8UZ1rKKfuQ8AmI+Cx0ogA6LyvR0Y1wBXA
+yUUo28EIcH3qOB+lUprLG+OaFOMY1eYt4KF2PCdVoY2X2/ANV3Xkj9fnFWAkQGU5PVSAF4qElg1H
+ZrHAsMdsNEoxGDeAABcMRoBjXMVyw8GerWpvzABsWECmw0I6X3Z3XPWfeCtbWgFUux3X12yJfNCM
+KcCjqlhzq8Vh8ffTSqkwDRmAVMWeAl4fSAjyUl0KTPwHMAPZIdjsgHQen9CE4ViA5U2pmP6KxVQ9
+sgpIodg8ey0x7LYDAqwg9vEy4RQDi9qCcwQDkwlCBA+otjskKbmPsTzsENCrrmsH8VJ0BEKtm0aj
+9X6CkfQ8wUiGRqTXCUbS65ouIYIEIxnjUAhQFyhNXeRTtw7sO0hjwSvsEdlLpSJeKeqLpNn0Ub+T
+QpLq9F81hSSNpOeICagNMTSSXh0afWgkvY4gRXo9FIZG0gvRTfoZIdWjkv5tQGh4RA==
+	]]>
+	<![CDATA[
+	0yjsPoxntDTNCL73jKTX4RVJnRGzjtmCkAhYGQHn40nBbCZr2/0T7WiWS4phqWBz0QJhJ0egrHTf
+M5Ieo8HoPuI+td07oNp+mBxIT/xsVBuIpaLy4WYkPU9hqPz5fqTkgVB9m5H0QK+V2oykJ3IqrfeZ
+kfTEldF6RCq7wl4i2tlKemBm1WixXybFfdhFZiS9hexkfQu1Q/lhYqg8jBfnke5ycik+b7G03Drb
+vtTbBoTejqQHeb+6hiuIjmG/B0Tn/yhj2G2LIfaLx8h5BTiG+WkkPZDLw36PRvI7oNoOwmDSQ4VC
+F7MVgVTvFApdTBxTx8xbwwiUphEl7IrHy/My0Eh6Kc3RmiURCMaSNIYkYBLLkLoNCPDrEFkFVnhY
+upM8LA0rNOMQcVgCVCSvpHSGbg6Szun0yxAZ7236g5U1YmKKqK3yPAys3zDVZJ9vExjwkwRY1B94
+cYHIIYIRQYG6hN9hgar2bUAwMEKK5+lWIQh+w6zTPuADuWR2WxI1fjsITPzecC+qJzgLVHfRClDf
+BgTO7GO7ejnXXqqRtYt2Ru0SxmTijbrGpgHztAhs7hq1SJseT8YUN6bTWNquTvfT1EzTMTPpMi+g
+FkdglBBhArP7sibspwdI7dppVWWkgKdFMCKYynwKXEG6ZjejMrsyGrZn6gPb15Bn7WSlr71sqAQ8
+mOb82ssSLDRYUrnvlN5WHRNDyEju9SIeSIUhdQIuRN/CWq4NGkK8bwXX2e68JHk2S8CDY5qCcVTQ
+eejptA0IXMeeQLM3ZD+weePqsC6274BkbSkTiXTkiyuDepUtzOr1OMkwHQfDdskKTId+bWYN6iAk
+DtPIEHJWU+tyi2YgIQYqiwhEbhXxrA4tLtxzjOb4hsRtQEhINka4uVuLVxEyZIqJ9wPc+TANB4Lu
+lzHM51tUDZeWEIE31fKQCQ+iDvi7X4GV24CA0ob4tb3kw5J8ZJYcQL1IxABRFJ+T3Kf7dJ9Y0nOS
+AYrio6f75MlKn2HwDINnMQyeJSuFQhxD7FFRVmJLLAnyQKiCpWB1BasnUMVPrDrqEXlEXQcyuq5D
+tR09xXIXYzAbg9lTLCtOsdwvtncYt09FvNjdRlK5PD4VcSO5XOxQJHESlizCNSQIUXRjnctJEKIb
+YyPkosxTi+XnqaXAYinQVK6St3CCO+UqH02pgWH1tuXhZH4Snb9t4WReyX3btvyBMeoEBNKBRTqw
+6NJ0gJutpLcxS+bCNWpEqkl2cNCxmSm2IqFdzI3IHgZBqR0cGvnBbwVmBbWJ68HJChDqYxv4yPRj
+HMTBkemRtVNQs3vUNe57IIaQkRzZdcA7ZwayUp1cn+hkWL5gNZBGjYMDRM3uhGESkXxDo4Xcm8fv
+kxO3CUQEI4IoJ/00F1R5Wlng+jRPgevTtgFhFHER+Q+V4NfsaJSk9FwZSRkLF6zPSUsmPKAgKo/2
+svuyhWqKF0s6lgfEA/PxxmbUjUYinmJBdBsQNroxM1EUIk7ycZIOvobYf6PBs0RZSVYKMQye5Rk8
+q9sje2SP7JE9YkEjmYLVQV5Xg2oQ+0nA5sKj6GoufKITxjhU28WLfWmI2kZSudgd5VMRxYt98Z+K
+KGobSWVWOmQRxMz1bsz9sghi5npXcfFuzL34ih1BiLjrK3nKVRi9/W2rRZk+6nvTR33X/ynbq2Fa
+Ur1qOjBG6gYqqf4bqaJq6jgym9YJmPR+ArYfXwGnA+nAok7AHiWxgs1WBwbuMKWGgAQhOWzYgYwq
+2mQg8solYxI/thrwUeO+Dw7Qo2a3YSKAcYkaLUTEPQl+RxisAXVwbE7P2leraNSotcm2cI2vRiXg
+wZINBB/QJgMw+3NoIbDN7oyk513CE0VV4Im6HkdrlrdKSkePikeFSc9qKhGRVZ2tDukpBsFYl+YA
+47F/ESBW3zSe/LcBQbJ53rDL709ZFqCfVyOZhHi4JNLPoFGSUiCVod+RPJ0eeIol8RSLp0D0kxxm
+K9H5U+x9AjnJfRKJTmwmgXqsIfYKmeKTKVifTMHqQCJQArVH9oitQewXvRcuet4Ll3sN+nQf0UdW
+mguP1iC2BrELuUAukOUCuXNygdw5MXhk8DGYjcEs2RHlFFTbUQmq7aisgWo76iW4jeRia9unIuaw
+pOLKIgjRlUUQosJLEOLFV0Q3ZjBIEKIbviIIcRsQ8pSrKLyc4Fu2nEDlKjKc4G8DwrcUMNqWuGhb
+HydPovPdSCqtF8Fz6EXwKzVUcq2S4ybR+WVkzq7YFUgukDviRVH8yItdcVzksyKK4t+Ql6yxxqLs
+p8g1XsU1FlWTqJoMo5LqNcaIFFXTbSmp6a//r1PUXPiUski70Vx4VMQq1LyWeKZkgerbgNBREfFD
+ymJ2I8QD6X0wBfHXj6qCLhkIZ9SI31mztRDSYcM6EOxp1EClmQY8uYBxBxuocN2deCjwP8JdijKH
+XQtMWRQHx/+QDqK9GvDSiKDjPBAHx7voq5egZrdoNIBKSHgEOnAqGcUB1fbVWhKtqCIPS5j1Kuk2
+IMwSGgPi6XiVtOPKhzTkhifqX6mHcqKYbhVz5mHZAa2k9MEaYD3aUe44bl/0VFJuKjf9q4pKiC4U
+w+2ppX7DDQZpfcU2fX42usDlNiAwXpzgC5yvVAxBlNXx1GjLReffZKLzoy/ROfK488NTI/A+sSJv
+ozkJqzc4CSdh9ZmJovioaPHBFMX/ryHeBoRQKBQKJRCyIW4YPMvgWQYvK7HkYnYKfZ1PS2oPwbSk
+ei8tqR5VsOwRS6qkaI/sEUuCROiCLKle8UoFzIVHw08u9/Lz+Rg65sKj/4XL3b9wuYcvXO41iCU/
+i47jEXl0h1U/usOSdIdNzEpU29F+iuV+iuXOOMVyPzlxDGY7IjZCct1j+1REbSOpXOyLuH0q4jYg
+iNpGUkmgLhtJRbzYl8NGUrn03FMR3Zh3nxqyCEIUZ64PvXC5uzFOwuXcBChBiDAWcfEVd+b6nDKO
+DJ5V0I3YbUBw4QQ/T7nKu5FUPEtC5SqWAoPKMkakZ8Hr08tTruJtcAnK3gaExkl0/k0lQSxOWnol
+BrO/bbERspJfzhnBb1tt/bYtMlc1lvRaxkh0/hvyIr37q7Fi1W/I64awK04xO5UuiuKfnNgQGRDC
+l6L4By1FUfwZ5PXZFRshVwVMeuw2IBzuD0XxbcjL487PjZDOL/syCcWrXaF/DbFBTG0+9RPXeBsQ
+MIbY1z+1DQgDIMrqqsn7NhoSJ2H1bUBQTWyElJVY0lPx+kyAsNzBVLS/UaL7nGK5qyZOKrvCxKEk
+Yi4CCFE1dReVq3jqgP98/ss1JTVxYUmRxQlUr5pslP5GeGobEMJtQKjfr1UgYl+LZApWB7Ek3WEF
+3u/1gCqiKMZcfEXMXZwZxlz4T3KYw09ywBezU9u3BKrt8IdtxRTppXh9eqEUZQ63bXS7LAGTmwUD
+3VSS9DavF4oF58KnA2yEXBxS2RVuqewKT7w+fy0xF/7kxC06oFj1WAImNx2qjZZe+V6K4nM0bIQs
+O4mVJfIiPRSvT+5LrPqks8nXaXZrFI1BPmhWswzDfz6fsHwfx6GkbQPCwW3ht6Sz8WgbEFKg8LUd
+HJyWYO2t1YDoNEajhr0IlQvXeEgkVpxysw0IiE6DQJvA2NLMITu0EHHUWNPoJCDSiINjGxAYptVQ
+6hovDiLFuUY8BBXigbRrhAJnwBTFN9w9hCG4ajAXvktR5vDwTlgYEeS0yX3PRJSwK2jIG5adxKq/
+agr5eInCPp4uDA19kZ4Gr06fNusGOM2zOn1axwT6tBAn/TQvcFloOQQjggxHKilFZAVWmp/c7WSs
+xXqXIlv+rKBy+vlhy4QGmJz+bUAIJUhTDBWJUzzlkurPDtVGztfAG5tNIT0rziY3CBFvcBYMlBMT
+mHgE3ab1J16paxS4jYkGyz9ZtqBm4r/lSMXPuJ1Cg/FPyicCHto0Ji4FI9+t5v/K+FrlGjYX30mt
+psTpD6n3oyKei8fLAvT3KXJynHpZEgU+ph4pfawCgv4oLUgigl5A8DiQOoyqjlDPmBFEqGMqjBao
+uwMNivYB9Xbgoc3urk1Amfbp4wD3lp4ODmgHUKd/A/kL7fSTCglpb0cdlxWmm40KB9MrJO6LJaZT
+SKpmonZ41JjfFOndXUMeSdKzu4YdW4laYpaiJV+L5Z+rXQX3vWkTDOZTEWHs+FIpdQG4kVRcmvNr
+mptY9bYdUQybIxMOZCAUT+4aF1SCEL2VwjV+KlcBC1Q1RxmZDITRaYR9GxDYgYzaOaOGxY/OzzIM
+sLZF5PWNaol3UxKrXopUk4yjBCuOCapU2vTgq9fUPObpvyKKE9aKu+VVUuPVZ5j1Kg8HE1x+UhjQ
+pSg+uabkfopaYltbKS8rYHRfpoHdTrvnq8R0FCesmEwpb4uTV18rfSwPj5D3JEdbgGH1UmSqiCTr
+RVQ/LEFhPGjV8MRWcvJmypo4YWdJuDytrTR9GxA0IJU2vVcJK0MujFuAYfUVr6i8F5oLX8Yf1l9I
+ovpJFc0qznLWWI4MHo6JyCTSX68mTthpTJdHKFKrqClL4E8Xq9MfMc4CDKtPTC3WLxKJVU9tROtX
+EVT5L1Zp/TYgaBDYa3JQ0+ULIHGjzPQyE2oc1+VfTf6m5VseZgcDgksQowDD6ifCovLfsrlN8Vw8
+VH4bED6rE8Yn1lj3O4mU97aLdJkGmc2Emcyc8qUGdh8H/2xuAwLmA34TpPgkNutX9JtDx2x0rzKS
+Mla+5L5hN6tYr1qfTyWf2wtg9huSQAKzWUYmCfEQe/InveDKaL07AM+h41bTUlaymxDqbwPCqLPx
+RLp3LF/bKODSbNRv6JYCY5mDNlxuGhf8CrA0sXpqgedwEsLIutF+U8HOXvMjolc/lw+bcrZ1cLmW
+9RtyBiyv+Z5E2vxWExGXRz6PouwcRkLYNiB8Nlh5iEkkpQdlgLsEY0r5tmXiPkqp3zCRf1j/mgj3
+2y6K9SUE2P0SUTbuF7keOmbH0+DeM6RbVBMixddviEljMRNjniRlZjxJSq91rE4/FS3db2gh1E85
+7Bz62avARfAqP5rE6xEsN/2xAQyrlxyO9fajfkP6a6yOQLDyzysQ8IssH3YOXc0hE34ajtVNMWOK
+231K3B7qtxFN/Ym/gZUHBseKBavk8xrq8Jq2hsyE7iTD+gzJTD8qThNiq1lOfxsQPIrlJXdTO7G6
+IV2U3cdwGe9jkvoNPzbPvU/9ksbI7TSIwJt1ivUqHSW1/prs855FA1Ue1WKnz3nvn81YDKbpmUmZ
+CX9mA5V2af58pUU6fVbDsT5EpFZx7Gha2X0KCst9cTmQnqnhLl0BH+BXN1vopcMMnje8zCSSMpNa
+dEx1gjJFGejwmjlidfqSNEZ3vNL9U7HaRO9yIBWylIdQUm5XbNSQprzTyecbkkbGpMsvEx5wiaRc
+1ZjtGmElC8Vwe6ej0WYeV3JwQMLqJWJhiovKgfQ2sBDqkxru0hNf+kqIacxOeQpYvw==
+	]]>
+	<![CDATA[
+	ITeSwWUuyU3x3mCviWEdXjMhMrz6HDnUaazFfe48kF65YnSfVExMMZMQFYqRJ66OsvUpysr9Mpk5
+IfoxpfwLsvh8J449MXSX0j+AWJ0+ZWVi/VbSuJ0sv8WGndmoT5lBhVA/VIetf9knjOewCLwpO8je
+0JaR39wGhJhKrz7plZGUHImB53DiWW8IqazSb5oY3U+8atNHbFRWF3EEHPMd2ZwwFVVTdMUEvEcX
+C9R/wVq5f+ISVh64gbxzUnJ3bKPbvcqB9OAz1v3SIvm8AZ5MGuUiw3mY24CAQEPel+shE3bd9Slz
+Ayv9bG36lLQFTfn7k3I7qyHrT0ruAqtn/Vc5kF7byt0eabDekCTjZjNsnLJy4eamqBpUjbLCYTPh
+W7Go/EUEGku0wKHyCshhwbigJgyrMzYbUf0mY3VaLbDbNwnSa9bhgvWHEZkJNQeJy7solCli0gVt
+HjrvbHpst21F9U803KWHLkXxzz575QwWx7TtSvcPAhVTwVH5mZe+ytW23zBzCX1eM5qtYqsouy/C
+tFJzSJZfJhRbntVVXLWJfkS1PdF5mNYxDZLE67109pq5RyZEF4qyvqJBU/5+ELyhAcYaywEHJWO6
+Yrenj9oVlpIvEzI+ntUrDNUUuVR2hblXsnSZQeUyvbZ8mCR6yISXTB/LUttUvu4dy894HVyuCEv6
+XaAY7RdaQlw5L+9yID2U41mdDYWnyBlY0epdWaXpnymTEMuS9YYLlyoptwFhRhJ5Yq7QTDFheFnd
+nDXyjpKS+wR9eT4jlipPmjCsnqg1KOvxj2d1zXlzQvgiJsRaVF+9LNikn6RwrHcXD5WXvUQHIr10
+c9Xifj8PpKcRS5W3hMJT/AnLwwyNJJe5tkyfZynba740Jk6IqVhUXiEheJg1Lmt5y+aEy66jL7mb
+qw+rd9rzhkT1m7EP600Ole+wUKzeUlK4lJko7msjEyc0rAnXOOB21a6ofBs+Hqa3uFC8S2Xl6FbG
+QPoFMC+5G7iR2zdfKilBdwMrWUR5+pgBUktJ3zQ/KKvnMgK4XCzcM3b66jlRv4oou98gBSoCMQyr
+c1iJ1otAAhlTJoavr0cGU8xv+w07I8llvqzsU3rCluUPrHGL++F5IL1NZZX+icjEydwF5dYRmE2u
+drs/Iy2ZsPOxpkjarc+390dS2qXDa24DgjuTrwmrfHVjsTG8Wb48z6Bo0M8bPKgOxlzI72wmSKjP
+0w3PGyZwfBUnFtbtqagmRLaSSH/J4T5PniaKjeFXxMIUQfVAehjHAvUrMYfKG1LZFXq+Uf3bgGBa
+R9q0PyZOqDCFp0i76udJjYTVHYbP7ZmKyOoUWazLAkb6vwm5slmvQKwo8k+w3CmuGjYTrmcmIU4s
+GNZvYQeXjNdjU24DgttqcwYnd7uAxbMenBxID6NKnCLJ+bCzhkHuFy7kPeK3xpJeTZywb0BQWWCG
+WG/G2u63IQJvwqYHrKzIJo3Vy+0ObnS7onIgvQ4qcYqs9mi9AiFZoL7CW9LGzAlFaZ4Q08Xp87UL
+fk0bk/J8xl59s5SMNaQSO/0T41ldUzCaQ8rmecNGaJGV3rPxRJJXx8w1NnHf4LBkQlHsuvx7WnTM
+3KPxRDgEScptcYEnsdOvYDCsDzui81844xyenucNQzDBWM5+TO5oXyRExFae/qzPnJB1cFR+UoBQ
+eRtUv8qNRIQ7KYVRY+jFhGF1L0cQIkbxUPlTIft8CAddHtEYOH3R+5CVaJ5qfFqccNZJqDxLcjgm
+py5oM6M64ZLUVZFnff9Qs9cHK1tX9+o4ubj0S2f1MGttlf4YJeX5Gh0zYcb/sVy8LrgcbejnVQs8
+h+bjkAkhmUxCTBEvq28l+nnT1Ep5rV1c+ovFcLvKYTNhujKlvCsmabotslO+1KhjZogRQy/dNLVY
+zzANsVdtItihNiI2QsZcNTMnxAaJavuFNSdEC16fmczMeq1zbMpLZcHq6CSWfrVV6b4sVcDlNiBU
+0C8Tvp475TGMrfWp1az7la12haXnecMHY1P5MkYvnWu4m1j3GaoM6q1HLlMxK3WfRluc8P0uSble
+RNSviD6fv2ECb4IOdffR1iYnWbMpTkyM9C8mB9KrWF5yl6BjJvwMdHDfBgRPp8ymWtBi/TaevJlD
+LJlw86Euf0tIsJLWSFgdY7K8JtgvkvIl95SxQH1OSFT/xPRh/TYgLAZMrI746u63OQjjDTQi/RqI
+zIQzR+jy98UE/xpru78NCCBZpc1P0CUSq75+uEtXJxyV/8Dka76HHONb/8cyMSNdpjpAZsIUR6i8
+aX9Yj0vS2awRqvcihKc9FfHEW58vFZzUwzvUT4yfKhthZQumr9KdzJwQYQldft2oqG9PZMtvCxDd
+9yjMIjQXnj0X6j8ZnPR7TA9cZj7la3J0QlbaMIbbLZGZE85iDJVfUav3MsRA9w2c6v02IBhwl+K1
+FA+756qV8mqE0/3GH3iYa6uivuZRWf1mz1cJ07Q44QJXuLysQfomwhJC/Y2fvHpC4S60hIhiPKt7
+kJLq2YlqiqjI6X43gGj9YRyZIv5ijeU2IMAgKO5jRBQnZDAkLn/5UPBfVB+sXAtytxtsl+Jl1kkm
+URZ8OA2G1UmHfooGNOT9WYBI/6lAcULPZUDlX/Lhm/hEtnzU4yIrFbY7GVB5TCg8RbCEE3yMdvo8
+2TKxPl2dC+8hZbwBRvpJSFcpcQKzyZnVY6mhUKzOkg6veTi1OGFmNV1eg4xMkTLQYv2mANyUmqYJ
+qQKmVsqPizshrh92DkPWqE1dkhIzgrISL8CwunvbdrkNCDgm5flZQvaGsAfSfRnYftNmJFwejGgJ
+sVxJPp9Iidxe8ViukDG/yM6IEvbPirNJRky1iZPxVzz0DCXEuMBuMDYl5pBKytfcQCVCtMp/Q3C+
+yvJRvyEnXj0R0TlWdE+OyismixIO+0z7VEQOG3Z8hRN82Xyh0G1AaEEP0gszI+mFEpv1jMxIegzQ
+xHqZBYU1eQ0Z9l5P3LSDl5H0KpfU2EMLGXYZh6L4XEnaG/r5xQVF98/LyJz0uMtIepxEgrOFrYn1
+oCyCEMF2JL0OEp2/9LUj6ZEFiNZ7kjHsdVlSfdcYwz4SneCIg1zveSyCEBOwYQ5Bwyvs3ktUw90B
+1XYFxFwoPGBXz9aRhyV8w7rTfc+QytUaAgkHm6LIFZjNs2WnPOa27fJC2V5zZqnfkIs1q7gNCHUX
+4c7hmC4vCU1cjyzuhLgNCJeB7rSiAt43Ep3f68bOETDFcftUEhtWpOq+aTFwhmjTY9qXhwtFCSQ+
+Zv+Mwn74MC5RA5dU1O7qGqdk1JGcHicwzQ5M5sMq7a0R8RKrFGy0O7RA4mNuAwIqoXwcoGYUct5L
+FPY5RVAwrA8XL+9nJYjK36wCLhGSmRNqLnfK0119dcRkxSlj6eeMMKcAJ5F8mZJsLA8oBPyINdEJ
+QVrKEy9uKSsphs/t8Kj65mmqfJOhbQNCJuIytBMkRXANMuyLxxj2v/KsjmJenleE5sKXuFaDKUCu
+91tjiL0CHNmLtviU1az77Wc0hw1RS4ilqMV9AdWGIJMQyQcsJ37FaztH5VFRRP2BDfIr3lgiWo9z
+DLF/aLrHqKR6yNp2X1YqyF/xIobRWZlBTjFtMdJf1nNCPAda3PenCYPjHRhuRAm7BotwElZvZzMn
+8lB5D4Jqu1cSnb+diKg/GjxvOGq3KbLrOIciJ2nYLlM8RfAcKiYH0vMu4Ggu/CYD4pwCEUU7kp46
+gl0psotYQ+xD1Eh6AhwJqz/wPOwaVWohpWBoJD2Q0qY/9FrNuu/xolHYV5bUIyvKCOZ3GDslpbGD
+qF5NyeqedHuidhKPXMptQAhNsMokrbhK2lIoij+AbsyVhUQ2ELfzUKo3OhepiaRMVxjWJwo0nqhh
+Ee7PfOXDpF2kyzw5zxu6G8VYutqm8r8lT5/yE+N8c/strIyt2vRrSOerXGP2G246xKa0wAva5IwY
+8CtenOCfPghDC9myT2NAUoSGWZ0+CWzutA1D5WmmiMvQPjgSnR9uRdRnwCXVp31iio2884ZdIyYX
+yKk6IPk82Wp9/o+2AWFkE6tucl5yr3Bgt0MSkK7iQTgCprgNCD5NrLqBMSK9B2wu/CQGSoiI31U8
+D5sLL9B6E6Ih/JUGiOg+u6gozBXK6hORifV/ZbS++yKjVAyUEFcRPIeLVHaFfmW0/qOMYWcaYo/O
+Rm3kBXFOgW1AYGtUY0S1nVKJMw/S+UmEvHFoMp/GSBroTitpAF34h0vxeRi7CQlY0nsQjKTnaKTk
+3kWpsIefFEOTCnskj9ttQGjEYQFC5cHzI2entm9ELCdccRpHynSaqRvgNLnSYWguri80N1aQ0Eiq
+0xfj/74PL1HYIQcI7CxIMX4Ccph5xrJzsMdylHXe8DBHxvJRjtx+G0jftDvm6dMW//nZ/Oo6jbDL
+QCP5oWwO+WjLNzVoB/wegon63cPLe1zLvHp+Orwm3mJ0Qsar+iboFUjKmOydaAqDiKzbgOCOXiU9
+TQZuVZMiuNUXIh/SzOgMqfPpbMMGZDwl3GWheOFyH3G4VR8xnzvFch/Nha9hT/rxrKeMv+K5K04C
+Kqk+s0gvnVVXlwyoIqILBtpGQqbogM2Fx0Q0Syhkio9NaMTlYTd8gYo3QlBtj2Bgp58Q+BXv4ZoL
+v4oc6gT1K5qX5x0ro/JJzWFicmCMnUvxeVByiXV/bbW4/2OO1SsWWO7bralwuu9VL9I7S9jtpeQl
+987gWd28LNga9TsExHiJwtxTEQUUFt+3ASEki0cV0kqSrk4PNqKE3fadBZP6XkPsv7Skek4q7DEw
+serxh0mdNqgiov7ASOuQus+tCB5mpvEhHd0zkqyqJkRFl1h1VgN1BgzrT0rtClOvQsNxPKHNZhtD
+Q1kaCW1WnT5NS4kS2gpJEYmPrdBqBd2S3AIfb7INCPgh9KBnJD0JxrO6xGZ0v0PSFl+zpmMpa3Vw
+z1ME3rTL+g3fygL1NUS+Jj6Wz4DI4rDP1sSqn58sDruYuyosBPQpP+QrIRKUH22aFs/quKHiMle0
+fsMOJDCbFxYElS490/TQYKIGbfMiPW0bEDqgytMwL9LTWviI+WALoqz+dZpPa0GVp5EYEIZGirgM
+zRXKBXJfLBaLxeuZ8L8ppQqtK3Wv13Wi0qb1u+70rL2jR6lO2naO47YF/ZJUuJd7PY4rdfCU2wYE
+BZjCCf42ICxIxatR+dl/aR6i9ikwgATbgNCOl+7MOZpKzHGbUvxEmoFZqYOnYQM1u1HaZBPLQyQx
+gDc0bVaDqJZtGGJf4iBS3MDovG81rDWRQdYQ1PBIbgPC6pVUHy9C5SKlt9WYwgm+Z3gtZHH3EoW9
+t0ys52RN2B9nrDutYwf/9z1gEesxMfrgPzaiaO4nJWRwarahGikP+kOXyX2jsmqldijeHxeRF+lR
+L2xDoV4lX3E2uarbgKCGHPPEW7cBQVTpjG5Am1FOoUrShqng4zFLC07F0Ykp0pNgPg==
+	]]>
+	<![CDATA[
+	3piFGrknkwkeLjSXFR4GVZ6mEb2fBg4guG1A8KCXMUGNlT9Chki/GpOZsCywU/7wykjKQwuVlB5S
+BvUTi21A2AaEbUCovEhP66DK00obmqGRsLnTTAwIQ/vORaeNIi5DEzUMCEMTMGw8LUNQ4FJwJE9z
+V6dPWxswTys5kqdlFCFD+5z0ezsU/CMF/U3MJsJ9AzPcz6LGb6IaNOURjZsTOkQsbWr1+E2X6Pzo
+goFuA8I2IMTMbUA4kCjbgODSOFCq5slPq4VyAZUyCO83vbnCvr5IT+sUuD4NBFWednmRnobB2LJP
+mxwUC1uG8Zm8g3vi4FH51nN4zRlZZsK8lFB5PC91HxPCvukZR6ZIINqYGEIGPyr3zaG4ijNFgD5k
+i7cW24CAtxbbgNDxs5H9M4gaQYwi3A+BWvkPGCIPk8URmVCR5qZ4b9xXLOC9u9BMET5FVl8FRqAs
+3gYEzssVKD1BflpDExBMf2jCKplQj3lKUVGyDQglmSopEYjwDoE8pos0eyp+cJAeBAWG3D+tYUcJ
+6k0mph7zRWHZtJQiLgIbGIRBMxT5R9ithbYNCChBvWkuB4fiuQwrkgoqYgynlT1c2qxjvu6ILIAr
+HmBaohWvE0XtDP5dNh6WfWCUmG71U0HUSNl+9eykLgF6a2NrXip5WGI6Z0jFsPEsneSMySRzyKDO
+c+JozdLhaM3ICxNIHq0KwrB1H5HCXtM1kZmwC+2xRA+nT0lrM8Y/uM/tHo4MftarwZDFYU+QAnZH
+S8xIzyCpbANCzGwboCL/951zGmGf08bpYem6DQj4HLOkZmjKSj/DrbrhuNc5y6qk5GAkh9Mac1lS
+XZw+ZKrdppiiKSz0RnHA9OQqCZSLkypSQo1juhKUsOakU7wzRnPh6ZfxG52S6m/6pELF6jYgpFJU
+lBzsBCvdVDSq9B9IFA6+YaXbgIBopB4TM2lpzEP7ndbR3dalTKQAlXdindGv3lyhDFwrk9LAzTqm
+6xiwpFyBgMcccRSgEhXK6PKlomK1lK0l1XcjStg9Cix30EsUorRP++6701rR+2kr0WRopGgytM76
+Py1h2HgaRxEyNElm0mXW/2knqPK0CCnTaY7fDXBMDpFKyrdxY/w2ICzc7e0OjMuXLcnnWRILLl1P
+JiFucDc/jaTZMrHeUtkY/pPYLIacQwdEBH7TRR2+6Yqr7qttCPXxksEUYY16830sP7/xVTQxXquY
+QBFl9wVEGNZzBgzr13WcQ0cY2xCwspNyOGYCBs0mvm1gZf2pKR+D2W/ovrpX19xuNmF1lX5FHZ6i
+6ni0nmEhpX+VsFwh5XcWdpOVGsYgf00bSz9soMV6d6OAS4qkfkOD7MPqanf6lAhcwYrcixP8VQFi
+dbctW/9bX/0WjMDYVVALCC4JUrNVPBwOqA+Ps28ixpM3KY/HrEGq32KbWA+edpt+VXzAXvTpXyJi
+QkSYLazUSIGM+VK216Qp9Rt2tA6sbK1mBd2zQsAPlqZWyqcOi8qfGngOx66rqDCN99uAMHt5xvJV
+RfWbdkXlN7Z0mfnMfkPuQ2s6e1mgvobOGM9lHA4Rcoon5TCHXzWKcFSeM2HUF0Fg1K88XnKXhWoq
+43iovCx1oxPUZwjksisUAAnekCRpi1+unvWMMPQ/lk8qxThm54acYgZhmE1DWQK/q9BMse0oTohv
+pNecGcaEaBKlpkjxDnNY8QRvGMYq6UctL88zwrUNJUSPDsHl3fIVxir9hwjnYZIrx/oZ5JEJ5wfs
+9jw/bEqRAcP6CoWcQxNzyISSyqP1lfLleQ6j4Ljdttv0nw3WG14wLrg0FaDKkx8T62kYw+2fOsHw
+MYJRzdgGBLQvTPG3B9LLRGLp7wjgleVwzBNNuV0DL2iT8kF0X+NRwGV922+oqQleJaID+2beui5f
+SmOItFvSb67jHHoDo3Q2NYmG+vX6ZcKFAyQpSxKsrLXMq7eTuFEmNtDnXX6URyoWlX+AsNx7J7Pq
+/lkg+bwBtBtwT9T06bOx6Q1FOUpSGmKem0i319yE1Es360Z+UlJyrxR8Pm/QSIrnGZmHrPwEs1Vc
+1zETnkqSU7TMcIzPPRKslA2YuD/SUquYbppachEToqp5eZ7RHsgC9NJNhEXlP8PtGUvGeuiYBQSY
+N/xk2VheOjGOuQ0IJg47/ZgGTfmZdmL19SMfk9jpkxrP+q89kN4Zm1Le7FpCFMOXHKhEdGXBTBOS
+oHKOGCNDMiRTBeMSCCAwKCIUjIbjbVA7FIADRTQkSj5ULjgmKhNGQ2FoFBAKYzEKw0gIoyiQcsox
+5kwwAAIObmV/ESqiFAPaEIkiorzO6uHCxcxZJfWzqL6X6LmaEPX9p3/2a2dx/eJ86l0zUxxK1HWP
+DAVsrbeK2IGqJqwst3NjOzpZTdIF0jTyeAHRHvRSQoXfYv3i4ei9t21lkv6tRFLOrbBIkbzPGJyc
+wPfbh3JN4cIaA7w6MXqq3GxmzxiwOPCFpB0T3gDs5Iq1Kyc05onIpYVOHpQ/Z73XV9tUI+Xj3CFA
+++tqu26X8NbRNrUAwuoBKRMEY1UrgR8VnwqjqtqYqEyhcF685DDcWUiI+Jw/F4P4xnvy+G/tJF2R
+s99D3BIWMTCzxCtcGm6jQr2BkOzLofvcR5oo5ZrGEO+2Yu/zuo5Stcnjg5Z/Nqzok67x165I0uBU
+VAm1D97R2rn+/TPxyx6gJllnBGS2boTNhgSDm1NOYJ+nbZ/+nDtWsoEdCqHZkAKpNuAWDE5sfEa2
+PY0EVQ92+wIWk9+FvdspVaaFEKlWgpWpRVijKjq8dTjvT9Ba4+QgnXxbejfNdWBLW0IDgdo81z72
+kjPDzO+i8Bx6493FANPhskJpTsfkt4sZqJ+qFgxuKE/epQ0IzQw2OIcDgT8kIQmDhaWu+/CY19dp
++/bCS2TsA7h1rxeWpeDgY7uTXq6EAr3vUiLDHZHJd0sp7aZ+7laVhhYgDGQxhkyYbHRVPKBfI8wr
+gSPWPGYpOEEXVOIXS3pY8fnH4Aed0zk8iMhfbMF0bv67kJ6MNeHscjrAf+qTQiklL+OvbauxqBFz
+7yYs7TSu01BKQMYstaQ7J9VRFL5Nqxek+TzjGUk9EynKK1B4u/OgDVen4Gl9sGgNrr7Z7DavBxXB
+4bK1LGohwAV9+JXL33f13foRg1GOiRCxHnvWtzUIpBxHN1WYQXWretCINoSJzJ5cfJD2E1i0JyRd
+IS56U+iupkf//2/VQ1ygqVxutJHGGwh0dS0ulMLkhwDDlBX7zvzG0tUCSKsjsITwBY1g6SgWG8le
+Vl5rqzvAr2O+Ty+mQ13wy7gPzDIHZgRRAy07MCTjpk+7skok5cabOlohzdqzaLrtQ9S5BuvWTH4S
+cJqjYw3Ha/+4ruVU80Kq1SNNcWzYWDaYUUtF3E0LU+errB2am6V/xiGnxw1OZrDxYiDCygbfhNeQ
+G9KBYmMZtozyHzuQ1zZ8R9FnVRXlRUgvDMXEYjMsLxXYlJOi0Xx7swQOOvxj9lMXJ9W/KWj0tcp2
+8WxZiv8xAY5uq/KMnTmgIJwz6gPzci1oboBT2aX6ImfCwrTZ9Fpvnp2wE2SeQl8HiJVyxtwIHgZk
+foUBNaNDFp3GkQluSPWIaRL0otfyLxc3mIc1HwYVpsH1w5SJoeBKTaAFzSudrW20uyGqo76I6caO
+e71VFPugzK1MFB2aUDUj7pGxdLk/r5kWnnJEznYKD0NhIvOwBGZpKxUMUUcPIa6z3Z8FMOqTQAhu
++qQsIaSUKFPay3KWJ4jtbEBSyeq72pJZU5u/do14g8mKjqRNnx670d3G5cR8AiWUWoptLE6n3TbH
+FBRKuA0Lj7QCgHciDzrAok3TT5A4h6T+ZkukuhpH+8ZAT1RXwE/V++TixNegxeWfvo1FxekORMZ5
+hIp6Vx7nRQo05OIYkLzi02uLPYEQZx1fXhROdZGObTGQhLC5TycJh6lPuUXU5/h8UfDW9zFIQN8r
+V+JYLMO/KNpPAQ29nZeg8Gv3TAXAwGTysIkLyfdFLUi+06vAVJGGS3/FtnZ0FlPfDI/YxfIRHMDn
+6YVy7Xt0DZwVMX4l9sbnUUnl9Asko6ewtbA9Pm+qNjmoOBr8ojwEwWVMSIzYGrDBFxZ3TYa24Sx8
+aq65jY+s5aKIS18CzvBaEsoD1wi1OZokGVyY/eGksxHuQKW4WqSiC0PI1bDeLJRDKset4aFnDhod
+PYOv0ga8ZmLsxyHh/jqlF/bFlH5QaHHugJgZkrqGW6VPHi5unhvEQ2kRUT2ok9KFQr4CdcTunzq+
+Ee2EiE4jf8HKpus04sspaWWyNmAj31G5lVlhr61xLuHRUvqEwwsP9HofgW/2wcY9uuroTMJOWALu
+Vuif6DiSZKOQzj3+CNSJTneBQEPMRgFGXaVZAZ2hFKSrAaTlIyW+0Y+dsVVjGzkpjXH/yXSZJzpd
+kZvRNQpCXemY0t7p91RPDzcUR3N5rnQICp3m5O6Dcrxs8ms5+XGuniAXyUT/z3bvxF3r8rYEOsYO
+fYtO0PhWI8Y/lOhMeWNNr5Kb2idTpr4nOhyj821Vrbb06H157/sUqgk+3dW0ayHt2aR+g84p6Wu1
+CW3o9KMfbaS7drQ+8Y4qPEIUVrZJhfesombVWQu55/1Qk7OY+mctuS5H1EXOE27SeaIM1Zzu0SIr
+zX1W35ir1U5dAO+sWgaYZI09H7g6dSsVymoL/F7AKK+L6grLQd3BVE0mBMh/OwQjPvvf49pwbF5r
+8HMxsonSPssC2bo8IvTKAWeST+6meBQmLRZnY1kF12yqqqw2e6UtnM3Z0Q8Xh2/+bd3aWlYwVC7o
+05ZVTWxj4/ZUOK97++OYAr3TIGZLPyXTe3yqWi3niz4mPEyou4hbNnkLIhSONsNv1z3aSWxR1NZ6
+tYnZlGiAROSr4lhsW5FK2c59zl8zR5A/R3exbT5lYQ8fcmCW5XA7fHfWRVUuHNNOpxFV8w1aKDtr
++rx4NxNGQK6oMgJcDl/Yw0t/aSdtGlLNj4gQaE8B6QCOfAnawgpBdwc7J3jgkG4JV0Jvck5zwgOy
+A6B2wxhrsFbMErNZsIdLg2O6S3yqTKZuQRcKIG2p1G7xb3wui0D/iQX4zKE6WNrc7HLgqz1XSFJ4
+fkv0PXnn87i13Fht03rUDwcCmiMcZ+Cir6bsoGY/z1ogQCXSJa7uLxNyDTj65MhDDcT0Tq0EXqJY
++ImKHFbJy4UFfHGzlC/dy3Vr86ptwDXwwadSmXiz1NhS9w5vtajyMFnSZIOoDd0R3JGK4veYIkoH
+oUU878VUdHdGD+Py0Zt+m0eagDSxITJIX4NGMHfYjJMpTZoNdZm2tS0IByWRmIQce85SIANu+JvR
+KgUO4PZ5AXSP7wxnm8xmO09+LWO1/LzVfF+9dXneezkfi678XQm59ztZmW83cup2P1IawemmNUjB
+/Al36lS/mgL0mtQGmug+B8k2SqQ+XMjT5W9GK3y0Vuh4v14GMaF1ROPGe5Yz/fUg8g==
+	]]>
+	<![CDATA[
+	itXm64i2EPys4ISwMk9GqrhYQ4SeUxoOiOTSvX/v2tnMUJDPyKGbz0HaQsU2VL4ut0XPEfjlOvgE
+z04JfiAV/k+eMIkHGKzm9eSN398c43o/V8qJyzG88Jlbr1q1KFaljrr/fNoigv4JAoyGx28+zyTH
+k/3KFHC9KgFEq4nvd4FJxw24O55OUaXl5ykVM+jtvJxiEhhqQHMXZgUM9eBGcjxHE9+mid1fG3MG
+ktfchw/gruYMMJDCw2zIpSE/s1jJZdGQRLNchrRa8bQ8/J35txlBLj2G6evfefdJzfdEUJwGsL/k
+8fgKxZIvxRTFpmsX39EMyyWyy0d27Qej6IgYKR4/Y9LdmwBy5KUVnIrmigtqckmM0Q8O4Ohrqxg5
+Znf3pwGQ1of1shCT4g5QmvDxUoV+6H4FJgZqVwHuVmW3bVTnUG2yT3S2UtWeECd3p5vpNyKSct8z
+H6jhDJEmMT1aMddb+hGvWEE66DobpGKQrVk/haOrWmlKL4EQMwdUIlfA8oBYDSA0a/uqu1SeVExZ
+6lP4mMAT9ojakHyCzYRq3LE6JnDRgkBFz91U64BV+qDB2w39GrYBbXYGxi5ZSUv+HyzRIdhxoh7o
+XWjpR4ChuTQYpJe+wbJ/UhsRNBWOfylHU37soMMwYTWXcbTy+7qCUPwhJFP4sxssCz8voLGjOffG
+Ze8EA/OrK520ijKJHX26ikjA5hjSpy0lwKmZz28kW3XZv0cLl07Kfeqj7RyB8Q+8XvxXkrayC1XU
+hSiKU3st27aC7keSFK29q6gMGQkyjFA4aNVIAPowgvJOoLpshf9QlOKYjtGtzL4HpyH82MGsLG5Y
+8rJKUp0r9W1EK5sVQe+Bjxqfks3TUJZA4zxvngarBTgkq55HzNH0CwjN3cErCuhEaf9ENrnZMzhM
+trosLripoUqpWzsotpvCHh8sToi67zGrja8sXonbKDxvKFipgwtQwDMh2USUbrJFeeJcyTOaitaD
+8meEESTTMMhyc2HZ7RPiuA6ePhDLeOC6D3vWEmGhK0ZACcq5bEjKiML5vHpKUV3iSQWqXSUyqZfz
+1Owy7cICc+sQQEpV6tux5D4Fg/GtMqGDb9wkyjZEjST1yx5PRcO4WizZFEIFwc2Zx2XGjOHuywYp
+4lgKpTbMDBKX6rqUWuYP8KAp/fUv6vdoVgTJZliWsh9w9pBIaKMCOUk7OFqvWGXLzZVWRGa5oChV
+G1PKLFbBb0F9dXNlnadBfikIfCxpZ1ObWj9gLd4MfqKg9DmJkpYrMIu+sIx63hveGSkhR8tis04J
+PsWfwehqOOdUEWsFMFBHJqqn5E61gx66r/l0R88+5XCxWBM05wbbyxARZcSq7YQ4v2bdWRdoBcju
+82UFWM1vn0WvlcniJ7hdWojZsixJiNOraT7juwL2CA9CBNqioTqBVbq6rgVAiBB6uNkAUmu7aGJZ
+lbGtE1SMQFmKguTSO2lGaDoUlL3jAlkCPelFp4hCMv+joBHN38efBMdTGqTKB4NeyhUFMT9fWO7V
+t1CjApwi7lZULxR1saffUtOc1oz3tx6XTWWCt/Cww+Koock2YjBEmJGiNyFpDegsxRCmnoSZyrWP
+P5lkFHw5rsCjF7nhwAfscpqnkgoATjgJVlkXsY3jgT+TTnosKgAzGckmN7BSU4CzTy5UY7z74L/o
+osEtWEULYJZ8VlICTVjzQ2LMmsY3pzaE1qw1wFNl3l1IHuAKFT5W7uNNCpBw96Nt85aQF4RdW/X1
+OUkZYHUNoQXaWeFJgOv0pvAOFqv3kac/SVzT2gBUZwbeZVhQAb/rTvAKRh8aB0SsLzlJoMURxt/x
+0y42COONaxMW+kncOo/m2/DpoOPUrV/U84l3rpaQbgXbyKVAGH1yHSMNgE70GAsrJ7u7hkZZDs4M
+THSg0LG3KuqytD+0kNHhXLHwlOGZkiRwtQ6ol+2ZViUo46cXsvRcHwJZ1dG2g2mdDKHWIvx5dluc
+pDhdFTie+lqMIQGJU6pQhR0syFqnLQNAbz8YNVkDM7eMpNLegyGWueERD+h/HkwrtDCl2llAwkqV
++erSB+GUxHDV3gYDS6I8i2cCH3SC11JQfFDR2bbAKQekLy5hCjVJoo1b+L2gdyqB+ncKuDtAvrn8
+KEoswdnX+M1EfCg93gR7xMdr9kUDRfRjNZpPn8pyrrS1QWIOTUtGj8vHsagMyxFdXyzDEwPH1EHX
+HZEaD5CPfLbyUUaVAeiv+FZ8UY9wq+IyHpZXkWpo9WXmIcDqb1Ez8NAdelxs4uCA/Z9I3nxX+es7
+YnXvPUkVPt7SlaJYK8WR8/pN71aoC7HQ8KLDfhEUIViOmJHjRYHF/tdjz7fVWKPz/Q1UByxBobWm
+o421fGXcKnT0bnhNQyKA5JLtZDPSGs7G6zYFvUOITRX7pOOKNdCX7fIQeNKYfyu/gsRoOCQbv5DK
+c1JfdtS9OHAhf+CtZym6dCdVXDpwzYs30xk3ptz89UI879UVMae7iGPXoNkPeLGCRiht/NXBJuA7
++WT3FjFnIXQhcg36VQOLF7Kkzj8vEV1hzm6zfLjg7hEGsKw4qQjib2LrXnItMySKnV8UZRxnFLDx
+mhDVaBJLajLYDmKGedYRShZ+MEtq4Ga9EO2p5WBDhZvi6BSE8mNR/XxJQQCfwS4o7RtLyhRHoaaf
+D6G14oMbhAToGzvg1JcUNNQpoYczGLTE5y0vqWrROZBrNpw4eQ/9bMQqS4QAr3J+cb9ncmBA0NbA
+k/dLpzZFKDitsG9HGhbJB25Elz9/u7Q3l4DDYGj0O2UV7ROYaMktDeQfnNdOhf8ACZACbDymcKpQ
+epBKrx5QmxdsY2Oh7bkHYLwm9VLulE2rvEIJBhCXtm4GIUq8u37mZBvAZBt4i2lrT00SEz9ylnZE
+lJsyWptjI7njk46B0W9vwUIxEsx4v47W21TLsb3kEzcCNNNVA3NovDf/eW0+sx/Y0XQSpnEqHsKZ
+zaUQhVfwialKhBS2nSMLH4RyA1lCm5U5QP6ea0SUWNFTd4VLC86VTdQfwqPiCDsSDy8xCYQEHEgm
+8qd9J4npZPIXs/BY2yhkPo3XTCbAZDpQE1Vde8XCX6wJ+QcZUyavlfuraAP9mNHUxf0sgjr6um6r
+Cyo3gGuEhVc2Xdf6GptfT1TqG0KFiosjgP3lEBOcIZz+pdntSG7XtNcGbq83ua8FARhNKk9CVamv
+WktPNdGkpJgcAMlFEOfUSm9rsl2yOT8BF9uK8jWFhD6kSfleeiDG0TyEzMaKJlWAN6+2mYAxqRwc
+q19oUvDOgGkywqPK7oxpUtKYnd6DMSl1xXAizd2fJ8ekALK9n0qTAg6u92sYZfnORnbc2i3FsuAm
+O114U+qBFjrzdzZg06MzTg+B5Krp5qjMgdP03Oj0sHlSQY9GMLTHvv1Y6Lldx38i8R2NdP0uGhes
+7LHrTHC0jAtppyjpfgqLSLdUcMwisQDDTH3Zzo9kbHbER4txTAwZAwt+IGZoWMkTF4K6umbqMDkN
+5OcjgeG9zlHwqK89JvPlB6tQIPnPWl8eHAhGEIIDw/K04f/se5EZr9RZ7bXJ+p23Veiq0ozDPIn8
+4Pve9cwAR2uHAcgcRPNtbsFw8yNpCZSl9767Iemm30REhlP65QSmIhjOK8CHBauV1cbRO5GWplp/
+JVhB/xGwntYQpUcYcB/lHJQBgmyZhjicLnm7mLOSG5K++1GNREC53IGj0iYqtLBRXDCvNANxv+jC
+dSGzYEQaEyKtAjc1TqkD/lpkyPOB4fukgdWSciUoDsjaPh4ciOyplmmwjk17/nbOyhCRHJTPmobr
+yZiMr7ObtvoG3j9oFKaqrQkmKjnzUx3sjpWwmkHpaiYwPVg3J1iE5ElkrK3H4aSioXPEZ4HjfgJK
+F/lazxNFaRUCpiq/sWOlKT0iwybFB+bZWPvCLQ74O68JkDUjoU9dji27cKM2e+u4GLidbZdGSxue
+HgtB46D3vUkX37kI2n00Ak5Rd/B/HiFc5YqBcrsw4muBIPKOZC/M4kwD+y4uslRdOIluAjy9ixBy
+/aP0T2BZCII+BmIVIpYd18/reSoTwWPuITUtUpPxKQGXjRjhga9+EGaS0FBYgT1uYUDTWKkSh1H4
+m16tSAsj8cRdwHhF5U5j4NsZFrFP1ENR8Wx+KpuaBzpqDNjlMHodhfeUTurrtPxHk+5Em7N4YuhZ
+KbyHriGKO3UQ0dTECXvIkXunqcMfgQTXBi0NyqjSPu0ULc2ovhKaqsbq/fdwefyKbRwHHu32sSNq
+qwiFHipOD7Z5rbZReY1Sm7baI8HH3tgJcEnx6Wlzp8WIl0rY1/RTIOgn0tpzcQvnZHHck/z1EIfU
+LyjuoFSSo02IzQkSgpMec+priLJ9AtporNK1eSd6Ahy9fgcldEhE7XIbgvR/nwqspJsQ773vIfZ9
+k1neUDdEufMxcB0ySXgdYrUTWFmCZ9tElCwP8b68JYkQPzAWym/Bu5rGrei2Wp2I4nYEso062pRO
+RKERNmU7xDSegRLmJypCXG+8EFzqqal5ie1Mp7ZB1RNqcIjfDIAhRCQzH8MPMSHCoRhC7CC8Sxgv
+gfGWxxIkxJqoMZWD98QHjDLwOSQK4kYMYfLx7CHG7H34lCcR4hKaUzO1tH5UKQmxn+4qhKVeBLFI
+iP59+XzwjGYpshdw3IkQi6c2ODnEb64yDg17s9rJIYa8HmlBiOsSZlh659+hCm55CAohFiHlbJG+
+ZALf2qjEuBBTAJF35mkYFneZJ19c+sLhUDaOUkKlegpi22S/U1Bh8PWySWCibx9XZgbRUXkjLpie
+zFYAMWj6sIWxmQ1FUj+/2QIXn2g8RO0TSpYdX9OaerXiTvEn6FjCo8qSv7BDXKB2yDKxKGjP7pJj
+deAUWVf0uDf95GY6GfPIfA9e88GyEprIiQrATLmF0rhTgEdoKQ5k62k/va88sY55iglRy/2g8NT6
+pQV+T1JgQM+n5V5J4EiZGXRct7i3SA4qMXaxwd4oC4kORNqiYUWA4pulsJ0KLQiD/HHlqmNki97n
+FGkok9SaXthvIZJWKvsiaNO785QMFfUqzDix4Ge0lSFK8eFA4m3v859XcIStwmkYeYAvV8F+Iyep
+7KFVTSS5U1ZzF0UHKmoAecFoiIbKEjpn2xtYw2lFOexBRNecpXWohX8HNeX5wDM+Gbe+TJO1pgv7
+Yu0yAtwXMaABPo0Fjs4XGWsoAOYdIAu2uyiQhdwOBBmrB2wxSxprUryKYYhhnFwXs3oEwAKIZRYf
+/Ri2CAOQsvHZ6Cd18YYGxaD7aqzm5gu6B4BLYQCnY8aBElF0POUXcAQCA7qxXc6SUA8ICCQ9ZqvR
+mDiDpVaDRcrQQkbjlAw6A5OFnsEWPCWCanA16nDwNcEex046g6kDWExxyDRPsxqthZX9bY9fDb4p
+FI1HaWWLgR64ONQWaF1pu7bjmD2wDVZr8oU/aH1Q7UFAYPLDwuf6RbqNErZDWboieg==
+	]]>
+	<![CDATA[
+	SBT/6N1ds4+5o5pPukhA0yCT++GRtLQwoXWNWYBsfVbmAAbkcZEWn4V3ocxynRJCKiO4uJd780Oi
+UFbG6e++pEIF66osLdXGHnhGjm+Mg12jS31KF/+YHPRd4iY9+LAtpXZpSY3klQh5whV+7WA42qKc
+/Kj5F3iCzkiiQYoZjAjkqcyYnHn26QHqQgZjcj9NM2GucydIN7Rk8vn0mDS737znY1lakbu2YS7A
+21BdlkHVecONJNtkpCT2jStZKU+G171LjWljWhHqUXji53EXlB0OxEAcJGZw12YTRl4nRWzo2lr6
+CbuEpAxp/bxbQP28jk5YZZqsgLwOmgn4DIi7YW/XM/wzLAKm3/PJo12nLgEPdzFK0tHUTiUKZbXl
+PuMqJEWIYTsdhiZH0JHX3auw3SVrKZXVOI9HkUx0KPx63uB7ovED1Q/ERoo+u73Bg4JnNtT8Z4P1
+hgYW4byiIamBDVaYPGL+NxiUDkPCBlchagV6kEpA5OYadSZXrT4YibzBPeg1HcgGSwNhtIEPFja4
+DP7LMLVshJuekGfJ5lMWZykR9MAGF0PLN/hzm5wYCJZdLFwY0b9FK3FqsowN3lp/JjXLZ/JBe7HB
+vrYPizJTBc0g9+qf3SiirMSCYB4ObEjpWJjz+NZQS16aXDvj7oS4koQvUrlpWoSdHL5O4zRfwWIx
+mZXhTGm/mwyrWextdF9RMfArympR9hBGgoMpsVWOCqyso2JTGJVbWKP2slVll9izet5PBoNjwIGj
+zRnJwIM9EwUIENTtlEfTsXpQKbRPQmJwWRvRG7wSpFRWn4+6OPDnzcAQnbiQVpqOq/VjM44a2aZM
+VT7BEqd0fT4cGhz3FU7v2Sfmntz7tPHXE7sBVsEadrKKrT4AIniZ+pTLkq2lus1a4h847imVQPCe
+rF7h5feDscqxHXzS7uHdzS5Xv+SdCaXe4c+RUx4kA/Ad+5xJp1V1KZDHgzSkqEpuwkRbngzWCJkL
+SWRDWUQku/6jL2eCsieD0LJ3MIFXFdBvFsrmkGpyaQSVFQHWGE7uAhhvI4g1WByhX82+wuZmajID
+zuDmo4XTAti4JpEgUTciwFLXZ7ODfbgA7hmYPuw3rG0vBbCAROR6xRvUCkhjxpzvhZuu/Ip822LP
+z18BXMWASd1czhlul+qN+hyvJXv0LCOG1uhSAFexiwAL8HcKoAC2y8Z55kJaTr7VpfgCuFbyU1od
+mQEEeAmCwHzNKctJcASYkITV1PTtogBG0+ZbsrsAliDqNQYeV2i8+9QEpF7Pgxq51vR7PONBY5k0
+1KaEpK7lZoNWhTffp0denOKNd9udeUNrjP1gCLJYPdbmv8Jxz9ICGnS7z0xUB2XoSQDs3r08RGBm
+YhTt4LRrsiUGpLy1cqkYSFjNhtRk9oyKLwjtZq2CK5Ui9YxCKQ/hziXSTXd2s9PcY6r6skiNhmCN
+TTxr49B5vZf8TjPgwdGwJ7w1Jux4xpc30LbTU6MQe4Q8gx1eFYYZ9N3SoGM1cwL+Ufx38EhsxFHb
+reyTC2QxTSVNAM2VCu4blN8iwPrBmhSfQOEHjSXIeON/Bx8ZerJsPXAvHqgFz2NRU1VmEDkKxLtK
+5Sb5tNYH/jP9csDJicYPxKhEUzUPuXMIVAN/IIuP/Z+5bNHraqqLWxPF4VCImCIhwkZLMgrg05pm
+YSbp553QADXRwGXuwpymtTrA1PBRzByT0OIRRbiPJOCFId+5aLhTOiVxGX/SyZiXr/cyfLq3mvgZ
+jBToJ8MuRzouzbaKu0fyMlL7ddK74Q4kd20xFjQh8THGBErWVagx9iSvylcuH3ud0rX6uPlZpfja
+O+5QqXsTOlOT9wplTy2gbzvoVzfoRzXuD/RHqRV7ZycGD4Bsti+BT5vQMV2iC6clmo4oiG8UR2hA
+cVhe87tagdCM3yGttKsiBio29kUfBREq/Yt0Ribq0nB/x/+cJB8NawrN+YfDmabSFJcQbogzJ8En
+jhrnWTIuGX/t6RjzahQMLjetCMFG5+fMmRqKC4UeA+rkNPs+gkmf1cQROOTWP6GskUnd6fCqvlqf
+p71AD9MKjqWkvwAhKiACNZQauVHTrX3uGJdqGUUHtsS5DD1Q4DWfk/v655RrjvSVuIhBK139+T7M
+TXlTtmNc6UvBD+qnEebd4/R2aVl3C/kh1IiQvhT//JKapO9unH8RMqFLNP7RAz7NpW8PlgSvT4Dn
+K2sLQiuMk/TVXn1euC87SV9JEtYPBMbc9T7fcEP6uuAYV5wxhtduFx9N2pIl+/bCjY/OAPfkFB9d
+m7gnGvzz73NOeY2/daNN5X3OVB5tLVElFtpOQK6UqFU9WVrATAxUCIiNyfUZsQnKQ9lL0wcH1jz5
+tYEPXFdrW4xMziOqfiFyQtcwElixmjxQDyxKn5NPjod85z0i49jE+mFVLAHDQ6hV89AEhwKnm0wj
+aXeDjw2ttwy34KEnQ0UBs2Qij24U/BDdbHlsMqltY2wkBW2IJfgtXPqJH8w+PIy5U/LbqymkMkzk
+HEsIMWth1h1FJHy88UEkAe3dRhoXvXCPrJXT8ti3r0XTiSGrs8bE0EcwotLf8T+zWbX3XY2twDGS
+dEPFISEGmg4wASgIfCN8nfuoUgTfEqpsgEY5YampSUp2PvmkeDeUf0BBTNL5NlAPA56umhOosGN8
+eDQJFLUaqc8XyNjfzDjPY3Q4wL6jSs64daWbAzlqaZKHk0Vf5skTJFf4axXVz9fRP3x3JrczzOEZ
+StdbVKpb3ArAswbVZOraeB09icBDcszkRg4PTVUf2yiixX+CuiNlacqOF8uINWHhpbsYLwjpvb6n
+TGfMC6HlaYiZv0Ksh0avb7hs5EbVA3w2AcROOFLfugXoddc3jhack1vsYmn4tMN/r+8i8GGEfBCO
+DalvBHF9Hedc/xm988x5r4FtxnJI8K6WYnCsCEzUeR01XQa4vgnoxhKRRuUJFgPXl4dIm55lUcU0
+Ai3DsqcGbZ269oMpSmb3mhuc/w581eAYCDk0iUMdVg2erAv2qPpRg5KgGXzBxlEKOqqgIlP0YXDs
+X+A4GD5yA15peywPjp8O7tEoe8QsTt1Km8czYKvf8zIiwHE0XQaVubQSi2Nq8xuyJH5B7kH54i/B
+sSXuq3cWi9R2t34vkuPB0RmncXT5fcfRPtbGZgs8hN8z9ARFKlS6ELb+I+qLYVgBxpILUTz+9RFe
+djWJI/IH9iER7qRg6m4FtKDC0z9Q5+Z3iRxToA133gqyo+Z7HZy9TNlpcJ8vli7FeNwHBceVwHdN
+lLcUz0j8CjvZ69Vmlpt6FrubBKqCZ5C11SghzAT/TVXGF+/lPUd+eskdE0Kyx2LtIpXW7uCqztGg
+1fabMbr0V9eAYcMtwen36PlmMnTrEtT5oHSohxqU83DnyLOnpYc7mDd3Hwj114mBc7hKaL5Tlzij
+i2A57dVw+go1GrKhm3WFWTgsoBb8aTpcgHFtDhYMlpqxaFjk5Fulp6PNx+//I88ZkpCZhDt3D5wh
+6I4zVCvAl9Ao23F2EwAWIcJcpCZqWeNpl4Th3IotH2qLLIGBQp55T/2mtcfrhrM8nVnZtXjgs93M
+24rLo/GSyIUOPmuKs0mGThTB+GzD4eY6VXA+3VkdR0XNr2uTgi2PEQ79kDN6jDFz6zwGlc3i/SuN
+eLK6rDSlYYNNpAfFb/N40WkRhbRw/acNEyg8zb9/LGpen47NYZjz+t/mEB8BN6owHbkGO8YAbjB9
+Gc/DHYBOPM9m3CCkFjEhSmRlpx9l8RHstLCZO2WyAZraxStXCkTWqLQBqoKkDi7Ak/E9ujOx5tRF
+MrxHV49nucrKDiau9q3HrYUAFYeOjfSv7thSXoF5EgM5T3U4AgZfg2/lkyBlRA6gDKsqn5VL9X8R
+XixG6IGt/V/uL/DgCta0VSe36bcQO3O6iJineKWXqdPezaHW0BG8HYFxaXaPNioIrQhwa3XDiafs
+his0UQ+dPJCVxjEcEi7gAjY5V/jgRvFwonRUUFCiuML3VfMncXnZ0yATCaqG0PRF18VybeLAB0WR
+RJVoa1puBR7qalbkoOJoSJaHSgrwCIdWaf/s3WJDXGCc37Tunnd6UOy/QPCuMTACSpnr97KurUFZ
+rWTkX0DzaLDp39tzARDsMLLrF5Kn9Q3DVd1yyuGQktoMWHDG7Ay+M1m/EFDB08BBWavKUVsJDPF/
+mdy14DHSZf3u4f5vHRFJdaJfal5bv87Vx4qqAYfAxMj823IR15bL6X8CtVlg2Yg0lvV2Yh1luXPx
+wohfw6bZhvSkHovbcdr2uhk7nGTtC5ObCy9svlMv2peqoMKPS/KnWranJjeLjPfSOEBd1toZFY6k
+KHhj7tKSG8avzQaowSzHGXimOZoOcrxTtXHvUK1etmlVqGih0rOqhY3vkoYqxgbT2CUx9xfWjDBp
+mBXem/yNncAueLIesH6UXHs8yojJ4Sxn8YnKdRgVQPK5jLEw/dKdtuR6xKbLoJeBUbIzhP4RsPSE
+SxxMf/7klNw6LqLfO+xulp8/MgWUavfld8imtK7GQl03ctecAD8HG/HIsSC/gQ+VHy834yrxACaz
+2yMXxbRdA/LFkbxK530IkNyE9htARA75ZkNBANluM0Qfs+kEsFDxufj5x51imSublpGnEnxjj6ZW
+PQUOOY5TLpPYyCH35Vz44VEjOLjNWvbk4NaDRPSrUZ2ahON1Gxfd+lVCwdwwuajobRPhFk+pgzxP
+F0bsp9nZyeWRy2Sr4wAqAkeojlTBkYdZ2YR7jP+i8R7LdSX38PqJR0I7uO+Ge+sI0vo2SXsbmcwU
+tGzWMeGJBXwm6RdduW9VyKc2szvbbysK3i8EVCFqtCwhAL/bJ6Q2un444gpTd8wmgXFbZzhthjLi
+4WgCX7IvvYe4555ZYkoUVT7mwaH10tpKyGy18vCSPvB9ngr9x/3VwxXd2BAOyWJopXYXffrsRobT
+Ptv75Z/lFGM51WRVUKJc7sL8TDfbl+YoXDswOEUgqMso5RvdLkVgSbyCA1EEfdiqZ8jWMaTITzhU
+zKTx1BdMe5jomaZSOTJ8kahLoK1fqjMnpgF9mrL/sZKkniQOQJ2lYAX/xRo8x8gGZtfuF+YX7D8u
+WqOBdf3kzRssm6W5npWKgYTwSK1Lz6klU2O1wIToNNi2vcaqJlwTEmshH8Gw6Dmwgt3ohQuPy1M7
+CubV1d2CxsroV7kOP8Dpbp7AnVmHEIGNHhxBBx7SFxN2R0B5a9j6tfdS3IFG4bEbQ4Lp3WJXd+xM
+abKKXtVgLyplE0Ek62InU20+PdaKkLed5HQaQfpQttFwetuGRN50eqU2EUsQhrA6aq1APPSaJy0v
+IaOxJLj8oxUJfE5VSBEUQeQzst1TGqG0eoGIMg9hOQgdZWADtHjv1gViiD+5I+vmigQuILAOjg/4
+5CAX7XbQv1JCJOYCo28lA5eIfToviZjxYFC1FIKFX+KdFP+OwqwyO7725tpTw39mwQ==
+	]]>
+	<![CDATA[
+	Y9Jqs840rU4zHQblvv5/ZmBpAnNtNYDO9HoTIg/KlPZiYjSe2kcMWBvU+U4Qas1MJoN8VTfA+RHB
+PdFL4Sq1GwegEeTagP8OKP8yc09qlxmNczhvUlZfiaFONxK0QTuq1KWpVedKRymtnOQ0AlSsSacv
+99UelvNvap8STKFtMNGjYWBOLnHI1pgvmafKaYDFgOcnsGEjBBJzs2lMEymVklxPugh5j+guaBsc
+5B44tDbJKIVdDdDEoAlDZRINUg+RRwjg1XiEwQZsEf12tIdcBKE2n6YU8sBrwkBUj3Gz2C0LEgz0
+rIEI0rSlwaW/eWXh/pXzfjY+GTucSqKpL9g/Tp+nxRlm5AdjP57WonNeRk3iB2MsMy5hgaI0qy0n
+08uNUgYQSMFU8AycncaP/Z8dx74nZXFSfScVlFo4/rCH/WPDQRn6wl3Gou1dziU/QCP2mJW8+UWF
+XmjmdUNB0YKMFba3qeYtuEh+d9McdN2YJtjm1eelVcWVMnfStKq/4XzOW5t+GCn1TyyqGgx9WKMk
+hYaBxqmqWlrpYA8c0YH5Z8jRRpj0aswyPtJW9QiBm/+Ad9liNVEBpAOfHajOv2TFef2abEVHo4Af
+o7wjwQnLuIkwqXGbi6RghgcBkgzwAyq+KoaB5cMO+CLGIzOjCV/Kd7jhKwrh2LmVUR2RdM4zY9u4
+HFVd9aoVekQ5FbH8g/bCyRP0Qg8tnhTgu9xsHQ9V9YkJ3XHRmufngdOEIZkzAaKvZIPgD9H5JE0W
+p3EiWrAMdLpyHVRIGXkiwTqPfma0J8BqMLCboSjRGJN84Ith7u33/HtHgT5SfawZWtHhCgLy5DE8
+AyPKChziPbY3q9OWTRWXy3Y0U6brIKE7ih57fG7lQL2rP5Sxj7loFuToKF/a+HPi43crb6viI3dc
+3LTTNalGlloCkDf0RcnRKGHoaIGmcZ7CBdoSa9QhFu9wL/Bou6mRt0VYZHhwHBaVdCAh/tdjJLWg
+EAeOOs5DWVs4YjF8EQhi8IuePrf1IqPLC7xREj6oh8jV5sRqzn8iUtnP+NCCVWqXANiUarP+nkC7
+PFFhUC6LIDRxnRJigDB5OfUF8ucwLZFWoSFdKk24CCHsNcXwpnCLHSd/NQKW8OYD7QHOj5HX74gx
+5oD/aNfX5GKouWx5PlZYctQhT4fWbBM1f8qz3qwVOE9IsZVA/g6VrV9QAZR52tOX8YpNWhAz1HBo
+xf0rVLixevDDbdjBnW056laWq14Ek1sAZ16/IT7YyxAiXzijM/n1c4xN4Ga4WW6QVZFlxbDvYnbC
+4Zz43oIlwLQF8okjrfGA4cmoXt2U7AunKEsu04JEJU/vZgzDIc762sKhvmnsygU09knVyOaA0ghw
+aUbm48MRVBhx0WlnDOhYXqCtOO4KYYSeWbHeyIHfqDTbqIvviKJunhG6t4mFKxUjI1CUBM1obFpr
+fapNhfaQqlYn7STE2z5v4m372pggBy8b3iNktqLljus9A8t5oZwDu44Dtv/YFLj13s2JqR9XdMhp
+E385fj3cMYdeGma0qnubWZhzjo681jbAsV7wx+e7SvG2qaPDLamqMzukYJN7DnsqTRkiSO68dXI/
+h5VdJ3kshGhssBc8OmB2gDJSEHKWvFk4Jx+aUODzkxPu21CZnqX9yUBk6ltfKP66t4DizEq5cn8S
+RDFWtZCpvDyX3KwLmJcBmCPAgRtmqe2TlocH7Dr0YByYu5T2tHWpPmY2+7fSE3DoONOoKga4VHj2
+qar7jhoTMqHNewo8WxdLr7OQwP+NZuLw+/h7VWvk4rF91y5f9ZwZlWZJWhqstODCKQ2ZysXxp2r5
+PkQDbCIw2f/3Mh+LwYssSjsdTtgFsGITiY9ukQptyO4ome7SOqXKYuY5KKNr5NwRSgYYW3xv1bzj
+0DK70DKakB0AkmSoh39w+ijl8ZtYaRP5rTuKI3swajZt0qC+KK/lfulKoBZ171nU9/WpXq4IaMw7
+15D88NaMCGgJxji8qnGaah7SU7UeAAos0tpACIFMQsauRLuJI8pEio5jaQLoxctjaQRQIHvq1w4P
+lFKwIGtgAMy/iRVk3tVrgr6CbHfDI2QaCuiHkhJtVcvzAW11dmBbJfTBjuTmE6zEwLkMZuGKERdO
+AA6HMg6U1QT3Nq+L+9GMPcokVcHg7BN3/X6tIlwk3mtwGDDNeZ9DhC187xwDrA0gjHEJHmBaq2V6
+ABEiAMQP0LA1qlMI3a4ikxYwjTkr7iSXiHy/wYR7dxq3kL/DCpGWR/vMDnJrFlqy7eEkQQU6u/wA
+UkeaCz+E9GP/LpNB9U9uLF2CP+SdN/tY5aJ/SO+IXXR5J/8bOUYZv0hLp3LGuDTqNS5pYJfRWjgg
+VW0p8L+aVIwqXMwOZW3BO5+6ooVXkkEwwI4Am9L8+9hkg0TiTaHzHM/2v0ZOPbzo91tDdfJVdQWO
+2ZCTVGyS70TtzXRmngxEk/yT0D2/KqrtdwgHwjZpob03b7LhRwSd0kh+Ed6l5EpSfOsoO6DsUTU8
+T4tQj4iSgzcHSuerYE8ZUVCKRN+IUchfTYheOF10kZm7m8BWGRVoZBPqCQTooSgPo4fxfM3N2n1x
+AGYLqco0fGCOSG4h8eWo9dZ5On6kWkWrcIL2wX6sWTsa1aMBXbfCj10ap+pnvGKe5eJgRjgRTSMf
+E4TuJ9W7c5ocHzir/KcBATm6yiuR7eB04UZTuQ+KPinaaDum5QdcVH3DqEeXAvNPEo8E1FofTG33
+ly9wTnERR2+YowYarLQ8CWVKuE131+Yfi+174Sgmte83nX+I0p6Ntn56m4WzE/dQU+p6lHo9qAPE
+DJZbpajSSgFQ+6rcIZuZNjMHRMDfAzfFI4J+klGYMY0I9DI8WpxFcACaMTZ/xEGlKQ+ltroqL0/f
+X1Spy3kI4AEzAVrq81UktB2RiPqm5M+GNCzjmuxiwsTaeYECKk+GEZzZFw4QYE03dFGihkbzrOax
+qwlG+XqIZGxlMuT5N3VGVKSPo/zejJs9o39PKQHxQfVAXc0LpPKcGBsR636r2F7ckkuzwcu+rWl8
+XyrLpNhGWSvYpghBZjRnfC6Rs+TnvL9APmGY0YUDMi4h1aLRVu+W2mEe/BpvIqn7dBsV+KADTlhx
+BGwBJzKbeTiLKRPvZ4q0fx48zqRiOb/kW+jVaAVVmm9cbM7rNeF9HcjAp8PuxehuaSuiM6DQ7hDu
+qwrdO08O3mOsZy3R2XQKtzFkX3yczZr3e0uNAW9KG4G3yuc5nwSOPDtbrZT6YseOZLuwZn0Vgi5Y
+sg6iXVTYFy/S9gk3PgoOXUD1pyEPdG+qYJgVp5lrjAnWl8OgAwCxRzVgn2+Y8V56himlrJyFUn/B
+wuBibyaCVk0nPKOvFjWvAovls8DlKBffo/tOTTj5Q1D2zaQdqXHCZnQxxARt1H8uxKBaI0PvECE+
+dZCdKmWR//pVf1g1O8lWUr0EhYKXFAL0y/Y8T/2hII2bbmbt8GR0scLPYDEvRqcEOlTfivWYNRAM
+9Jl+HLFFj2uaBE73EhDC7/+XJKiHj665qYwPxoxO28jLsjaAXXmAunIy0atl7m0JA5Vy/RErSGy0
+z5mPW+egazVAYvCdcRyz0gFFZWom1HxodfYkJG4B1hJBAVm1xD4b5wosMm4C89G808RAdg+AtL7E
+x688EbK8NcucbT5FO8eljpegyM9fNLSzhwcy3sk7FLogWo+1mi7mVmH3WvQZyMqgbelTlLypgxSn
+xruljCm01qxABrD695Be9ejOtUE3kCdc4MafF/IAPXHjj0lpQgQ7WcqPFwHAhpPN8Usk9R32sDxO
+f5lxIkS5N4/NYnCHSFUAyisjPuA0pIUou2vsY35iEv1s+5WJXZx4dE3cFsiZLrfHkI0yA3rNeeAJ
+mztcrzgwPdNQDpSW0K8JdG1QZsn+O+6RxC/peLRCAyCqgRZtL3HpjUFhAzVoh/TFFUr/j4F09AA9
+o2biYH94fsAmxCEe9iDoJXMj34WKsohON21/Gy5ANRKKpAcMvo6BPXW3AZoKTD6wUyrjl6RdtDpK
+3sRVLx4cM412sFRHiuHtjWL2QtrJxTcvS0IgWoNaJaoM4UB1Ktdhi6C4JLjMj9pbzk68dj3rl8GW
+7q3WjLspMZPcghnhYQZOcJJVn4sJXBtWdQ1JqGPLW+ZAZdEmOeB0+bDXDUnm+JYfKci8h5p0Dizl
+l2XqnGPvPj1wxZUFTjM4cyPetOu18UR9rw2jLnIFOg8kh9k0xSudmnM4R7tfpKPdYM7WpvVOxQ3J
+Gi3OMm7cGnsQNKLENOiwO06aik24o4OxVV+biuNpNz/UcmqUqd1eF2Q0Wlzjb/TZ2fn2Hk8r3z/Y
+dgKwm5Yg2IoV7X0xb98LIRQBX2sNTlcuPRUJmDvX4I9AbXlBK6Vkg9dLp8thGhs+xIyurALWLmO9
+numplLNzRX4y8RImgcJNXyhKPi+YDXorf3YFpkpjB+Q61uzAnPcDIuo7QmXnxaZyA5+xJRrEyKh5
+AMMTGlXA5YrWABlUDWzZ4jRSxQFzBFkPnGNhwNgGxWGBEW2BzrUmz+oNTmBtynWQ1m6IQiIzHjs4
+8+oDkRngumBAPySS4KRnmjkYnbYZ3KkTeO050rLUSuo/dse6hPgD+ahrWRWcGxjrWH7PxSlV9olY
+0w+VKSuzNjoPL7c4FbspuT9Iq72I1sRfvyqqsHQltauqHJ5AVXiO6f/eaYiaZF9QoUSbL5wNQQIX
+FBeNtDtLvnTw3NdzJNN/Kkq9U4OJQSwbGbHu91GScLBH1O4UlgX2VfmsTykouAS4U5BAWHla1c4l
+5R9dmAghhZdpHKcNYCRP+rtRYPkYNjr9nZ3plRIrCRTT0MFNCnSO+3vi8Rbq0C1SMM/D24iVO7k3
+nnn4R8CkiGO1D7L6NS69vzlrVFA80ik6u63S3q1BOoLcJF4nJFxwiEhB2b22eiT+DDWpjr8mQDEK
+6YCGUsTJbyhcEehBpvDkhi5R1RzfZEJWqIgUmTpVigyiDreaLVAQTvIzkNaEItxvKrR9QgM3FkbL
+WGWQawhGgUfhQY7uuQ9VGJV5aslDvObZa6oFlF4NpWA53h+aVYK9gVZc9u2FDWcMnB7beFWovZR3
+jPOOr3GCrD334zmCOSiTYCRATaUW7PwIhYOjY6FhAFwJeXgC1v487Nvntd0KXJgKSNild6hCQNnT
+7qOBF/4udzBAodFl6bf55FaEkaF1w3Vo7sxfaRo6NUyJl8LxUcmdps6LKVzHUkOxi7N+qLYNKYdO
+r08p1OlUSk6PTqcRykOpDZiYbKEbBjzXyd/JFp3BQBEHlUQbRBLEmpcZMPKrpnRbar/B7SLvSQxi
+7J4piTweur2AywDjoaOBH5bW8kKLi31ptvV61uI6AB1V5PMezPQRc0fzW4eZj6cPPSd2zLIsY8uA
+G3FEgc2eogKlfwtvNSdaMmx4m4AgxsJ++rj/xt0C/npnT4/d707v05t79di973SfVw==
+	]]>
+	<![CDATA[
+	Xo/Y1+v4vDV79Ca/3rLfDdqn7/bqjXtv0N76bk9v3PcG7dV3e/bGPTdon77jr6fZd5t76dm9vfTe
+t7lHz+7bS++9zT317J5eet9t7qdn9+mlffv1beejp/jpCfa7HX56dq9elO/t8K1n9/TS+94OXz27
+Zy+953b46dn9eul9t4kvfcG3p+H7dvjo2X17Sbuh4SjkHAM6bu+tJaBEpPnAPDsGjiIIkljH8Khn
+E7bFC9tPqXSDSYM7OV6OB0+aOAThCukK3grtN1/wRn79IWLIHjOAqx0wbh0SL7dYzFsdjPlsZtQl
+ZK2QeIxg6N+F1ThfI21Cv08ze8Cc2jqEyp8F213GDqc9lrAAxib7PtKJVeUkJBtKnE/MaB4bLlIM
+6xUoOkB1W293G6uQmwEcd0I2CVocOlwocAoFjlfwvLrspg+NgsFLMsUso0MuQrWq9Y2FFHqLpyNx
+LzZtOJJNeBAgvZZipP7rI+uyM9uvUyghkcNYm9AXagz6X0ze9WdmQvU3jrtqYZuX4q+D65+Wfqrf
+NRxd3ECHkl2pvu1zQhsNEY9sRUsz7R6wLmJEJwERgDlB9IlS5vuaK6B7CIOHP4avs5uVaXPahfVd
+ISTvjRUwKd0GJxgExFi13iG0ah1eMadWbKG6xihggqJR5ocB1fU1hYpzt+LFnCCrRrwdS6Au262v
+gxPP9SMaOZSTzn8X7/p1pLSUMYH1bDmE6PoxNeR1TjCA0e6kZbkUdfoaNg4sJm4eBnbYLGstABYT
+N1Z9DScNgdxEsw6mLSj7j1NVtoat86m7wd2V8Ji3LSogAPMabcUIFySG9TIxgBGmHM3TF6gOd+/P
+bOfrH8Mju5ef2MW+MOfTDmGBcTMLB3CLV4xwexMRcEvE4nA7JbbOg/7gRoDsMlxaSgJqwOFrC5bS
+NmCGkcdmL+YwHFqY6hcEQfN0GqpC/4OkpHnllUMvq1TXExquR2/N2LRdmpku65Pl6zVH1nlU6eXP
+CQYnD7qGre7qENtkruFkVVgddSzg5aiYXA2s2FpRgKqkcPrsc9q0AlwX6ojmChldaU8usu9F1mgG
+4awmJgLPkLxFk7lnq9lqxAj7uaItb2tPoW9rnC64ZQoVb1t9kBMMIpzIpD2kfrJlJVmnWn21Z7CJ
+7LK4e3smQYpeIze6NDpXCiH9q32ZHx6dpTTMmu9Zq9PZNgydr0cMHc5vK3jaqpSGJE0QtXAjd8mV
+NGL+ypp/muPXHbOoKmtNT4Tk7dh0sPJ1CAh+b45gTBBxEeQEA/dQjps5kBK3yYLQbR5a8W2bAUa4
+SUoW92zr0GnVehUQ7ityAtmrEh7xy0vVeUL4av0vpUG0B8g7mvpr9q322Tlcf96IHH67CGwgNfrT
+FhRWOxO21eZ4RnUstFjPJPDTRvBXqpxoJKjvfNuekL1GFBUSh8C1+nalmQXqtdgofD/IZ0r9vagK
+YIScYEBbfB4siX+vKVWS8qxvSF//G9LXU8TKNGEFZHCIVXsQLNjA5/YZh13RoqGB98XDPbErPVBF
+5zOwjcMXSAXnlNWh+rMs+z6WEJmtq/GplCOnVPmVWth5GS29nRMLIVqa9JMdnylEC1G9zna1GIV8
+Jhot5aZwHF5mOk3a2oYjgydxyL4drCGpAhu/W6CeaKxCzmisIDLx3HyhXvM6G66pxaHTVvIcQ3aj
+hDltPqqjyraf0wY9ayPsNk4wqMVk34aZE+ImzglxW/8F3EgdSSc5hTpfq8LJLqwMlrJ7Rc52o2v9
+sxuMyA/nu2olJAXcvyNGwDpzzMWNItQ1DQ0ndFTXFzxZl5xgoHAEQPZhJgk9Jyaqvd7AiHVauIHP
+DXCJai+7ONfwdJB1eV0tDrBGZDs8pevTxKeHeotYhZyR+Prkgxx91DgEiTB4VPJ1/iOKVwbMon56
+qL+f8e2rY5S5qqqrmQm21sJNUa7gFhnVcStlsm8Ljeq4xYhaOEpOlq9TRB36Qx4vuuwyCkRL45ge
+3d1Kb38/I2RXUBX6w8iT1klMkt2pLG+XsP6kCfWPMXzdBSrQf2F66LJOkLF2IJ1A9ihk34doKryN
+COtzHV/IvtzFElo5wQC0bGLY+HZF4nuAFRJHZNRWJrHfrrTTiNwhcbhFebsX4J0f5CQnGIitSY2+
+sGJvh2rvVleFhMOzgHfNYn2ux0VPhnd9SYdjtQfRIvTvpzHijw6jLuk1JfEHBw51QmcTeg4kINQJ
+MEgh5Eh8O8lEHitUlZITDDIxGaalB0hKG3MxWO3aejEPE6TUZ4HA1ziL6ighSeFGe5xwi11Eum3B
+Yh5eCrR/vB5Z6iCBepueqvISUluZzm9iZ8OTtnH9zAIhAgRgvrYGmccge3DAeGS7WwvUS8nItB0g
++D0nGJAJTjAgEwgCP+3DxRSxNkq4XWSyt4VGUrhxzpa3cbDAuK1oxQdC0JZpF1SnVfsqGSzlJhI5
+/Ar9ZHe4qu8drpHZcjXT1xsp/xq32HzaEZCT+cVSgJmmLpOf7IwHoy4NMwSiHdFGihMG+hoGpByc
+V8N9ZPBneGuUkvLy/zjY7kmsE5RP2NcwpiHyl1V8jy5GEo8lsaq0vDD06zC8gX2dKV9nEE6pMqZo
+Qj2V4c7HYInziBDDet+aRd5u5hFfKXXnEY95xMuQR/YYMgRgTnpGryOu94MlNRiqknuI0+YVztcZ
+ragqeZkoE53DsJ6MS5TthFiF01PTqFBwgsEGwXk54hHtjE8axwuQ3cV4kX34RLjDEiGvN2JUpTSg
+ZigeETnNI79V+ZvM9HljACqG4mFDdP1SMZq6KIKkOIzoZzsbQEl8cvGRXQHNFYlHhV46okkykck6
+D8NkUN+UV+l6d1UIyGD69YaoEdk9AAInDH6F0aFuODsbckZI3uwM1KG0jdvVTRPqXK8xQoZH83QF
+imbQNm5PWwm4fwbQSg3U/8xQlaMmZnipg8gPIBEKEpk2eHal7XKCgWyAEW6yhkBuAa2BbiO3btxE
+2X9bJhaRrLZ2W1+v+QqJw0ookcsY3dthXYwutzY0c/jLIFpxC3D4jivTScava2oQEm8xH6/LKp9K
+memIFI9nkMl9SrsRqFeMi4MTDMwPu6GtInc3I8hWGyPIVhcNcOt8IrU49BXTO18LEyxLIgx+YVB1
+ngVlnVdJhMGrmB5qxStj1MogWpnOr+QrVXJOzABpa2oaMG3xVEkW3TZu3bidWzduhF3yNpTiGjdW
++hpqz397RyNWB9nMHaIRslfkiy5lEFjkr5CltGHHVeoCMIEJpcGRbEU7gWxJSCVxx4zD+Qj9qZSE
+tELi3+OkfhmaFyEauqxcDeyR1M4YFeDK5QvSyjbkMKyOSlmH3FfMlcv4RbqNjElUe1mw1axmJgVH
+GDykhRG5g9O56oPz9nchqsoJKUAA5ohOovM113xIxdyf37eamShk+hEX6UcMOycYUGKfRkzjNtOK
+b6uYrHBDffDbQANsSXPICp627Ncx/4Yt1GMIEbIfW4wuM5Y21sZWJlCv19LXyVcmMymw2piAe7Yy
+hj/tF2Z4O+QQqpQPGGrEYxRXqXeezLScYECTJJxrtskJlX+8IiKtJiWqNUwdsqGOCCLuWH3n61rp
+fq+6Ht6MVKWE/iBfO4k9EYB5ocBhhAgCwuD3YiRxQi2A4TmG9RMY/r6rCTZkyIeBWGa1GcnGaUNA
+LU+CMJajxaH3V81QyE/MxR5AmHTyE3MXbGNxuHUu+G2mkRRuJgr1ts1Q8TbyEFMMNEQuUblM24lM
+j04Qa/Rn2xddbiE3cpiz4NwBPt7OmY1ihqyzcU/MJ7Hasw3NtGOKO2lTggjBxHVZ2zIUjzBAiJad
+Ub5eM8hY6/kI5a1NTkKSa1T+k68OuQrzXEPL7L4NhKyWGuaOHfYne/w8kCeKoG3cLhs6b3+oVJdD
+entDVo5D3sCOLuTXotKEukrRdP7tjG9PzATUyQe7s8YIF7SN2xEmwuDRSuL7GvexIYMjDN5z2Ii/
+rVnktKZ0fRd5DsbMHvrqtWADDhZsZdThAeoqhW1JfIFYmXYCRBBx2i29/RFREAoFDmPHZp4+UZTe
+Lp4maUjeJqrDvYHqcB9H6ALesNMSWiMZjwzmBAPQ9lGh9Yuy/VXLkNSFQ/ULnRHqcAsj8hiXWW3B
+k5mWDhXoL65aSitCAkKdgfFO+7FLph0ZUyJ/F/SkHXDQIFuecTi/papKWZgdYv9Y0xlUWB0xzUeF
+Pjiyzj8utaetIodsYlU5a+oLCPdSFlBrz1YC7m8rAfeBj1XrlJPWcY7X0MAqUoakNkKzjl9EjEg6
+2ZzMOZFltY2ZZtoxk8KKeNcfeA+TFu5g6JKbVbLPsO+8V1NlHjHERnwTs5T2QB4yLWStOx+BD5O2
+lTDqkpstZJdViBFcVEJr6+MVXrVlXd68l/jbAAwr/g74sqhXW4Z+soMX0PU3BstqVxLEab8DLKjL
+NKpSYr4c+kyJSPERRhulPicYbGYPVnsoESA9Rvic7RvxrFrHYfs+Np91SXscnNMEQqcdr7GDyAkG
+hvSU/2FefS4nGPQIt9Pyso1qjGBE0kiplfq0ygqyDYnR91sioPMz0Nl/wuHFnE6NltIy0Ol/k4Ta
+FMK0h0MG0cItRGQ7HJlJy8Gl9LcWo5DHpbguLZ3CasGNgbC0gZGqpGhUWdF5BTkx7TXdkL464uES
+LO7CNdJ6Iim8ogyj2wilEC43ISqczgkGJ4fVSmIy0z5gzfeqjHu2Bw3s+vDm40k+ldKCavv/rDKq
+Pz404Wpb0tDMJ/1Ddpgr7Dyt9vrXoQL9WS9Cl5Y+stpZo4Bhq1ijiGmKAu5tBXHaDnaDO+wqOpWx
+aUL9Yei8ndHgIvcQp50ACajQTh/JFBsrwkmY6+rylkvVEphZNvOtU+hvOA2UVkaLnO3bQcX83Xy8
+Dnt96HIWg5EtsgbIrFB8z5ZQI17oXl+fyQ6xf6E+J0ljxF0kDF0WRCGkGz6rf3WA3cQOJ5Km85CT
+AzVSlRfWoFpt0s37PWw00si+J7/OgrHDaY9k46QgG6fCCfW2VED9bayv422FjsHbNhUkNOKbH9D5
+jqMSeY1k9V+zHCZt7AWjyzNECn0MUaM/uOcU38AC4spH5J77SD/JmIS6gdCCOuxVlRL2FRLfEgEs
+iHu2nJHgvyZgXoRoqONycF7F55HBEhIqf5PC7RQyVr6OmOeYIzICjo0WecOtv4JEGDwnGKAtx3x4
+xffugAzq5sgJBqPYf9uMxXobJxjIjbDbGitGuIlgcbgVBDbLl1mw8xNTxXmEIus8PI9CDjNfdAmC
+XuxlKlHoNafQaY+OTupsCySBt89Mp0kbUZ2sdgs7nP/tiy5h0SfmDRf+HmMCw4uji5uEQCFpCU+o
+8/JF8yuaTyleGTNqpCrPWru//Yk0Kbx2aKLay5I0UT1Bo0JxAjUuC5CMrmGJJfHO21YbczD1BUd/
+BxqqlC/KQOKQM4Npu47qetNRsHxve5uRxDEf2v/FE/yvOQKcN8CPujy0MhR3XDSdZw==
+	]]>
+	<![CDATA[
+	pSvT7jon9TUjOsW4ODy8oYHRlKxRyBBY8f07Y0kJj1bXHu5rimG9I/UpicMP1DHK/AOJDgcM7LCF
+YIFxk1mst00eZreNTqi3oZxgoBprzjdCTOQTTkniiUYj5q8ajC5rMLZbiK7f6i3IBmMkye6Ebqyl
+HVqSzZ21/lslPOIZAe/6tVII04KV1tdJTjC4HMpx88ACo2vWZTJIS5xXkK3AoEaUlRv5K2t8RgDm
+kE2CU4d6PCCD+ukYZQ72TkC5TVa4T6Fv46M6bi7CAdxIVeq0amcW7nwB0Xn7gAQT8xrGi/nqBaPL
+hxiDtbPXzOEPMwSiFWB5Mv1dDFjkW8f16JxgMDDLcA5LRchWIF50SYnAnd8+kBSvbAimXn6SFG4J
+Wj+UMpAZokZclsS8NMf8NyamzdirjdsdCjDU+9lZ0UN8ri2qri3y1Uv2rrQLu+RtK2fhNg4LjFtN
+ruBmLgjddkI2C6sdwQbZ60NG5O6h9fZYxYv5y3zRpYVTdz7W1KHeiVedFzD8DFeDkf1CxKbdenwq
+ZQ3+Kf5uPbJjBE7/pDtCukmaVYinIeFqZ9yNbSTlBIMHhaPqvKMEi/lHISJbptSfUaZEkM2mp1Rp
+xmYzRCiG4qE0ug0PmyGpiwmGFa8w6TYEWLSchZBekVtvd2XcVRsfQpWSJmUo/l7C1a7BJrLXSvy0
+OcMMG/EIXH//QnEI7qMu49JnxGUplcQdcmTSamiSw3NQhmMVPgwZkcscFScYuBv4CyGG9ZaSFoA5
+YkYfmxVkk4Xa18OLH0CcPoYAzMGYQCyAcmu066NC4WGQfUUJ0Yl8mZzQnpEBIwarvTzoSXsprGbe
+YhojvpliGcVCdtcq7l/SKtGfg0FoHYTIPaSbftZmtJRba8DhadwJNvHw/1m++qss2wvW0OL2rhhh
+xdHFrauvYQs4lOP2iUZvYzGf0QKBYT2M8U57VslmYgCDnn1i3oK+8+D5QQ5y/ue1KCAmpC9GtlE9
+hWLfqqG5GlgWmh6v1n+IIkA6rFWTbFjH8HYDGaqUXqNC4jOVyOEdsibUKb2W+t+hloSmftmYoX89
+UBXCAKLdSq5HH2Dss6VBDpMWrDuVz+IMWmXiGjcJLDBuE//HjVaoeJvAa44kDB7C0fwIh5SNZqbJ
+zDQRKEve1qK84iY5W97mUVzjZsICo5iYdD6TgJV6ivShy8POINoYqlhtmIeQfcFFyD58Ng6v0tsL
+YamVrq+UFFbrhhG6PIApTMvYjCCbUZlnA5jTbmVaLodig/ufcV6Zo6Jt3P4RJRYEmstCkE0Isgkn
+GHCCAfz9QRU6bcpJANQNMQ2idc1YoA5vPl5nzHFd1kocyYYHGqcNvkgLUwdTndSfEUipP3cy06pE
+eMQ/4kWX40ZD8dVbi98Z6hqO/+NWl0Di5mU/o3kvgZcAJxigl8ZlQVM3L0etlLJdVS+hdaEyLo6I
+h0IaO3XnKZBHrO0+mf4zmuntBhh0/XiABfVGQ6zLBeYz4t0sm/mqJph6pkOA9I32TbY7ABM5TfLw
+zwkGsi5Gl5S6Q+Ky0MLUO5xg0FgVnX8joY+hkPhbmkccYehoywH1TglDIXHZlzh/lgexK+3w8/Y2
+HV3cwF3yNoEFodtU5ApuoQFQwXkNabU+pmMie+ugQXZt5OE/brzospOZ3h5j0v49VDjZG8jD8oi1
+FJZn0tZICv0fqOZ71YsUcrkFI6is/lXHyrQJtI/IOwmBEm4lS/U1LidV5+FVEeqIzAOtkPiskn2f
+MmYgBWMG6jzCtDj0tVIDgQY6h414Q3KqStWjxUYBsVEAI+ydCyGrH7OhgT1w7FsVjBVeZyxOAXeL
+U/5hKrr+RSRyeJJEtPyHysH5u8GIXBGKkP06XnQJUc1QfIL4ZCdrRahTLvVpR+bYqpVZTSe+qxbW
+eNGlQKbWfyvz3959Z+fFkP/jJlkh4+bxf5SYLLT0dhcF4d4wX6kSE+oOEqjXuI+R8Gierkq+zns+
+mN55RoPHXP14ycs1dhgweIeN4+jiVhCQdBtiICVuvgQSLRqVf0JrE3qZQEni7HzW5Wz7ztNCoakP
+pKOQl94h00LeCW1EZ7TVGYuJ/XMNy6O/0q76265UfiIUIVuCiusStJD9k3tOcU5ch1xOMPAsDKtD
+woFDnZaVrk/VtBHZcClAVWpOmlA/Ww6oL1aLA6d2NqaE+JlgOcGAz2g7ozKrIZAbWwKJ26kj6bYC
+bdZtI04wcBOVyucVhut/NH228QBM5JssMgNtLXKZdlbCIw4/XnSZYaw6D9ea7zOgGtEeQJPEZvnz
++vi64bPo/3pDXm85GHUJyj6Jr1Zn/5DUN9mHkkP/DqRrdMhlpDiboKS8/OGxA+p/a1lIk6/A9M4n
+vBOy0dqqtvIKmgsrXr8NSaWEQieyw8a+FZUZyRQB3iHTciae6z3mzrRfAX8vq05WO5AQme2sE9el
+Qf1Un8WsIHuHItw3NzSKKaF/WQr9Q1IQ/6wXjC5pmVDMYXcLdQIBJPIA/+cNTbOPiaqkOZpQh793
+UajzQ3+/8eZ82g3ExLT7Xq0GL6bu6vLUpqDEMBL0Wgx4VGjjcdZgs8hjNQpkD0A8/L9eVSnrrkF2
+VovmHP5gYt4BjREemhHtbAR5O4TiTtqN5OG/rcuuUaa4i8D2HwnLFJ9oCKtdMEQoFFrZWl6o/BeO
+WFVWQppTDn3/FzOQ2cp0fisTbJgR7RA14pBZVJUqgTaaqJibqJhjTqi3paJNt1XmhDgjgcStc6BV
+av1LOg79CRJXqcM+H5HHHqOQOxwvuox4TuYsCn+/KcXONoBH0vTTIXOy13QUclrFMTOQOKSjHj0W
+2/RXTgqrzaRiQwcka8z5tB8wGYTqcK+FCTZMOVlq1KicqtLHaKsA2ioARHGNMtm3qbDASILFIaiR
+la6vQ/tsaWpblyFk1fnJKlH910hktTMUC+qFN7VqVRY/v0Scz56UOaw96/LbaDrv0IQ6/2Gct8uH
+Usg3mJLmnGBg2i/XY12lDcrbGw6GqoS0pfHtKRrbuN2Bgo343r2PGOKFsDpirlij8LXNy9HpxLoM
+4p4C9rioJ5h6bKAm2ZjalzmMisx2FjHqMvMoIyDY9V3yIvQ1WODRS84MrisRRiHxAHej+o/dkjjl
+5OH/1X4qZTymJP66iu9ZB5XsX8novIBpNsksrPhQy75V7qxM+ytqzEhVzheFR/McGJ0NFQSap8cO
+X+L85gQD3nnvqR/hJDayUKFQTEKsk5WQeBAFhum/NtaCv5b6ra4C2R3dpj4hDVXKrmYh8Vdn/Prl
+/VT/MEYWIciopb7b+sTcsXU4/6p8aL5McQ70qr7kTKj+QWb6Oukj5GRGW2//rAbxob9fNE5VSWvW
+kObpilIixAjJO5VbI4nvWgCXyCQukUl80/zqc0ulSMhtzSnbYV3mylGhaIgQIt8+TupLVBLOFy2U
+yAsYSShBQ5Wy7p9Hl6kt094Ws9y053rMSSVxSsnF2sSGn3ZdprH2VUFVyk1ihr6LdbEOYWHFl7MO
+uaxH5U+bMWCPgVGygmwGZhZ5HIFTDn0YRt4iTqnSuwodqdCROMFgx+Jw42xocZM8zG6DWwPdRnmY
+m2v8+jyboV9xMHTpiZPvZSmrZvLwX4G0Wn8ABCLONv2brEBpP0KsS8+h+P7xkqz2TCZA+iodhXyz
+hao/4Aq9Il0JIWU26YE+bQR5QraCgRpJPFLqpUSod4l+SHwN3zI7Jxj0kLwLAylxQw3eYVMvsMPm
+K6+4aS6ww3bY0CInGExqMf1rETP0tblQl7WYwbRwXXceNnQO24t9TLWa15bEyfZV+RiWwNtjEcuj
+T36r8hOLUchlt7OUlZOltIaWyOE5wSABu5zauYR4GhGYuaViXqPg9+tjBTvPShoi5wSDFEQQ8UQp
+EeomLyFO+zGTQZ2Lp+UlkikmXu2MT5qzCRbUeVSjMtUSstDcbB3NNykY0dYUzfec+q5amn3UpYWk
+krgLZHk7JPaudsAkjbUdDCLAfbVhxTlNbJl2zMVI/VblUynlA0fiDhGEaV2YT8wfJUzMS47jwvpc
+i4vUKGRVdUK9hIZAbqpi+7bSB7/NRCW8yC/f2D/IkolcJsX0d0sfr7+OksThYxzT1OENdNqewSFa
+PoexkJ3wMjtff6T+Y797+0vqZE4I6ZfR1X8nUWFlrlicqjLCUWxQXl8THxt2ibcr7UJH4hzC4CEd
+T+S8wBkRqAKBXkizM0ZJXOKfhd+6aHg0J1EeSLdB8a0OwQkGtcPj6zMIPKmkVq1kg7DaR21Ef9eM
+TZseubqU/Fbrc+fqe1qsOO3HDCPySNrR/EUYWe0rgsX8lfHwP8PEdem51PQTCORHk7AamGMaVkf9
+Q/b13yW0xoY3shsuu2lCqABVWV8qEUXnW0cj5qVkZAo5weAS+2/zNMJuIy/wt7GHctxoqcWdtBya
+NXWOQK9/SFG4PutFCvkWv+gSfN+z/b4F6nNEQLMKZVZbx63Wr1kv8sYowfls8aJLCiY09ReGv2eV
+JcjuKB0DO3CCgeoQVSWEs0uN027necTXTsmDMWKpFSNEVNi/pTKXvR47hhFHF7fa4B22Umj0ts4F
+dthcmezbOMtVyd7Y0q8LzLHrMwYob4ew3dsbjxddajCWR1eZGPTHqKTUL2OZY7VJ0KP57DugPjNs
+oQ6LRsiORY3Tjom8e+mz9TisZdxqJ9SDMbGqrMw+Iv8zj/nanTVGiNiI4lNCenvrOFWl6iqwCiw3
+NHqbIRaH23e64Ea2n7gFkMCOD+uvaXFo4lGXDa/4Hk6/s11UUCMei91VW/BSMUfQQh/TiDmsMoLs
+x8xQlxZWZNLGLD6yXaCzf1qLBfWOsKbf1U5otf/jdjBUPIb3SpWUFS59nRMM2MfElOBonu4KKFMb
+t4+sgArn66u33KJC0YAwLg6KWIfcr7AqJEgs55RyggEmdbazsfT2R6o2sGGxy9nW0J/iCDM2bcLa
+1iVoQJCdEwy+kmjmZH99nZJAkX2TkVh7WL3Y02TZ920oQnbsQ5US/Hi4lw6G618IhtUBcyErx+2w
+r1GIyG7XGo1cztTiUDgTbNj59IX89rcUoCrTlVgj1GqE2mFUx+3RfuIG4yzcplkh4+Y4od6mYhwd
+KGEYID2gM0IdApJ1yZnIoaeRTFOPEWqpzw6woF7SuljrqExecuFFtJgSwdRhMhhdbj4aeriTsZaG
+eNfnBINCbWS2Flgr9V2rmuFdA5Adf0aqEmLgZN5AoTxY2pW2AtXh7hHFK8N8cN7+JRNVua7GravV
+LNbb1JDm27qGQG4pp/42Ra34tlOh4oG01GvVbs/U/2zAYCk5wQAiQyBaQzzqfMw1Q/+gjcy2MYAR
+uYsboHA039MQXfVPmpkuZzWFaGuTwvVhY0fzRhqbdg2iGnGGZZscOOEWD6TEjQWmZxl5ZU1bkkFd
+5QiDXwh84pUBs6yl2tcR5MS0+ygDybv3Lrs0anS1R7cBETEeztGLh6OEcw01A/Rqxw==
+	]]>
+	<![CDATA[
+	VoX+K7XitF0fFtQl6KMuJe6DxNlWI7JJfql8zij1ThxVzDXvCOlviQX1VQNVKWEl2IjDSEr/cUTV
++QmnkzlFQC5D9n1ZD0+DEwxesOfRDdzK/LGC3zNSInfASCAV1eHOMDGsh9UaDnW4hfL6OnrVq6mv
+4220V2DcVgbvsJE4Bm+jK684HlacH1YyWJvgJ7rcNBWmLXA70zrQDey0zsfrl48teTGh+pfa4ntF
+OoFsFqx8PVLZOPxDITJb1wyrlJgSpbQXSJt+CQmVNXTIBaUNDUy/sbI1ORgy2dqAibxujVSlxBM5
+3CJxfk18m2vm6erMYoQIg1+0Mp1/t+98ogMblaOZx4s+uLuiD+4kKVIVEghWp4A/ioSs+vXhaRTY
+xcXRItVEtcCRMvfEuPORwotoGeDWeVnmtWpZtLtqIyNZlw+/hTro0iBaEizVaYjzzepQ/c4bQLT1
+l0K0L1CB/mvMQpeaBOrRe7qo/zaqqQHr2snN1a1uvvnmnKuCQWvzrvLdd1cFg9bm3vR75j712+Sm
+N09TNffMT36a53mm53p2dM8cPVEVXVGe+pSnqmDQUjdP17SrXj3VVFVVvqqCQWtV/aqq6Kqmq7qu
+qsr3Nvee+U735px77vnJUc5VvvI9885772Y/e9rTvvbtfffe75n706Ne9avnJje9aZomaqbm5uZq
+7rOf/jzP80xP9UQ3ytE9c9SjJoqiKbqiK8rTnprpmaapmm6Vq1716qmi6rpyVV0Fg9aq7plz3urr
+ipo+baXrytd13XvmKdlbfu+Z83mjW93r5iTnm3O/90ZJlHPOd+fzTnfvvHffz372s6dd7dtz773p
+U4/61K9+9avnZjdN8zRTUzX5uU9++tOf/jxP9FTP9eRoR0/URE80RVM0RVd0pz316Zmi6Zqq6Zpy
+latc9arfqLpTdeZ7VVt7e973zM91n+m61XXzjW6Tm2bnM/ctc6d8RtM9c75ulVw33ynJW53zxj45
+597ce3vyNMnTB+BqeqZoX9e1802enHM+m+ZGUcGgBqKCQWkTYM/ozHdqkt4HQGe0gapdVdeOkufp
+A6Dn2bnf6UmmaWNeOefp3En1RLeJcpWT6OkDnA2TPPlKdh/gPM/zVPkm07m1V3J7EzU3up4q9+T2
+5A7gzdP0fVXV3X03/Zl6daO9r3unp9r7utNz5evp0ZWrW11RdZuriZJpYzYb6Rng7Gb353mS53mu
+6NrXNFXXde1kep6CwUyu5ykYNEzOOfco5zwA96e5qihX13XlpDdPr3LOe4AdgL+qZhPg8wKsggFG
+MMCAgsFp3vucOenPN8BpFgxaHRQMTCaYKGUBxRnLaQ6gerLPqxcMWgHM7vtW107OfgBTMKgJBiYA
+NgG2YADiBIMEhib7oB3g46AAiADvAzPTm1L24R9gCwauOcDHA3iCwWgOsAPsM8AOcJ49gNp5gDXl
+JRcM4hgBhPLcRasMQcTFsDH5PCAICnyedzgcDpxgwAkGnog7RnkgYOP2rxCSCSCCiH+FT4KiKEw0
+5sY8smdG6a9CjQjHiDwSLhjl9mBKHgROGHyIEFVlR9uoSnGyOHSRbJy2Z2sP/VAIyZt8BXymAZNn
+Tkx7jIlglhMMWBgu7Cdu8ooRbpBDOVLiEdJHEmj5snM7bRjNc7aipEPikPST3eVgi3RG6zhV5ykx
+Izw9J8PcsIr2MuNOL0tucVCPopEQAZiT/4OcLITkXXZoCtmBYf3o5Jio1Ui0Gr8AzEceE0ScxKzK
+PZ6o0UNR8/QxE/JlJUB8fKTh6wbXhfVgYcJHM0/flYk4T8pdGx+Tcp8fbEzAQkjeHROH5wf5lsSf
+0RF/2vhDxDPD0yoQH4/HMxkCJUk2TlskcHA1M23vIM8ERtAZsDh0gZZBxD9qS1tnT66QFSPcCKLR
+2zYaejOQEreawwM+dua0DQl60o6jB/2/q/k+Zmhl/hihlhIzq7BazsFF/wtF9f1jt1/va/19K0JE
+NkwK2Vdk20jaSYXsyyFO+cung/PGYJpVuh7Unq4/a190+Z2j79lDS+LfoPie9ghwvoCAV5tEgy9R
+GOrAlq71uaTK2USKfTnvIuZ6LfULK37aLw+GLl2jy9nW0oAWDDRzGt29vc8M14fJjJfJJHO8Si5M
+QjAQA5QBtmmqAbZHU8GAEcDfTu4z4r1OzajM6zneo5mnj46YDklYM2xjkjB/dephGLnDRWC5rNVq
+8B7SUS5QIo+cjHAMZ5F3Sh+YewiE55X2fpyl4/wi8UYSrwyycZZ7lEsCX70W4mpm2p58MkISJDJt
+Eaxh/flBPqZmni5aFgeTxEWf5QlykFDPyQjPMIbsdAbq/MrRIQdNGDNpgvGBjgztNAdopBIX0crt
+tTzm+0MjkRuaxIGmGqfvY0qgLS5GhzrIb58+8qXViH92Z1XuzarcY2VllrxoVO5Xf6yM/hmVm3dG
+5d6MCiAWpRvoFKLyHTmhOSC8nIzQryx06TuTEsRMyi2eH+SlZFKqc5+Z6mihKlcv6JiUG1QbmHn6
+VwDFrrTJR/xpxOAi/qiEwZcPFsNx+9hgLBoGEfeEC4bnSxme/ThpCMzJnE97lE9GOHqI0169FmHs
+cNqffDJC0DRQwiyvCciR4A2Qh717MQGq0hJatBPTVqQVVuYz14rBAGUmDBNz88DiOk4wKGyuCqe3
+NO2MJzHGxbGtZGXbGhCRNgAFITKqL8s+1N0BjMhphg7nZ0INQuKRUspqCw7ez9aDRmpS5GwLhATX
+J9+7ig3ubWkkcQnsT/uFCKCNB1rxbSKQ5puwFthMZn3n04UnclcBz3Wo8yRrwqo5Wl6fC6quwQkG
+oE6CEpMoGZLKzRx2zz/xIBbp+WEwpw3pXkQ7tkJIf9fDpB2YP5USnhlIfJV4pw2rMJiWcL6TViA1
+fy6i0HcpzLlDNMf88WhT/zGGKqUhEhrxF5E4W8epQTM8vr4ZI3zGvt19TEwwqiFyt4I4bdWjebpj
+E6Pg95sTDEAyrV+FrkDNytbkZTz84Qg4pZkZTVQvAW2sjdQCUn8D2zh8K3U5WzkVeIkMb6fhzlJK
+PLKYX8SR0pIexvLo7Kch8oqE7N/lWh499hRYrStpjPgLA6uUlBr+3vBSWO0E1BJ/3B2ct/VZbD4x
+XyDQmicL6CSG9YzwlCp9jHxPqLcR0Ja3wVaqbzuNpHBrxWTfNkkRK9OsXX1forBSl1n22bpg72o7
+Po0R/+SLLrcu989+aKb9kDWdBzdII2SuNiGtfB1sda7nMu3rDHk9nsHo8rFjMY8/pdQXkEsgcXs3
+tLi9OAZvg9uCqgQfX2+0SJxXt+9jw/5QtN6OqGDi0OOE24DBa1fI+LYMJO5AW6AucUtLWWCsOk8L
+C2Af+O6k7Rgg/iNwHfN4gKXROBuHx3jgyJ69j7o0pGDnXwoV547Vw70LCXC+wGMiX6UM2sgJBu1a
+C0ltIwCyEw0+OSQi+3UVKDrUSkVv5x3pKVWuKx5SZ7NuM0Wjt338H7cNdryN8mBpQr0ApjDtweRk
+3hoU378Ksdqh8nVY0tKf1sKI3Du4+jdwQiL/TDzXxzNU5rLHKOSPikf9+rt23i4JhTr/EX6D8JhF
+VSnRlDMOqDO8E7LBRFfaMZg5bVEVEGPQUpgkVuixKtU1vJckU6yJS2gtMEwO6nr0Buwj8ktrE3oC
+ycN/LNHWJSUxp3hNc5n28WKwWowP699PnDU0dcubQrQW1WbmX2R4aVSlhLfUiBM8Uv8VWIvRnpCN
+SHyzrPn+Y2bDSRBhn5jPYInzvNy15aCAG6YQ6+QEA5J6qiVYAaJCsRqNZApJBO48JN5cv7YS+Ppr
+xgL1GqhAf8IIVim5l3u2lZcN/flSuL5Y2eAuIWUoDs6n678bRGQzJI0Rj4ChStmAyW8niAZLr0Pu
+DHbOZpG34QnZAhYBmDNgdKjHhq3zbAsm8hiDRq5Wg6dRXnGbeVa4vZJFt32cd9jMRATcXl05YkyP
+/tg6oF4Yubo8pGpEW+Oosy2g7av1Ys5wxJDNCmzxDCXycJzJ/jBwdSl6L/au6+Eu11CY9rVDnJ9x
+y/VSXnFLrBjhVqm84svOI8h+bKnMe8CksLq+xn01jyYGMMKd8H5nQzR1yF+vNZ3rHaiRxEXxW70n
+Jxg4VOFkj/Uj1oZoChGVbqgEttSREsYohxxCxiAzM1UzgxMIIEAgDoaDJOLpgJr2FIADUCwgRjI8
+ICgaGiYgk0ZigjgcDAkCoTCWYiAKyTiIJDG0TgWzcwlYjyZ6G1fw1HiQil5ENig5ZgegYIRGjUin
+WKn4xYEFcNjQqIlCtDdO0QFTcgnyIsMpOfYDoGDSYhQ9tFouS9rxAE76M3wdITJCg0HS/DFhuN7/
+CMzPzkRvPdZ7G5n1xrOmKOVQFshhUSlEX2ioWDhFYBaluoe92WmOyB4K9kb3GAMmPWZwmZF0WU3P
+IZVsMUIraklzlq07oGx2kliEQI7vA4/5dsszPgaKKA0YgWua19PNCE+ACQRlESswcoVgf2mDRwYi
+lxnkvjNQQimaAZiXaEJBiZFdz0QW8pyolgxtmesBLGXnHfZIfl4n4zEZtMzzlpDxFYD53Ii8nnsG
+IgCYf0GLXI+RXwT9Sxs8SiGiBCD3qQMhFNENwLxcJwQEjNxSTUQhzEe1fNGWvx5YKTvrVI/gh/UZ
+j/lCyz8fCYUvAYyfa4PX08pwbgCTEjURMGByi8zKcgY5piGLuctx51FXydkCmCsQhCoSkP1vRApy
+nEYtWWmZ3wKY0R8qK4XoH6FBcx9zLmW1xAbilUpyxsz1GCP0FGAy5Tmyy1EunjqRgosi52i/sVxU
+KcR0iL+AuXVtEQZg5bbqjHhg9r9Ry/db/r6BzfSPMqSgeyI02wTYCVgVggFILkwd1jV/ywQAExoP
+kDd5lnt+ZCbxOPgFNyrLSGfEA7L7FTD/WglEBrwcVS+EFcr+1/I1Wv56YAnTPwYy9LUOMjmZ+1je
+lAQgOsLUYw5uWU/1kzsjwhwdMoSrkWycdirFuwLIaH+jXCTa7BRKhcmRPcdy0aGomSTaUC1ztwBC
+1R9w3zV0iXXLaZE86Jo2MZz7W9dDPeDOwT6jnBRloymnUKgrQI72N8pFok2lIFSYHNlzLBcPhZpO
+4g3FMncHEFr9AfZdpItYt5y2yEPXvBnDuL+7HuoTThz0GcpLUTaeOp+CuQJkaL+RXBTdPIqngsnI
+Pke56FDU7CTUUJa5ewAh0B+w1zW63jrLaZE8aPzbuIR4PQ1nbitocpRLkWyccirFuyLIaH+jXCy6
+2RRKhcmRfY5y0aGoqSSIoSxz9wBC0x9wr0t0hbmUawFf9Lo3wDnXzGdPsUHPKAYilxnI/UeFMKYE
+54z2N8pFos2g2FSYHNlzJBcPhZpK4q1yd2D44HmwXt5c1VVqI1ZguAp16H46IpzcjA4HK7c2LM75
+wskNLd4ux+m7nU75NTByksNynmNRLok4DF+x1XK2H6iHpxqR0oj6dccEcDhBVHgXpw==
+	]]>
+	<![CDATA[
+	YRVAdI2px3FgCAC7EBqJUu6AADl6FBQjkbLYgyPtNbxC0ifjYivlYxFbV0ERPy0elQEAcA5yZrkx
+pbr4dAdwkB9pUiKXqRyzA0TRy9XJTxMIIXt29RGSDjY8kDZU5NtIL8VGCVA+hhdqMN/2yHHtTPBe
+eLff7k21Fq/J8773fvT02HIXJ6BqQherTElYH2uSRUShNrLqm5AewYf3b9tgn3kUHQlugHJhnYoC
+G60eYqYjDacs8R5PMTYhD5QRUqhoU0+74aXoq7VLa+LgIOpg5ukyurFDKCW+5GuFiCoiT/yHovvH
+I5ycGtDAX8QaMgcOjbtSy1z6dlwJ2Rixq76s5mpKxvYgENDE9eQ0VSViBAaMQCZkL6c9FZUCRXXg
+/d8SzoplKROvNDFql3xN7RaD37l8CrmbMTn21yFUKWum0N2L5Vh6jaDaXIaK3GVMjj0Paiip98rf
+Hz8WG1pHiMhqBIogeU2tFm+/cn0qcpdxOdbPkVQta6agu4vJsXoaRAVcDIXcyViOfR5qBFLqxd8/
+HhY3WFMInmVEFCH5mtotBr9z+RRyN2Ny7K9DqFLWTKG7F8ux9BpBtbkMFbnLmBx7HtRQUu+Vvz9+
+LDa0jhCR1QgUQfKaWi3efuX6VOQu43JMnWkiiwXODAooHnZkZCUXOQ46XPI3QrG2rBzIIj8uXjgK
++bK9NVUevRVd8TEnW5jYDSD8Cl3XqfE5D2+HtLHwZC9U+6uAfcMsXaENLWNo7S00otJ7nCScKhoB
+OsLUXDZ/HEmfF7IdcwAEBb7YRqgHZIQcKlrYBUaQxVokorqukE3R2lGoqFQNIuc8J4r4ltvlfzxE
+IiKIoWSCMY/b4gGvoUgtEVuvxYQ4FBRaaG85SaoRBkh5lAZMBQAXBys9xd2IVu4i1BbhI/8PlF/I
+LVrU26GsXpY3eT5TqeMZMfHQpNjnm0U28pa1N9P+qqEnYYwEBLMYclofRXOghySGlZzuKsl90ALw
++09SBDkCLHgGCncPKcsv1bo4VAu1p8+wQ6Xipo3k4iMtLi615/tW/MqtBQj1xGLsHr2Wyh6PQlGa
+xQXmFQAYLL1lTwq4boya1/J+Nnd0HUNHjajuNlErcTs+sqwxyz4KDtUHXHYJ8ERfT+8NK1wHd7IB
+Am2k7wX56MMiJ204S7aw8372dOasM5Yz4OTQ28FGltgaKLvIrlqAQahoFSc+BRHepzzDHjboiRmy
+1GxZ7X7sBkS+8Z90TX/dOmh1Cz6LWUyDsoirtZAjy0JaFHqH1JJmTyOBRmTzkGzoOsUwgrl0ax7V
+8i9zQOPHAoHHm7rhZUuvB1UVyyTqEhx1XeiC+CeM+iaOmAxC1c0cHSjUhOfJyDFMrYpkH5U1owKw
+EQMiSTF4QJilCkZkmJZquEl/FIuDf+jIF3WhAneAJJUeoIkowXBXsntVC+E6e1iL0EP87imUMQd7
+RRnxxLgEjp2QZstiG5ZAPblGuDIcpHWcNeuaRjWYKpCxrA3Z4hGTfABdk5XTAWqAy+EaVuFVNWp7
+cVUkjS5hRNGXUUFDmnlZ20bA0TTlkVYIl8CFh8rSaH9LpHVNP6R1kGw6d6ViCh2Uesx31PsnaxQ9
+KBPS4Px+PwJQOzk4um58Gq3bw3iUziYOUV0H6IzWYaV0pW0vWNMbmrN0I4es6Rr1L3sMeg97eT3T
+I/P+6S5b6lh6ebFKOxIilAZ0RJ0w+lmXA8zSH+ZIW+JjaVfG0tF/nNUqD44vCUw4GXuoOiF563Wo
+eXlMD+XSFc6NOqTWQ/vHL4869KmHUAJrvB/tDzokc5Xqe+jINb2EQowMIJ+g+MBPfzNnz6e6pwzn
+X24byiQ2Q/hpHmU8n6Y/2GoNZPzk0wryGzGiF6E9SMTmE4gMO+WnblTXN5/G6Z2Zn6bUtJOXT1Wt
+qiXkE1HcFdul4dh8Ihk/WuIhmi6fvvkJSn1F8okhJEvqDiE/0RJdnU+qJDiiXv1h2TuFZ0BsCeon
+gz+sd5GJ0jnrkEt7hkN5f9jdo0EYKMoATOgPu0SMthVL6J4ipBxEheBuCIhdgbqdHexi6b8j1J+V
+mAJJpP0OJiDTX9pwdn9YLmtTuDgE9ofdHSkE2xgJUNPm/faHNRIQa3XPVegY+MOK5flUm7/kD9vQ
+RWgz99lP0pjDKpKVzTMHRnj3h2X/wbV9yBVpi4Wa/HTj/QGxmNaQPyzX+1jLO3cl1R+W1nbO0oKK
+yLarPyyz9LG2Zkr96pLE9MFirjYQzTcbTkdNbGEfK3e+XGt3qkokOwq5mKsQPKyLR7COreN+QrXh
+KJ27+tn+sP0HxLYzJDD4w3Zi34AVEDs2hPOJP6zqWTydKGzK4GisnWcCYlmb/rBFRIxLwRuV4vvD
+kh5LJbXiXQk2PI8dlipy+8PCCYhNJe81aX9YyQbEbqf8HNsfVuyA2L2kP8kfdjyD6FTPwzFYvWvQ
+bo7looAcu0iiw97h3gf6/DTQE3HlMp0GSlMmEc5Ju7YQcKFJ0hj7nyu6ggOLRNQgIl5WEL1CsymT
+n42H5sAUPkYLQQ84QYTAzdZqWndNddJbs3+IG/wWIDE+7kZcbSAlcL226U8OFC3FfkUPkOpdixP/
+yJ7VCmJJQQUBqEmDSD2lQeRqIho/WFqFzGuASgcnx5RoWc1xYFrXaNZm2SO6RCZblUEWWmnuW53m
+zA/cstIx4F6CPzaJ97mHqBLc0p9BSy/VIBdGvfrOAiX5DAcdFAEJXGZPII+uC3Cvoj8nfYPbkwNM
+jN/LNezFjv6EoFBlrqhMaL3V2mes0+ZW5G3ssK6TQ2KxgMqTWDnLSoyTtfuDu3m50TAUB6yzgSrK
+CXb6AjRnE1Wj7Tx/DwvknF89PFOEd9/dAqBq7yJexzb6Bzc1h5O6UoeUV6C9hQqBTEyA5oQNFHoa
+djGNFPD5ry5japp04GzkVDkktcWGfChHciGzL3BS7jj1G3homrz7LALYJMQgcK6muHYLREKCrwhK
+WMmw/lx04ng0lVhsgGAtdALYDeClmtPPAyhQSxJkPiSl4YVmISYJOfX7FGWVxZlnyXoK3nH3QgAd
+dZwK3lzgDg9BgJBqNVthpjQpV23lNwuC9ahbahLaR1Uh4Z6NfqFbRWe02EHHtpnsNLYPSK02NqPG
+MNBrML7ZCj1z9lB8D21KnViruNpPHf24PUkaBxCVV6ttQgVK4o3MahqYwX6W+wLFlucGsxzCQfc0
+FYYAlONH06nGj879iHdSCX7gYhmsXlI+nlF/tuGPnks78Vf/jdZ9EKq1MjZZ9mfVshpSj8XJfnTj
+q4bzuPpnipa51Byf7WSAPOrGVeW5PX+ht0okwvWoT4KThoohL1SwjCMIIH2pcJO1oVNfSAJFh9sd
+S0Cf3OesICccEBE20MZMNQHBRinoLAB71B7V8rFPKqM+ecU+PZD3tt0CSTLZN/bqDKaAKtVvSEii
+wIZK4PSzCvOB9KtlUU5WuQ0AEDLl+yl3Ryc861ixWvZmMONHzaJR5Taef7ZSEnU+l9O7CrTJDfCt
+6p9BiOWEcCQK4KYkxzhba0OzhX3JnmMQAscCiOIST05ME0RK+CtsqLDnd7fmy2JORYBtOFHyHyjl
+VJvAyrPEp4L9HUwJh/LxKlhqsDoafxyCJhjpQFao8/cHkxJBW8q0L5NkTupHadqNY1YNA8UgFOE/
+9CRMxg9a6W/WzviTraWQn/NnTe0XglCTIa1lB33J+A76dCMSXPbixV7gHBbL8uWbOLlSGqqJDIl7
+E65BEOIOnyMC1sw/+ATqztTsJw3HeULKX9qCU45Po8r/XGtTQ1ycGg5V0txPjSv7O4P8UsTON3pN
+RZbUCOWRicORZresyemaDUuo1lcITBz/EOyAK3X6fO6Cfm1wsSkQoqkt0RiffW/8PqFwPtTyhaYe
+hPEyE28dXk1q5Y8vAElVD/ldQTj8H574QW44lhsl6nv3gooOfCM3JAcKusyIhkqMvUzM9xs1ulk+
+rVGsSjIooasqK2H+VLAQHVXogj+s8kdDsRqxzHvu5hhgLhN6zlgnQWcJ9oktPgmQtGZ1RZp88eFA
+EIxezkNfeMyfiUESWmGDHUsTCjbSNgGvqRHofJSLnUluMmAxtxxSZT6UGsddXSQmYNb0rHvxSlVd
+6AA1FVarnukn3vWjdI0Hb2PwYwbC5hakb/CyyAKF5ZAvqPO+ruy3GslwNwHde9x2u81Q8MCjdzdB
++nqyHGXh5xZb8Qhr8dx+3Rm62Sd0NLW8kw4Dgpslhbdp3rrAqySpQDTqFZnJTBMNwsZQyBmRJSWR
+LejSJxDcwWj1X0BXS+FC1K/5eo0BkYVNydDF1Ahuu+BSkRUdAZ2F0qAoPP9radf40o9/admWUm3R
+boQzkTwiiHypa1o7TZI9LJCbqaEzmIOWHVPUW4Rqa/uk9CmfLxUwvvBVpjaAbBGOvX+4E5EMAAsD
+ukZdSZ4CRf4RYFPENKE5XFh9Gz0A2U0hJRsZGS5eQcjK/vQgknJAupudAA73Ab7/KYVmYJBHmg8D
+P2L7q9JRONGtz/m6Jty5pakydv0VfIyyFi03FqOMB5m/vGE1Tud8zzqBk8bcDb/cz04kv4L5+66w
+TsDCy9ybcgAKPtOr5TPBByzM9OFMRSes7e5Sthw5NtOLz+SUnZxGcHIuvNdrvgib13V/Hyf5oqA+
+L7lJMdrtHu5aZtW+iJtW4HdpoeV3JMCauz8CUtlu+pdkr3Di/jjQaNGlTe5dukMuphVkFnGKDQgl
+1adkozFuV56Ae0qOaXf4JJ5zVnJTEnPH5rCMAnbbT3YSovIDrBTQzP1meBNOAaY5Kr+z+U9JSQtw
+ls/XHjrt5bw5JKy/5mggsq7rNdECYMYVEwTqjtWVhPDq/nVMiFahXYFXqfYWkDFgBmdhsAzxe7ZZ
+MThcpcKS6WJi5eLF679m4ToGvnyM8uaBbeCsiQ7F9zLWcADduP6MN/+aDNxxLGLSESpKYkH68gvZ
+LTxHghIL5jE68QmZZRON08zNXLO2JWSUvRzSsG1Q433TrZBJPWFG15JlNRKrcovkfhaoONpI+gVW
+oVoYxzpYltrQQkirDogS/8i0CpTe4/7HIAEHpgN22/oR86Zw4KrisPDcysAmNidQoWV+k+uGUhJf
+vMot0BkcJiSnPJgFU1WfSQv/uBspb3amawsv3akxEAG6RBeFYZ9uklRv4asQAJX0hW+0hUnVC4gO
+ACNjwjp4yOzSy3MyxAA6HvAr4FLtX7Ma6BveYvDIfjTelwCY/S7pnI0IH/vNRY72S504y62QnQ0v
+D0mt58W/7WVcX94zVHXemlDJDneBAKSkgimAtEvqXST4wDFr9DtJ7g/XqnXw+CQZ6brpAij1GIPR
+4XEMxfu0fzfqhVhqJUkoUKbMTs2arGibe/mSL2UAMonT7RXvvoffFY/BsL2v7/B7oYJ5Ib7JU4/3
+LNPTTFR409+gqUxo3IHUb/ScNmHXJmCEjLDpcWiMxSbdLfac0seIj4HRv5PUUy5dhw==
+	]]>
+	<![CDATA[
+	BDK4rKgKfot7jiixkyz9CFcU4XEIsXQ9xO03J9ntcN0X2rSLu01P5C6F1iO60EPkbRPkq44UqAH6
+4vDVRFSFWB6wVffZx/5kjpXzDgOgkMkVSewpTaWDl1to3N7WDNQDAmfLLYS6HD0ThGqLy7SoE2D8
+88DGwGT6E2hxN2u49mzUxuOWIK5Yj1FCzFtc7XPvurf11uGzBLWzRrq3WHIx40gxUzBbgmDWPQ+1
+ilo7iAbG0bpYVjcCzqoNp7bQCKeGtBZLiHAYWo7nvPfacMgBldgd5lnxcqcSDx2DNt+bhT9KPG5p
+6AX91ox/hX1mHgvoYQ3wPDaSJhPRGGxQyqm8QwJoggw24Pxco7TIauLqypQPnPMuLbO8pwN2oCBc
+I0ONUcJ0lwExU5SGYzsw8B3LKsz2zbhoumlvbM4z7iZcEx4umvAb1JQo6CWteykqgQIm6KVDPaE4
+rSFds5nhHGpegxHeWnkOFbS0h5rV6i6XpmMykl0kwisyy/KG9uviMPVYI/4cfyK46o1wYO5xoVRt
+hgcoL4jsiwNgit5p+kAORArbID12+SMIc96FBHc6bE85iEgQ0A4qhTMtIAaoNYpTtRLR66zoLuaG
+zX5+N3HsEN8nboCFM8B9mCXvebYscyHWysZlaMr/JToWq/HUPq5F9tgSVYB8GJQMPnFEQagwF2m2
+nTmkA9YWPC4Q0EalxSNUrOzd3fdr1I+c6OjWLLhULHkcx/KJEZHENpQuf0Jdjm0f438UAvpxz9wd
+61wWM73Qn0jeKd4/JCOHoJ3gAh3gI1NNARi/ggKrKwkfiX1croZv2E3GfWkZPVb9HAQkghGxKLRz
+5ZXp92DI44FejBAUucHuZyKiH/QTMUHuG/judq7ayzYjdLpF1SDi32CaUIjisezcH0s/oSJ0OV05
+zc7l3bi+0+XNOiUp+xWqfiIQXFmXevIRbW36ifDx2TldeQVzACNSEJesje70yoKN1OFEpPhFyx+9
+ahik9rGwpJFKetHsCEmQXuQoaPnXKFQHNnMC8DaylPlPQNQJjfnLhL6frfIrjy6G5hPPBOoOi+QX
+enLKf+SvqbSEjlxaymV746sBusAvvw60s8pjUYwgtDO+FAmYAgC3h56fLeeYknaVb7WQBiEef4ea
+eXJ9l9jiZTVISGJ7VSp1jVHNk2JQF7Lnv4Vlb1XGpUALmsSmtZ/pUX1262daX22GHJZq5UwvolW9
+i+65ULFy24oWLqzYpIZFw1Z7i+UVyN1ask4lAXq0ddqWLyyJhjnpkQ7noECehqBJCtoxEy9NGSeo
+ThvFZmniymIktgdnJBGXAYTn5RCE6rWfxOMlOMAkzzSIxuhfAuFeYPU1h62oQp/phDZUak55Hi15
+UD7L647TX35E0DFecxrvMs7ZvK6CX89i6Wh4GPZfbwr2ue2do55lDvCDGNeR5H8tcgS3Uzg2Epl0
+5eFLTy3AptNL/5GqcB0L9ZNH3a77TDRrIPZrj0YLvlvlyVwoqvbAnPILpCchQVgXwP19R2vtcdKc
+hJujLjuZhFzRWhpRe+jNOy7uEZBQntrjgUFmm0uaaVVwjwuitdQeoqBk5HFVgYugerkJXAuwCjiG
+Kdk1aQglVFWFD02gvws4bfYloLDtSZfdNex/M8QAm+YMKgy+3hM2iX178DhQkErm8/YMh/x70OA8
+N0wl3m4kzrfXMMG6XeXtlYZ2T9wuCnXj/X2vTrssNwqWJN/uwfe60WRt7HjaH3nnOywQJ+nOKOqS
+VWTOIOWzvxZOMm8CRb2f2w1WVRBoVjv5dl2VAeKxuDniCrkZGPeFum73hCh/DPsaIyqywNOluRt2
+nSATkTLTbUZEM3Q5sWcyJmoFk0l1EDqBzFww8QzljzTV5gRvT0DgUYmpZHQATd2Wb6V/Hvxak88w
+A+aQMkOkhPhFs0E2yiP8/9RGk8/smUFKmX1BZWd5cJYJv7WR3WE29GDGGkvXRjiY5TYLopSNaORF
+1jiuNV+Ml40htdQ/EKUo/llxWSN9P0li7tiQi9nQwNdrTz7GG/FEq8QQrDyuYOskahWASJM10EYX
+YlMtwmz8eT0S+ZX1JzFZbgxSOlQtd3hW1lGDUU1OZAl0+fsh1lMFhPEdW8v3rNMRBbFSJgi0ip4d
+O09HajY8bz+oMNncxiI9jksSRWSjgEHjNWNeWZeNx7gR/HIYfNXyzyYljPjLAzhm6hHWkasY2ouM
+M3nFZf4mDNhujNpvffIQ/NS+slhHBj3JzuookYh1BLRapoxfTplzj9KKV+pLEFZ6jSrJXbzRX+4R
+rmT3NCMkGQ6LQhCOydJ7VNHv5QBSFa2xXvmNN+AqXZAE1kWC9j31LKNhgVCw3g0MAju95qjA4pb3
+pH/GBwNW3MTE/w/AKA9gdJyyQ+psKKFxAjDG3rUTEAmVge6viGjYwMPigfk2mGeG6qK3dwYDa6B7
+7vFBlWtcr/SLH0UQGv4XCbHfd7lmIAigZ2CL7jpbCsbHI6BlHdhhBARB/up/A0NShpd/41WYpVsc
+2KzQcCoZx9bP+kACUAGXw4y/meCeqeWA3ZhWTIcytRrqOG06JwTPlJpA+QEzyKD2NLAVaSTeOZeH
+YBiwS5P7NLBJZwPKVLTmEwcsMErTwNalGH0xYPXl9FzH0GdHNsR4QMzSnPsO6quX5l/HdW3A3IFl
+YMPvNPg3YKV2MTBqP+DjKAMbIESaYo63K2yGN244DH1pEB9i/1t442pgVjmCOH4JNAy2D+MbxNwL
+ZVDR2/Al5gDlHxRbvYJZI7SY26YfCv8CyWSGAHTrjnRSZ/WQgkEMsdIQpIIxvd4j/ICwy/mV9d3P
+BOuaFkbfltLoryKXP5LmnLsVrD/U8PBXYpOd85K8R8dlaXY0lL/Ywwt2e3gmfI5hQ3leOOEYhKxa
+7k0UqXeFYcAQHYieri0vJvOvkrmN824k1EKLMqqw45lYP4L58+BShdLgE/U1wVTwpIYDOcDmcDdS
+/AtLBav9G0P2Hd3T+cDOspYCjDABE7WPQ7NAPdGl+qi1FFhA9/m/g3CZ4y9swIbTTamxU6UnWonk
+QWbQPum/nzvjjb7KAhbybLU3YlR56tB+fjp4o2soD3Abg+El0DjU+ALeSNVYN4v8savJ8N6NnvVv
+S43UqSfrZPoGKLjw3nAeZIKqxr6q6UJuua7gsWxbYlkTL4Lquzisvxkld1pqRnYEBAHyWzPmdMXQ
+0TL2Boa0DvjCg9A7H7VXze8nh+p2orwh3mrmT/+wq++PrKYokYV0rER90ObjjinGnPZBDDXx2mVz
+dHlnhqOuoucJ2wQBUSkL63GlOa2rLIFsinh/Ie6x8qh7vYSv5wRQXGHQFBp4+lUV5gfUB75vHTKz
+3UUMjftrTKSqk1no6XAYIdz7iKVbatW2YS9/fYYJdccDdsBxOGO9ouvnW2G/sAmdpgIMKgQzwZ2r
+wU52hEqHQ/tqWry60zOh5fRxHKRt24TFDoMH0hvcKMcTwp2YWhQqb23sisqF+9CyuWLCSIdDVeob
+durWIDzOfUgbGRxmyHbYIYl3RA79vjXDIZj4tRwYkB129/zSMztw2UwAMEzBaDckhsgOe6RrPiQH
+BrUCjn42LJUyyz3DUhP+n3m2mW/O1hKFqM7ME+XZ4NKnH6ST9eQoaCoEc18V4Tiq/zGSEAQNCpLG
+a3mhlnKuFW+uRQDFtWTFaBUCHbTyhn+Vw4jq1feHty291mqzEYwqIrtByICYiV236xkM8xUmT6tV
+6XMEwNWhR9rc8brQFnjjIhxLs+EGok0+MguCosEQqM3ez78sHc3l1rRrSRoYki0btrmVlxT7nNoI
+U5rG4oDCd3jotXgu1S6+vKm4EYpAx7C3K1OuOm5QuRDtuCHX3hQHV6aOvCF/cc2uFSIVWiyKTXxD
+bmuyeYBdOFWEl1reRqIYag66euZWdhF57+DynNG3ZTEC673Cew4udZyjGb7VqHlY1SA3J4sCjsld
+rkJ8sZSdwdj10TDMT2QjAb4ucFK8ptmmBCxftJ9MJDASR/AiasRXWGZfqPqIdCGi7pJdGo3CM5zY
+dKRUY1TnWtqr6QSe8wW7uVaqcwJzsub6nOd5FMdQNslmg2zUNDCyQnxGMWuo8zIffD+BLmlsOrqc
+qcZywbBLxa3X4hAmwtv2lvIHPZOokV0GpY1TEAM/weA/iSE5gnc8GRwIeFdRru+SWnbp0d6h4UOY
+c92S9b9HzrrAFfALRM+ml1DGPlTsjy9mcH/6gB5gzZURhEaNeWLpRmf6WGmpkdBkSIsD3TcsTHlD
+hRkyGbqjbamLFujiFL6MHdz4QzfNTJgbZLgb1X+A1bNs6QLtx4Q3Uy5kL1E0zgwUqRG0vpbm2Hor
+1hBVaCn/z06u9F2BU38YTl9LEVvlhrd8/TLWno726CbjeIbMxU/bPYUfb40Ti7dLNvUaw5btlS+L
+fmbCsnL11zq07vW6V4LwiDftK8iwljpkQsPQDuZLdmeXwMebekFIl4X35OsDWI0H5zoriYDxMmwA
+dd28OK7S7JjNDQn7WpN9KgrWttINA6xBxpr8HlULKtigsruOMKwNGiyEzZCFHuLCsSJ3THAheqpS
+D9Mxak5LmGIcT5pSB98znvBDhPVGfdg3BUE0PeSn9uU2p4f5w8LSJApE3tvHh/V2Bk9xcygQ6/lW
+bdgDqUhigf2jxoMIBZQ1oAuwF+GphIajgbJQtoPadxqCS6jdoqU2K61s6hXntm+dX4yZgM4/1X7f
+G8HTFvino5pP3un93kjIP+0nSLTCPMgCOIKt4EPe0iWIWy06GcyBuDFIrSaGhCXlWBKE9YbDdiCE
+UjNNwjolcAeHMHJ4AGdYqzJCqJFzTGP2RqDiL99sajBE4O8hSqLpw3xBiYQuKxt6LghhgPPBI3WX
+dQ5n0v2njPRGkDl/bamOpdfWVQKcuhOm6IXpIGbe6+GaIje9zt7ro6IRl17fc4OoQcqunlQqy2sy
+s2F6F4A6rnJchXhE6/J7phfeMmG0fTm7V45B46CxXud9QRrAUsY+UTN6kbFH91UC2uplAHHsUgJY
+vklTbpG/KqqXDBFsbIAVlFFh6nVjzGbT01csO4C+dDHPs7rvhQD4/8bQ9B7u8/7f3TjuTrE2fmGh
+xFnDZMeE6e/1y0GDBb270tOQXrVUKxLe37SWIifwrdEr0JVg7V7wPjoVGI21DswRoKNqhwiU1yf6
+517smWf+GrvWCFRXkwxft301VbTkT5xhsURFr+gls4fcSye95LovXWZCniBeqrUv8I37CegF9pZ8
+akfNlESvd3NslrLgYVW1wEVbyFodL56Mu9q/yjZkcTDjhUKokDnHBqeovXIMyyZZtX/DxnjD+/ry
+fnDloRemPpSvEHH+as3jQiVTHgw8vL5W9VqD4xr0BaQ4A/ULjfQAnMSxMYZ+CrufUP4AhJ+55G9j
+Z/2lqZNaiL/7ySp/AP6in6a4n7RRecRMpcIrhLyE1tdqne2LUTNpHhNFkac5vmtWbA==
+	]]>
+	<![CDATA[
+	OvZp/0qzzsRIEa6C6VY43gcmQ1GsIykgczbe71hkFSct+GN+6KCkhci0T+QZKcqwQuQFeoFGBLut
+/IzCVYp3BvQybXgJdJ69GmraU6Xm1TYotlkJKn8rSjPIHt11q/zgovCo2RsZqs9JpnC6A/ZNUT+G
+GzA+yDuPWEXlCZVuQFLRe+SNwLvX1yLqoJAiqOw98WhoNIzF0PK354yDLp17zBoS3RnwQnWpco1p
+AFX1D75lRrwV9coZmJbFKzgr7a09twxMf2lBsrkrRVuHIBjxsI5k8NO0tPL7bhstoHE6Y+W4YYSu
+G26/fO6cfG8+QWOVuOMm1ARkfxluZHfez9cyStnKCR2DoWO9ppTtt2sHCAqWolFCo+uEWqQgJUAI
+FzPTCAoNXbcP1YUf+KHyPlFw15lDoHhBAfAo2AuIwv6kIgcF1E8873WQCG2FGF0HN4b7RgFjUHAP
+XUdqFHRrs3W2xqukXecpGeuckrrYQBYYtJjGot7wSoF2MQfgC4K+puolbDJlM1LxYkol/zg1hhjK
+OtJmYC9mp1VjBssfDcF8IQZmjMvsZE6cYwc5cgZUE99TojSl/mwJszLmZRlhGNjEWPcjwzOThINz
+AwTwt2yaZmc2rRE4AvxvhhvamQVm5wYkW9B+6mc9B05vVuYKx8WQIBmT/xFiAx+77wAmQfq74cbu
+C/Qzyxy/W84+qRhIkCAUZDp+XQVFqUz6VPxAM7S0RbQsWwKBweb07pe3JOILHxJMIVta5GGx3RB4
+pjrFcCENlcjo10ZwKWoGdokQw2A7Dw04XpIRRr+2tD4FYtuwDw/G+jwqAn7ZHfZjB5QojSjzol8j
+PoYSq57J9Vi6oH6iX4VKg5WY8Dqz+dcIhEH/kaNfsBtjOpKMufKplT0X3Fo4/3D0K588wIg+QbDv
+866NTm8BXwmg1fg75AUyT7K3kqgxIU7sHdOTIoJw/EDMXzYwMnKyLoAI0XNqbs8Rgo/IuuZoc0Ua
+Ol/fYaoikW2gXFKxmSxVUyQVqRxWNiQEu4EUAdG4mMhriGGXVFBloEZMCDPLAcpORqEEra6Yglem
+voIPXIYcFqQkqZcHI1gYYqAJzIi/1RGq1V9SmUK07VUDQFhJkKO5sYihCZJq/W2k5T/bIHgmAAGf
+mnT2ldQqKaKkRklN0JHaQ4K/6CmW2jAwNYlXz+LikMNZjtuz3xDkA3NoiBGd6dwjNsSVEnAGhzWU
+2dhNvnp3aWbZiAl5FqCm9swGI6wL4wE6Whr9Yz+0SxNC/6XmaNDuj+nJpmyRkjhe4fIbSlJeZBry
+YY1u811h4XCTenjrdvgZDouS5lmb0Uxn8AwhI2RkNmA7qFKxDkxFS3bObjIbjNwJGC+I0wgxPv+W
+h4791skzgk/pEvCbri7u4W6H2RQzmyNB07Fqwg+gBbO/0cnwQe3UIA9p14ftREpApX8SH9upgGLK
+JVhAR9RBS9DhVoOXUR1tNcoHmHIudeSg1m/jkJKth5O84yA0R4kSqb+fxdHu2Kb0zUpSwiwo9hkD
+Su2itHp7YaMnxi8JUBqjtQko24RrnsM1kZupa21UtanWItiF72vC7XBNNMI1Cmc2wNLLGGamxvfy
+WGZ+5vmGqAG11InPVy40x7HLTy2PZxZN9houpA0QwkUStjPqEAiN00Lmj8dkV95YeEIlywvqOGnZ
+1cyCtPDRD7rFKZ8D3Kw1cbS4UU8QJ1Eoi8VGTYuv7BS0eCxeGLjWOlo40QZMkfO6NTWCyCu4bgEL
+cIwoC74RpAw2YJKsHuP38VEnn3diY3nN9Ut5CeV3LEhO0BlSx86s2SHU7XrSU0BZS0PAmcEhWMv5
+64nJckzcIfWEAAQCZVeMNkqe3Jn+wVrKHBH9Sp1xZSjK7UVRIxk8gYd6xVkPz/VC32lXMIdCJvtj
+mWVR0BlUPfObTtEcOgiTWL6cUqdUUoZ9Hed2Sc2fAQc3iKYbaq8Ed2fz4J6zDFMXasi32Y93EMaV
+3BN0OzSR47bF+q1wrM82279e1wjHRr2ZKFT0H6dFzfJjtCcta1Va1ikXJyJcThuEyojtMxs/h+PB
+GLFyIuLe4Sl3JvYRzgSt/kzupmhslD8TBr5+AqZ2yTpuh+vaHgTZ9QoMAWNsq/By/l50XkmaKGoo
+gXPmWBqO99D9tx0Ebpt25VtwB6PTx+HVukBIwqjX6LfVPpgfzwGEsRW9ZgLhDgC0AcADdqEBwvfT
+XVC99r8fyB+MJokwRLIwTc/wL6h5N8R+0tYFEHlc5VzVJhU9YwTLvg0UbWK/H5oY4jG79gsIbMr9
+Wtdcy7WI8kkUlkDG7YfRESh+QNTcXkn6k012ijLWulW6MO2ogoHFDrwdZto2qpc9Ht5qS6ZBoNv9
+5MEU0oGXGY5pWGtgGXuSplttbPvBkN19s64oyo9cLnsSrqY5Jot+8MMyG7zpIhXTmFdI8C5Qu93/
+X7wTadPwgPkvtRGH9FKfMTGg2ZoiVc1zyhFFk2elKNAEMlIrHeryEwGjutgxnsS23792a/3NU7aX
+1VVeLR2n0uFUbLFmMc2szV3W7LZcAAIvtYnRT3L9ay/IsC7mDbjQCQLoec0VxbxUrOPJ6qCHZYez
+SDl4XLZc32qkNlRBcJ45SQaJ2pgG5DchPpdHn2lLXYt7G+zFwnJcVvuLqx1zmL6fRMN/6w5SgiGB
+O38SOt9g+4PHtJ7ELanBBqsclRk+CbV3VbnBil/UuDUmxH6ZYDqAT8Uj4DeCBDdYpFF5G4HVNlhm
+R7sJs+4uXLUlpfc7Nbc2QgRR1roSifocTWCZ+TdCpEfoemWtj5gAUbPWS5gdPnAoj3DwCbiKbxoz
+2ogu2u6fr1Z2UAeshKUwA1gtBYitFlE+I7gC5G+kidWi+ds/9s+OrZ8ECCkDNJX2dEnoI6FYM0xs
+C28T5sivpPn6dlg4xCqSg+islX9lHUCg9GR+T/KbVZd+Vt4ZtAMqfMFLTKLgarPj/J/VRAVXOzbe
+ShL8Rp4h9gAa4pDfzG7lrUgaB116SSkh6ChhmMaA/Aand7SgtYpmmKWmyNWa3wf6YruHT1xKkmLX
+qkIxpFTRKyyVktg1QIy/fiiHTZW6llLdXldPM+lEfQs+Y7Brw8PP1NHLQxzOMrDMUiHYNnOqc81S
+0ZtNlDBLlcF45aB5sPqim6AHTBSYpHPI1B5AqTpYqvA1f5hSBQsa9jcDhozZpGvmrfEaAcA8KnUS
+tRVyNGxWNw8Y2BjZwJLvB50DjaTflt4glioePwAeAa5ORdluDDHZi0LY7AEKMbKIeK6KuWeQwGOG
+YqnIWdpQpFTi2T4zjSm+Jfq5tkwZSB6tB4qlN8X6o52r6CAo7kajGALEmMubYJfckP6asQGKZxuI
+gnnfcGJHagXmME0+WVbUrC4BYX4xz2TrvedlZUTe6azXjIgjAbaxthXFSkMp55cmkKnUNzFmYEPk
+Lc8BNtes/rzfawQetgOwJRnYcrp4GwHYjBrYjBj49ss8vHpgszkFbG08DAawmfIlCqSux94dPEwe
+YmQHzT9tNriGJpDE/Jk0H8IlAXo0tKqAcM3weGqB7DsNEEpIkMF2ic2nLtck3j8siTGjBMdfPqLr
+4HFp3octK6TfdbCH0TOae9CrEH3ysAW25nJw5xYp7A6T7WcD1lTVDTzh6Oa48CiKeIzh5HHSLzzq
+GQZba7jvenzQfygQBmaS8uDDHqEf3QdeP8lp8UFdsKmdZPfAkFwXFp5dsXvoKZ2klv2NeFxQeJjK
+7nGimJXQg+1M4TkOlm3Wrcpiqto1UzMoPF5tS0lTBUezIjf0lquoyFpPgbs0htcGVAu7ftoz86AN
+pRnwEHu5wlKTJe2RpNMWXg0YLfcKs3FSnsPOUSLXcLk+1RD4AVbDcDhyEGznxCMrfe6GC/jK5yHG
+bfY+uAB1UKlK1vMBg75onZEqVQbTEM5wjjYkMKu3LOObOrsgeIeMGVf8rXVw7/Pd3tLwAGYMug41
+hLb0FK4GZPQoSh0iu45Dh+CanrP36GC7U6q++q1gxNMKWUgfhge4iYAC3FjZfPzD34XYZtrvbtg6
+xuABJy8hvkDs2RF64ygctDIzk2nYYClwpacmKCAmBD9Egq8As7+MG3pa7waiz4mTs/i/RKl51O0O
+rs+EPEdkcbgBpCWsPyeg+eJCwpy4L43npBBfXcKc5EGUPGIC9+U5+RsMY+0YhlZClHAT9TnPTizt
+1Jb/cgntBosvbFAft7+zk7WLkg1rPBDUPiUuO+rzbYYXq1iX7ZcBidjJL4MN4amSj7DhgKgF2hNd
+h6XgPl2uHOhPJYqbfcvMKeeHwHyAcjhw0doqGaaWDACNa3ivpVhbuoPVUvK7NwNp/HB+rAZEHBiF
++OR3yODHgy+kXcXyY8qijhnAMPrR+clpq0exNzn8MDaivWSlRnOyS4zbRGLx7DRuYXkKc3VamRbC
+6UZLxGPsaYOAw+VafgqhDTBriZjjRFONaUQkecp8TeOEY7Ltxw+99JYFmWr6ZC1btqX/PHrpjfW3
+5G0qWLBmayRbhkPvXT2s8BBqnfnETL50NztYIexn+3aOsNdHbZajHEx0cYXs9lZSQBIY4YAxKjKM
+B5Q+bUNoxkFIbMN24yExFZpnQvaU/sz2Vj/Nx2/Sq6iE3pMGDpzKon+qdo+9dXlHu+Hsl9DZnVEC
+JSLzDk6ErCAgmWfNoCN3UOU+i5PBFoURhfvX/Sbkbb6k1FB4upAwYBiUN0gy+AgEE4UXYQjoGL8f
+mmhAgSjMSnXvjkzCaSOGxgu5dW/3yi6jp147bG6NguJorGrO/RCv3SNRUzkEin+16odkkQ4Ae7sX
+IImZo/uhvuelosNaNmVitHuI1A/E2v1tR+P7gzYo6wdHkF8Vxtsspfut+tyEWYCf9lP9wBNobk39
+1wSh3T+6SeOOMkwXEsrPw5mgQ1hBLcNcpoVgHjEZjq9hCqG5tCrrz3SytZjgA4GVpRDSwNK4f//p
+hoabDVqafBib+d5k0rGlRBp1TmcJTMyZpckpPyNyI1InqcCsRKKlxvx8C0fLZeFfkLT0R3OVMs3v
+RQob1yfZgfcK+CILPqgYgJx8ya9ARdhXTVcWmlh8kOx+X6B1BqoVxgoNM8530p9uVJa+lYG3hnN3
+WTIyaJ/MMKS3jgAtxkz0jASfXDnRBoLyx5J8N0rBzQ/KANsMN2kKn+zbkFIDpT97Cz8Uf3QxZdWm
+P/ZBOSLxh/ZrXumPvhUSFwUmG5KUTYr+tL+WFUyG4Qz0DmlcLNOlHQbNJm388UnvbO5fYLQx/SXx
+Amz7qlhDLVDUpe2km5v+UQF3EJ6mtSxdpJvmZ6vzkMCS+ohfW25JFBgbgQRDuNdwC5kr25l5Nx28
+N8oVsvM1I1aNCjczhLeIyYP64ofVJqAnzkHCguJhytBpqzvDzgT3fL5RRJPBN4x45tuPbnat4BtQ
+Lxn4IQ/sff8Z+IZQX8P5lt1hKXRbDt883C6tzbfK7QaI8G1kXODMheVGmW/QR0sOYQ==
+	]]>
+	<![CDATA[
+	/iHF4Vt3rJg7kjccXWFOCYQ3A9cJ30D/aIE0K4sI3aTIPGlhKOCoHQyftrE4SDuC1K8mkkWqIap+
+GjwksHx6DzZod7RVV47ina5pSebABniDxlyWfPI4rq1ykEnhHUAHsbIRwRWyoa/xhj7aShtBNuTB
+7tHqNzRYhXdsyEySGJV+9DE7M4ZTu+IyTw1nniPWlq5925kvXeay1J0dT2eeMmmRVb24fDVFJKfL
+mbs1t7Wmw60N4uaZgtf7/sMmf960Sbaam2VOVBTQES4LVzhmojAnsu8yJ+oEIwz7TVD7POBl7EMo
+R6UJSjMUbGCl2cHQFxnwP4V6FwLenRjIgYtOwSCaaAWBvnnUPDM/fQX8Ky4EhyzNMPgKMCIMpg64
+Aes1aGyp++aNrGm2JtYNmYfYLZPeSCyKTYKB6/gK9WxUqk/v6TPivSkYOUPmpCeJGir2KRe4Bjk9
++BkiVno2qCEBt+ExjyrwXuNTQ0dxUhmiyPnmyYli3ifM9P7r2HmcTMBYKX4589q3BkCLpFfher1g
+VRiqHDXSwwqrChLQvUysaZ1Hc6WqYvqkiR3+p6q1KvoaxVJemCVzOm/hMqrc+Zxm1M3O1yeG1gF6
+NhyPRL61NeYuD7f/+NaPolE83OTiWzM7KaL6yDDZcCgCj29w/KZvrjP7D1ejCIWwtlUYrncRCvl8
+NgjMwx2fMdM3nAEQCm05QvJDNtY+BTSZ4WZ1UHxTwgDXVPPmF0PLQxN/ml8QQsydm8PJDs5Ng+Za
+6cNZooiJXn7VHJTomOueLnupWmXaZreHU/aidjNHbBeByk0TbxwM8q1jlBsD32tR3pZiouiw3ICz
+gOlRBMtjTwklOTcSeCsBE036eW6tQ2IGxdyqgZgRuJVh5jbQT8y91E7yitxkBzG3kvwyOamO/Cp4
+T94ecW52wljy4k9ujmsN+XQcnv/+Fz/RK/Lnb4YTK+M0d0oFmAx3X3mM/LX7CK3bFX8PN6hxw7jo
+BrndLPL3m4zfNIsHMdpQSevFuT9RtQcoXk4AdCF0gBxsoRNTMM3q0wyDIwE0lSdBgtGV7+B/TYQP
+7vEnAGS5nUPG6WD4rRWKpXexEvU3zByUWatTILI0HKzk7t0ib6FkokbA8j2o18lB4QO/hR9scAM6
+NEaK41TK0g6/JlTM48IRyuH43trGC6e13N0Ol3y0c0NQFw47h/Nst/IMPftxjmpte1CB0FBtcrnN
+kfPrgg8JGv3ZJonayW2FcHqg2RVdUyWfOFMITal0ZtkOloxnYSPmy1VC8Gi3UAl15KQMP3XVThEF
+PcQy4bkKRXGOxGjKCI9C0DTQdxh5SRYwjVjH8+0JF3TpcA81uhdSJsi8IWRRo+VpuVR8yBv81Rwg
+Nbn8tYrobMiz5hCIKqchk3T6nMJUR/tS06UJg0rXQRMPECLWZayBPkIVkN5g3BuUpAH6qjAWJDBt
+krQBr5roVijoqj6DcdHoTV9dezmg5JbckmUv1EihUL0KBk0BPQGJAf////////+P/xSWH3d1d/kx
+d/aZwoNTGOYHmZmYp/C4xzOFB50fWFZV+VFVU5gGzaiEnd8U7pS1Lc7nxgZnMAdnxn4yJWMyhdmY
+IzODiIiF8c6MEFFw4O/5nwq/MBt/++HT47Aw+66woSs9KG2F2ZYfaGeaLU4PRMzLD1/aJhrLwuz8
+EZhH3FmOKieSaYwo9PnMLnDqP/wRGYKIipv8oQKnVTrBod9KRZUKmwTE7d4u/ttFDFpZhj4iQmQe
+k4yJiIxljFlqksyGwzAT2oM2HIYRXSGxnMhIztDY3OBMp5LTq9AQkekkOTVV5brCqiXH5hs9RmYm
+Y2g9Ot/d3AyHYZJzut3uhjcbNBs0w2HYoZnICInlIjkzU3OD01Zy6r7YISIjGUJqUbmuxJJjsvmM
+HiuTHDuTm6Pz/STn87p/v8PfjUjO4BkO4wYP8UZIJs8n2owa+XGI9+fg5aVyi+RFPjNDU3P5j2ln
+2rZt2/b6Xp6EiIqMjE5INdW6fFW5rl5icW3bvvyNHquVlZmdocld/np0PrvfTz6n1++CF0EpSqEY
+5b/8ZdBQPcskf0Hpn2Wb+TOdukL7dB7mc4Jt28xkU5nsBKmiovxxMplMNhXlx9PDqqhamB5VRERE
+RERERGQiovQgIiqVSqVSqVQqlUqFqZgf9dRgetDM0JCQkJBQfphIfpAJEYkQpgfmxyEiImJ+1BDR
+Ppge+UHv+8sP71qYVe/Q7FarWa2YH9XC0gPz44jpcflhj3LduoVb2B7jR99/WKtztQelelUXrFar
+VSq1hUulUqlUKpVKpVLbtm3bts0WbtvmB6bHTU47/UylaPlhaaVmS6WIiIiIiIiIiIiIiIiIiIiI
+R/z/////cwThmdUPYdPUfCRdtU6sRViS6whBc4S4HAmGQxoOCc7JMRwS8FbFf1XgVQ+gYIGBAAmF
+CBhAWABAQmEhQgUAJCBAQEIAABIEeILEAA4seNAgAAYeNAiAAQEJCRQMUGjAwAIOLFgAQqKBggMH
+ERJQgIDBwgMLChAcDJCAoOBgQQGCgwJKNYkuKEAQIYGdIAFB4p0g0eDBAwiJBhY4UFhQIMKJXd5s
+NrPb3O/y5zv/fhsO486jTehCG9qIrlxeLCcXGRqbyw/OtK1ehS5PRCaj01TV5esKS1zbl7cxsjIz
+tJ+d3Z39nr/ZoBWt0OzQ7GcxuczUXH5ucKSt+16ersgIqXX5cl29xOTLGz1WKzuTu/zR+ex+8/r9
+Dn+CV7wz3v0uLyMkJSYoncvP5+YjpdZ6+WKHio6kLl9UrhfW2GVf3me0WI3MZv/cT/e62/3ueP/p
+v/z9/4Mn/I9H/C0nMjMzbbWXvxIinujyr8uXVWHZvhsNh4EmZmT2NDQcht3z0HAYl7+6u5PxvF8+
+NyMijuff//+f46PuLuUOx83szMzGxmaImUfZJbu2fcNyeJTUkehEd0ZEhLWWW+10mpgz+ZSUGRlE
+/CwjMzIDETGLg4NF4X34xbi7y+Hr3UCzs7O0mdmYbbtM9hiPEa+oaKoqKy8LauG8QruiGqLCTJB8
+PZMRdlNkRXRTGNEyUzG9QrsqxG8KIzpH+01BNPL51Mzc4NRwGG2prvV9h4hqOAwyOkKSarXKVVXD
+YZTFY3LZfKOthsOwMtvZTU6uR+ezux/evK/X833xFWyxhDXWsOPYFCEpMTmRQZHpdDo1npuPdFql
+Vq1W64sdKqLT0UlKSqpF5bJ6YdXjulwuGy1WM7OZ3W5yc3R1dneSeGQ4DHn2dKrh051+QkKqQjKk
+RDIcBpFUiZwITRkOYzyfmU6ptWJLRENlOIzJMVRlOCRZkctwGFTnqyqrotWNVa+kFZqSqMSXySIG
+ACAoCoMWCKAIYZxlURI0OwMUgAUREBAYLhIMDh4oMDhgglhEFIuDHAWRJMMgRuFWYQEEEAAwK+e9
+VypYJ1cpY36ZEVRxMT7enASOX9Mcr7f+FEAMapLIhIeOEi4BA1kxz4Jq5O46Y3VGQcX9wOnDbHAu
+asmtIYwf5UkqumPjJlHFZbmR7oP5MNBCwCJS1CHCONEk/cPepePRd8XQile0f8iT+H2Lcbl4W4PG
+sjg1KB+HeAgGL6YwDMSKhXwBos5XOHPqIFqQWgUhWdjst3wI1Ht82V+gTGYiP9HifpTRSUAspz3S
+c0Bpojf8hJR5qZfJWKzIJxDN30J+Iw4g0/oyCAdMoIAc9GkvxsPwAULi87wB0uqibOHxmeOwoUqR
+TwvFsuDIrZMhiXaAf9BAAaeXEtcvLXMKjBB1AIXocRL+MOaiR74Z6nz43GMgmBxGuvcGxqLFU3Yp
+z5kBeP+IQrFjyoHCwEIxLtOM1uwuZzygDcJwlJOAbvRQypWaMg0NkZJYnDIrEnQ0EDpXcGh1zu2T
+eqZLtiG46D0py64fRP1bIvmxILNLvRzdGWCtZ7nR6cNRdMmDXYFRLD3dLW38MVokH1zYcL4HtTuB
+bPwxPDSSxI/XQUDXQeQq9sviPkkXz7qByNRD3LeVVXvbCqsLpql7clYH+4vCXggESoMUI1TRIk96
+jo/3H4b+Mhcpm70YJ8UhmUyImaT0JALNo4C62MO4Rb/8CFRwJs7Eiky9jESth8sXX1mgKIdVnzQF
+aBIfN2Xib4cZLGLKW6L0fYzJLg6OaJz0atIaip6bRKQALDkdjjwX8mJe5KgNH6NFctORGed7ZLUf
+5xTaWEYcq1J99/xBwYu8Cn2ZuT/dlWdpABGpiHBfmiu9beuufkwf9pDYiU8Ij46Lkx5SK+Lkb2yn
+r6RXoWRzrjbGjYGpWOeQMjjeQLeCQQOcUMyxMT4VScvvQJyRODwAEpJHZ+Q/vFmclVkggpk4Qzaa
+d1gMhSb9w2QWWT9VRv+FjK8KMeLolQOQL3rpJD0DoGWq/liZiAdnBBT148dokTzwwsb5vtTuFBLD
+Idwh1cd7jlLR1acXJfeLpjh7JoJOKzL1AlC3jie+crEPttV/V5uRkE48Gl5ZyPDiJYtEN4O+fDzS
+sQX1sQ+JZcpIzoOzA7ohcQSDe8N+HN7LxtGDVyXtNaEvUhXv08OiRaw8UJShgKCsRGMfX/JvAMPe
+FbVyQZByXLqCjJ8XVLmCLl1yK+EA3PJ6NkUaRIvG7HRa+niwKBYxts2xLzyBePyxH4Xr13q1m7zm
+/srLS811E63CXA2HzweJ9EnG0IXFe73SxXphFdd9Ox+B2KC4p8eB52GtIlYeGCU2fUVPJMSYayrg
+8HMty7IVY87RLdpIBYHfE+cRbZjE0AWmUI2HxW++EwypE2NIhYvheBFRngC1nbnbIJDhQ3fbH7nj
+MAa5Jkhpaw4CUCJ/oIDHgi0BU0TWLJKwtj5ayHW2h/DyWSXHnN0kWo+Jy8Om7j+xs5sQLipLBO/y
+kkFto/HEpjffjOwS0ApFhFK8ECd1lsxIkGlnfaWbq7heBvc1XTVHJrLt0bo56XiCVw7251sD9Boi
+CrjxcPMOi4q48kboala54RRBWPG2ETIdZuUFkP9illuo0S7SMyEefnZzTS/eQy7fMp16Rv/1RCVK
+HL4W6eS/IS4lMvq9IhyjwV9bkStHbBSfsmwogn16aWVIrIVVkODFuFScllmNfHwy0YKZRanfiGGC
+mO7zwVp5NPR7QSnqUN9d7saAc897Ax/UEWMFmbbDvR3AAHVwB5jC6PGnegCOhlmB1B8So+HK4OeQ
+aZ4cboGpgxL3EdSb78ZD2loLJgpBKasL9rUJwC3s8XHRGZF68M4hN6EW5pJ4AT+6f2d+U/5aTMrH
++rWWTNu5G9p4yG0SGBjYig35R8QOOD5TQ+5beA+jS3LEsngqi4E6JC9hOZIYbh4hYBgoFjv5g4hS
+Bs8v8K8J8VuzRFGxtFgS4LsieSZkr4Gig6AFXdyPAVIkmQZsgxyt7fugFZqUkF5xSJtKiEax70WV
+cj8ky8887euM1Wn/kTeyZO75GBS0hlcvjI/gQV8Noumvw6vz7PkZNTyRnG+Y2lnn0w==
+	]]>
+	<![CDATA[
+	YnSBhZKrT6XvDAC6JyFHLqFGh7l846lxi3tVAxfELLDBiniC+zAYHjYe0lGEyWMieKFPZ9BovA4J
+dwrkprjNiw5Z9GlBAv2vGNmhil2YpVgh/0M0r7iB+nkhq1DEgQaOgOS5uAwiKOMNoSMQDzYJGajP
++gkNKCQIYqNiVqE26FIzVfEBcNTvLlLgGuqkD6LLET2De1kt+kUdoCiwMI4aQCL/qEP8QWdRMZaC
+PAMrlJVzdXSvyB7RIDHGzFntYvLrNWG165qKl/Jaf62fPzDKVMUKekwIb45bylqnZYlo/U6bDivy
+fV3xTr4BMwsTFyvy04hSCkJAnSkSsWLFkAqiLjQ5CSZDFF2wAALIcwAsHnhYcfMcH5NrYYbL4Otg
+Ba7x6O3BXSOxVawGBgkdRhZN5TNRtyv20EpxXEYqRmZuJBkFnvcPsvYCvRJ9sGLMBWGf5tBL5dwD
+RLS0deFqVPAFu1bcIQfl6EkjItH88qyPJBL/uDq9qXOpgRa3qvHl6sTyQPxwgsO8+sOVzW9rWi+a
+pvnHtHOkaNTATJp6Bfuoo3yh8aH93cOgRb98Ewp6bXm4QsNdXuE8jF405N+jvnLo3qp9EgPpo+/6
+6MOHIhn5LGLUQ97Ls4+R2UMtKuIX9bz0MLyiJ98VdY4MN1PDT+owgOaQyMMF1eh5br0fI05RjIJw
+ymWywUDh1QwUIZP+utnQZI/GKPu6+zYRK6OKjjeFuti0a12lPS0UI1ec04A/4TDzEShZihWHroqz
+sADtODFnSSebW0d2hHdUeHYEVfMHHW5XisThiF3yBUqZLbkgYLGmCcypspd/7PMWRYWMYh5ROwyh
+mKw1UUMBjvoH+n4GNV2DiLU/wl1Ix5B7BE5EQ3KTkU9/j9rM0Aix9rB7aOfrWKs9ddl1AT58uGdz
+2mJ+7mSE8cxvJN6CVLzyNmFOBxoF/GPopcyDYN0W3OmZyC0KuohveuHD5nLkqmxDL0C7hpf80EpY
+kXmBzBoLHQbzD6BtayYgb70dH5cqHvk5zDtlI4kP7WiTz0Yvs/LSpsdA9E4OOIYs6q/fRHzDFbLl
+8/lcz1CogIrB5j8SqErNzPVQXyMwmVPqtejXOs4U8bSmpiSPrYBmdab4NbW4zuXYbDUN7qilzGyU
+jdzeOI3RlZXDHkrk+SZjdlMw2RASK08Dypd4tNADmHLaFQrLz14liimLGdRxln8HFE9/n0oEVa6j
+Pd2CXU88ZO71yemH9XyUKppp1Kzky8KAFoUIAYa81Rn1JbVBRiobdLTfhWGtOodbFhawVfRPTRRA
+FADYiOafgH3rC5TxReDe7/U8VLVmF21Tue1Gi2W5kIjB8ciHy5uLynDBtNaCpPHKYw8NkuVeGFQ7
+FoMlvoyD5ccBFV5/AQytmHEcEM++t2C/9kFxL6Tcwroe0PIf3KmWaAXLKQkBAlzoKTuPg4owt3yz
+ECgIjPZWqBcilrIoQ9m9Rz3LpgE8p3+byoXGF01xxvkSdu4TyISvl9Of17OvqjWnqLXKlw0JOgoi
+AhjyrufQT8qGDKls6NEOw+HwBjDTnELuoXY+IAIA3PZFULv617O4H317WVO56YXyIdNVFnu0g6HY
+YZkpCImyZqXsNJQvi6emvlgsfT8GMCPOTF/1+AqYQpDOSVJprG9B53foJOQ8j1FmJbMZaHOV6slt
+WqNABIIGFg44An9Ay7KcCtQGlIGLp65+YUvp4wFi19npUfLw2O8jg5BFlskTBY+yIHEfv4NJ2MXg
+I76P7ZV0AR0qwtzybUVJSMUQAaFsazn2lPIiQ1oWfKStkLivnv9UvJks9YWYF7M11ISpT6QQy0QO
+rRYQHvlweXdROfCnsYFamUgZlgkTAZWGT4Y5Cr+3zvw1vPK0IkIJg7P1Y1MjChmyprLRG+pDpqss
+fm2E0lGRhpWtLwobqgp1P/+n7NfPw0SEAXsqaQt/fcT75J1GZEsvYm9SuMYzRaSIZUWCtragH/l0
+WWeRbHKEOUr6ox7bwTMD2gNC5SYG12anwxBJrRYxU9m2Y0lFCUQAQN6WXPqhdugRlYse2kew6DLG
+9oidrTwJBtUrdQlLJ1dMA6h0CHFikgw0nMTXRdKrIyDIR8t2QXWXzJNgZ1v8n2QQ5BbNhsxFJI6m
+I+8hO9D9jB0kHZkv0bC0PyHeYNQaRKdswOu/dxUEEPtJheJScksSYCUPdIs13GVZT6Q9KKCexHLw
+2BJk3GDrc6eFipciCldlnH1B+sqQihPa/lXlcejas57ZvM3FWkDcKgk0AHIfgwxxiBuWfug4cri3
+Qzj5H+iOBmox5O7pBSJLtBzLhYnA2AcpQgOADFHDmZSTkjrUFf1DrSzotJQ4N44AYN9TH8W9cLj1
+eD0Oq4/ZDLVvkJHKBh1tNahi6EJR1FBye0VDaAUQhUVZq5EceyDIkJYtfw+oE/rbkCiSifKVocoU
+aWzO/l3T3uW0GVJ6RAEg1ykkM85goS+0qLHKQ47oJEjAmqnYHEOBlnf3EC7fe9kRkMedxJqb1LrZ
+X87esPWAx1KJEvRAujKSod8ax/yFAvt6OZACQUrEx+zK0rkHxST8kFaLZtj2BDKwyMILKmBRXEy3
+FSZVCcggZO9GUdhADuRSu4HS9uJrEBrLoitwFFBqbidrJ0yCDkM9c//RxT3DHiFuhl42Phuoyl4Z
+Igv2TArAhwq5hQrldGXMSXjTazPU6cOZCcLKPwC9aD+W9knAdPM2ShpSIEtYPPJwyO4H6uKid+NW
+3MdXl+/RwZkiZCPkM8tdaAREGjRzsBlh4lKMjkgSd1QoOJGf96ufC6lQ61xnnxxPLyaye8ZssjJW
+chi+khLbSd8386LWv5/MkLFJChiksMU6WmBbxW2bK+65v3M4Wotr+bbAJtS2XhMhioIkJm8w8sX2
+A90+C0L4fdXFuBGuEt0ARA5mhkx1AqVRrBvrB4gSYMCKMbFTebZ5NBue57YtAnMFf4lraOfP1DbO
+hm48kNOf6RUhqWIqvOAG6JWG/iptnxWQ55QSCcoaDxNktzDeioTS3lA5kYIt0ADi/rEqXvEggUuw
+QhCCxfPly/a7hZNEswByk0HdeL0EiY7h0+IuFt4q3T+3i1qVvhKDxEdtglJnOvI5l6IiVBd5utrD
+5ifRCPXr7t/Q1DiLluqtcTIzQvOQx0lw+YhiaK8uKrMYMsuugk5Fbow/attWYkwztbfduK3fAJ0u
+iJwlR6+c3TSZhe3nlmqgDRdRRrsKBYnd1MW8Kb/ECVN1rCWjAwru6szz5WBfn5TRvqTInVkfAiqm
+jg4ENFCT9mqQe9JXalsqHfezzWF3cG+crEOFU3istBLf+xGwjDy133+izP8xCXlPHNTDJ+r7hbRh
+T4d8fmf5fFsw6hEmTu9fIQpW/jw1un+mg79+zc9/iv/B+wO+/yfsdyvgIgftmbTuqGSgNvCeG2m0
+DA87WFrtDPaCDFtxrYWZxmDX7nk9etgP8JhciqrDDhTlTRmnAiBHSD9YuolO+QoNotTJlgH1K7mA
+xvjQcRBxyj1EhCKxOlnMopOQ8xKNQkZB8grGT/sL4rcUQcIdRjSwMDHfnxdRgOg4QixW7qMjvtCU
+Q52EP6GGyqUEsYKwxiIx5AjqCpGTMqQh3GMxHCpGk6eT0qUDFsgy7huVqC3lrIDYnRuQJ6qnk/gh
+PQoK4DAfFXPIxcuVntPqZyz2o2PL0NgQuaJt9ZVbg0hj5cnk2Geus1VkQrLWUN146NJJYaDoZLIs
+Ql3AJAFJoxl36gt8TNdCdGQhirLSjCEEkWEkHsyoRoebZNdJ5R7xYVng3RrSYJEAyNuMyqCfOimF
+IcOQ+RkVQHxBUouMlfoBHpNLURVYgaK8KeMUAOQQ+RdLqujkWuJ0UqlHOliesLO2bDZIBNkmookq
+kU6aYtAoZF1E4xRUkDSCcad9gcd0W0SbLEJRVsoYigAZRsDDjEp0OBV2nVTqETeUBdxLM00MCYC8
+mag09EknpRgyGJk/UeHIF0hqwVipH+AxuRSqhx0oyptinAZEjiN8sKQYndxEXCeVdKSD5An2asjG
+hkQo22I0oybqpGkMjULWRWhMSQVJIzLu1BfwmK5FxE9I3VVWlMnGmG5BQQ8TYrmLznz8sk6ezKgu
+5E6RsoBCQLhLrgCiAUPp5GOC/rjcKuiNFwTJmzI+7u8VP1ULiXYYYT1rRXnNF0MQZOTHfPKjUyI0
+kFS17FQWAvsyNlCzBmtq4Yk4gqpChqsM+mjZWAyDijBs6SRwchAEbBlWComoLXJWgfLM3ZDn1etZ
+fJAcGXWYgnh8i3Io8VTfP0KlieWO6PwSmg/ak2jbv3JrEGmYPLMc6Gx1doWMUNY0VOcPnTopDAh1
+sSwVUJeepIGk0TNu7EsVX88UoXcYpM9a9KkoXweRxmBZTuKNZzK7XtjpXnWy0kEyIXN8QEl+HOLA
+8hhRXfhHJ5kR5NNlu6LOvCdI6pSxcD/3MfEhms8SqChvwPgAQ6pYv7CUFZ06gnidxIiQQuSuFnKJ
+ygBxVVYEtL0m0UkPBPqy7EropU8MkiYxbqyv+5h8ieRwQVSUFTBmlSHqVliYyREdofMx5qOTmBP0
+YXKLIlcwVWygvmyk+GTYRzlYjk42+IhryrJAe9EckFyD8fiemsdMIWSc1FtRahtjihUBPhzE2FN0
+7OS/OknpIvGQeSqKgL8O6SRZDqgO7KOTzAjy6bJdUDfeEyR1yli4n/uY+BANJHcej1dRap+xjDRy
+H5rDGHt0zFW/OknvIvGQeRaFpL8O6SRZDlRX/KOTTCTyabJdUXf+X12UumUs3U98TDJHW1JCFOXd
+K+4UoCrYgJjNiQ6Z+Kz+ldsQWomc31IsQyEQr8qKgDbTpDrpgUBflh0JPfKJQNIkxo33dR+TL5F0
+LohFOVAiMY4pIq5bTpI6qSwQdU02DM75jD7rQkZIZi6iowp+OhlmhXi4jAyIy44ogWTpjBnp+4tv
+aEGoOgxCzSbaXZTxGGcVIMyawZiYRWdAtKKTLSPqV3IBrfCk4yDikHuICEVidbKYRSch52U0joyC
+5BUZvwk6MfCYr4toikUoykoZQxQgA0h4mFERHeEWmrnTSco/6qBcxh4Yu8HQXMiaiKRZg3Vy2kEy
+kTkSCZJggWQJxpz7XhKfMZEY7YiKsgLGDDJExToLM1nR0RGw10lMCdFE5lhESAsZNlRiFIl8GS/U
+MfipkzIsMgRZn6gs9BMkdWKstB/wmJwUVYcNLMqbMk4AIMcRfFhSj04OJF4nlTrSgfIIED0xvAr8
+4Hoyqo3MKXkuoxyI98qkQJvROY/fcJyxRj/u4kMxco76kpiHqeLgCtT4NxvLrOgcZFaxCrxTBHWy
+JFdGqWNCRCFzXdQdFADi0HIZqKb4U+cOCWNtPx7xATFkwe1uEEprinb71mYRpMGxjOFGS+y6VB53
+pGiHyXF0AfFv+ESINdlgOI5n95kLMkKZcYjOUSJWTEIwd2/sKY2GbvvtFwOMz3iKZA==
+	]]>
+	<![CDATA[
+	R7Xm4LB8FZ0/kDpsFR5adOJy1EA/8ha4HGFmtwUqQhpZRg+UG1dEruBJ8YdQY3IZQziEwRr4/h4x
+HtJTKn6gjwJ1mC+xTvRZzFda0B1ijawLaCYe2N8zH1CD5TZBTEZM7IckyiOdLMsR1Yu9OiIZam5o
+gHIdQnIoRs19CmN0j/KK7yCoQffZI/bIZWFkwbCMhRtHcJ8AoK45AzdaN3LkIxyLb39rQN5I2WSR
+jjLsUFIG9u1gl9AB4qqsCGgTnWIR7cQZZ/TwXgixjU5SY3ovOGEcqkTM+6Axwf8C/MKJK49NMwfV
+1OEhOZF5EokD7aC/iFQURVyOIuSA8Oo9SF6CDCfQgnxZdpUwaQSCQn7D7Dd2tO5x7HpIAJXsETb5
+QJvTuR48artiUeoW0Ji6VFdnp88CpgSCz0jVZLGO8gzm7QPBkXpoBELpipBjm9YDgvyVoeONiHfL
+VEDb6GA5mdMWgv0yVtA/vEJKxsGI5DEeFYKiXpZS9NhP9iGaGiFTKzVLs/uU7UEJIbOjQlNkT1O4
+GPGMs0Tew27lSE7jVSEojviBejAyiHaW68UVUlTEVLKrheJ+x93lQ0dy8Yj75U49oJ18leo+xoKU
+7KeSAEyh1e+fPzxo5OFY9srhjzUJO4NAhEBL5OBM+fgI5s38LT1KRESRdSoq4kJvZ+rjUBdlQ0DZ
+ybIGsyDSlQ7pYjqAy950QDn5NA3CBF6WfBB85CEjlSSpWyYAQzbaLgJek9VJE3K/1YvXEC2Pp8t9
+JGn7FiSkQaXoJU1GMFjcOs5IFVsJSRaFQBn9g/rMUwAG2jmE85oFXYtSnL5sG2jEYpgrbF2Q60EW
+m0XUi90PQbTDKjMXoYmpE9VnM9MeJEeMPifB3PC3WmgsGkRLph8gSqcBExTwjqvYSwtNohDpFY3w
+gwOnbAY4LZRwHF4VQdnpgIqU/ID1XND78/Czi0QxVHIdRfSZKy7YKDcuDNWeBZ3SuDuXzCiERPOa
+wf17fjIzUQOvogGwE3XnhNWWIlBsXjpBoEH4ev4EHX+F490JhHtfvoGwa35zUrswhk/kdjCzbU01
+UWSlDFR6/B3R7nKj9Gp+/X60VqzEw6bNnmK0eB/Ly97i52zaEmYvnv3ou8s7i2TMtA7/NltkQMnD
+azIMTgttabntoqjQimozKIOtwgAz6amGJ7GZUYhq5gB6thX88FVUuyOimOUqhVJP8B55umwr+eyW
+6iGTVBZ8pEkBF8M7OZs7H+SkBoAzqKOaFvLuP5vJJVDoYN7eLyJvH4XjF5wf/XxZaxnohvoh01UW
+vybCdahIw8r2G4UBXYXUIDUEDf8KrqeTmS3wUBLFWK9Ixo9jkaADobVcJhmIGoB/yPvJesuFp5QG
+OVSy+FGthNEJGYQ7otnWirkoHCS6Z5GkU4h3qFgg5RnkgeWj3Pw5Wr5437ibns3tJlegb5YPhdwc
+5e75jTkqbla6F20bhp+kWqiIYhwmkCLCcwYYUt3C1UufyneMJOC6EHPotEMQfCDhSjZQoeEuIDSw
+P1igDi3Kkws5gZJPCPaQLX/RxuMOkXz3CKG2EbCyq41iFwqkibWXuyuOTmYPpgN//DEUdeuQcy08
+BFRoCJZzpfrahYoY0TKRpC9pVUQVbPFmZKoI6SgBQtPJ2QGJsgwNkoz7rCq0RE73LjIt3OjvoBlg
+kGnb0Tuvw9LJJt8C9F8uV6dPMiTWNt1JOjS4zVee9oX7n8mTGmBNXDyBwtpR0grmwdiOnKTRuS+c
+HtcbtYguxKU1FleHNoZHpI4+AQuYq9oFuJWhSkb/zqNUquBGl3WiuHsTLnCr0ytI0DRFAdU6o3JS
+FL+GEDlD4e5nhKmg21s1JpI5ShSBVMW1IadwqBLOuWTYpThmm5xm/YGDK41imwVnAO3t4Cj43ece
+RKhF2K4CYuGZABvFrnEtjz4f5sHdR1yiDiq31B+oJuoQWzytRYigHKHEmuEpnqykMg1h94E+jqVP
+t/VIwcGF2H8vFCC3s10vEbubttC+dPXifUgWkPFy8r9P5qmK782X5gKGguiNJDRr0+YLlcfvgPB3
+C86EApsugQXtKwgbJHvs0ex1SDjsPajBTN2pJgaUSOnZbm+nMODkr764SkBLWbgVIAagba0QhChT
+1toowVokdQXGFfABskQUa9aCUSrnyaw/I5hQhJ4tYseFJCu3EqTAyjlBGMr7qFREpEvg0Ps217f2
+I0UR8THIg/Pa1mJgo8jZ9BUWD/br+6s2GDpb0xux/Trgxiigdkq33YK9FaSsRG0l8MXqDaQpa1+B
+FSWAsjtttxJUAakF+vM5+r0LWGReoD2aqAf+6wUqVRfGqk5Gow3QPzKr77/83tqMFEVEwCCPnzyb
+rnYnq307R2BKP04auk0DYXF+NcQ4y7JARhbY4cgBGC7+RpHgGrdaB4NKpPRsa/OwWIl4iaAXV+US
+aAqtgCiBzE5kSpTBaPgiqC3dXH60LmBQXW2dNZsyKpH71aD90QsRU5egdnZsrc6ywhQlf4aiYg0F
+k9/Zf8qJ3EHFo+0Tj/7QCwSvr1kVYBB4qaO0Ho8LIife3YG2jqwNhFsfOo5AwKhgmt6CRXQrC/sk
+W1ywW/tQeCx9rYJOrqQ+Bpc4pec0b4c0sXJ2cjejIs8HofLbCshFRUP0WAdu2qtBMsFfvtZbdV2w
+0nIpcf07BcToK18MdftqHXYoRxZ9Of+vRTujfyDCkiL9cf+OYjAVymUp+/fbj4Jo+WmldPUnulBy
+q3ArQC72fp9Njzg70FuFAKVL6bS5iyx4BOWkyKbJ0YLGCsfGe6/xaDoJpJ91IYpgVnetqRIQiAlv
+p9vkRKy0LdF/UalMSjT0rq6AHRRNSTSYKFNrYIFwLFq1cUZdYOjbT6M172G0lIuLfPDwSRt2R2SZ
+M2IQ1zCVzHUmYZZdlhdW2vODD0W93BdSdxTYPxV0VK44bXgsho/iUk5j426bI9eD8o12KoQrOota
+dZPiaCFw8sHxIzAJ9g7YTFQ6qk3jsPhhn7uHZrBo3AZvRB7aQdi4CyJNOTFBUGcf+rByhkSMLl6y
+KChAqo+Udt0plERvirK0hhSE6nL5TabsK0wwa8SxZj2McnnEyMrldRnPn+i16+CevToI4cVMut6s
+HaaSJmsVMij29BAgX2f/ECyo2ZYyyBPd//6LPHhd2AXdtLc//RPK9LRTYZK+2UWj7RK+v08a+QS1
+zk3TQSwe2K/vz7crbw6E0Mn98dKCh3yDXAMbFNLUEROYKhYbI1Eu9X0nUo2CKJI5CFMu+qpdzlvk
+O4LGiptIjKInGMu/b901A/tEIH6Z4Lt3qwnhO9HQv7SYIqc9tNp6tFBsmeZLXsEJnolF38Ay/WUq
+FPjaNzn7U/iJFtFRKECW3L9BBjRH1XMrpas/9cld+TKvgFJggosct5GtehzOguGgyo36NeQOk1dn
+lPEwL02f1rZ8+mzdHJr19Uqgm0k96kScrCYLC7IY4pJqyecxVUOPLVQ0H0A0nZpz2jelBNIEQUpb
+AlgPwfybkwiuuCSXhWYmGqlc2zyWJqX2vO70K364hcS8YkZwF1mvykI+YadnduOOldYYXfKjUS9s
+yrjyl8igpQJtJwqk6fOkZhsRg60AHeWwpTQcX8zLwVZrXn0lAgEjluGLfAHCgdPqJoLMfvTKrdZY
+3YZdEXQidfvZtumC20208xy8xDglx+lW+AmnyzqgEXRxCDQAgz/lHTZjJyPRBuQVGaH3ba5/7YYN
+mTNJhyTnwH8eQfXLRlr1yfgYAf2gTPT+m58vO+CikQjb6PjMs+nU2iNBQmSO8Fiuj9POtOlovgH2
+QLj969E4YyfQ9BsP3Aw6YXa6bdUtaHtKL7bbkzDnZmuNqCvCMamGoyKia+UQ6+PuxSslBMxy0bNH
+q6rGHvH7Vv4ZRZy8F+KL+68CoQFGC0X5QQNjBBzLMi/uogJK6raV0RVbc6yD5BVb+XpCInqADQqe
+5a0oD/tHuAzZPYZHswne0fdpTWpqhwApYXdFABVN1U2E7d+2cDBKBHDCmsNo/Nr0zS2uW40wTlrc
+aON7ckDg+LxMH4amy626BrWYsLewEYw2svMLg5guIsqF3Ito18JIug5ostcihNnCO1fZo9tNtxyE
+lWga3WUVoJ84+/9ZRPcP+8fO/v164yNnkherypVMRWteFgPSMg7oPypnpd11WBn3PgmliY/FuIA8
+1rWLQApQ1Zl5nffX/q9CI8JF05zQ+3bEVwcOVkd78TWlu6cVcdzR8RURLo669A9tJq66OWdF/N3W
+nDQoow2OYDue5TZdyIIGI6nuXOQMjczEy8ZgSncDxI1D9kgKggmk40vayDt2llWKPMVSnlVmRAd0
+Qx1vcXxeZyIgl7HsHTzair/PQ1by06goHx95ave/TyMwsQ7atb51/gPO4lUFRFreaKgOpTXTUMjc
+4icrSjGincsIxlA5a5VE/86LJK5PeHQk6c0kCmEK1e4MyJ+CAIpw6RxDF4vizzRrrapkyB0XpvPL
+2kRzTGvbIsUGdcN4kgW3PvKI3rL0MGh1kNwGMaSRpIEJmCFLBCNXlhtrx2y36MkWQPpdIvQvG9T7
+HvfTdSYCchnLPliuaN16+6RnrBzBiCQzGTFn9o8ion2y4vZWuaM5cnq3J/aqaHuFvIwDCljB2gUL
+oQ0IJJONx6ETzPwZlqttDXKzYZ60O3yPM1VGSI+uj2izv4Lx0v4tf+PPVek7T2nX2qqSgTe/AdqX
+tSnmk8b2LOiVEfvCjiaIZeGogpxYtbIcGKgL1kcEHwF356X2gEsWIzfCCKuDMCt+y1qhaxMBTLAk
+EJ9KUyr6Qtii8eoZgbQ8dQkQnnNaIiMk5uBGVJkpgnzfP56CDtYHt7eKzRWQk26bkOeQdw25cg6v
+Jo5rF/wPPdJDUYCTuPD4Wx/fItMFtSIJW4u5j1clTKragYUk2N0RgBDFbe2fsXAZnw5MaANeOwXR
+sXTIlOSVC02/BR1WADZUG8dN5z0EUuFo4kLCnN137TVQQAlf28uGMCMunWicoimLjd5cbUE9avr0
++eNJJADBWf5sBw8mI9LqboWiQ9mMMBlCtCWM8q8JCKEREXqLYJZkRWJacmjnKR1styACRXv5HgrK
+75IOPYFc1+5cePz28etPttCxPcP+doDc7WmYI5WUdklCnXlLBvv//8dTp9Eer3i2gNQXGWGVJEP6
++KiZ6ozEhIUGgsX1qxHGSat401tGJI0csE5hrrhSfRTwgiLkEtwWEo0xVIneirpyx8jKhzCPfkYB
+TwS+ocxcWobgunx6429NRscGGxBtHGU2gsn0BXtiKH4WobeY/9Elpnau0uFNjY4qjmR0WPJcSDzt
+VOpGAX4klvHuBn91xalO0Ys02gW4jfn6p9aCjyGHe5PxkJEjDgRYxZrVv7A11gUMStcPGWjIw/iH
+OwWgLy40FizOV8MYlnrsBS/Q79tO894jazAXV1VfNTi4wSvtthHMiEUnYrd4ymKhMw==
+	]]>
+	<![CDATA[
+	pMxaIwJh2eCrSGSVgF1WvWrbknGWZJsT2MUhIwqZYAjFQQVilAP5hzT0hKOhC+ToFmtckRdFYR42
+dOhUDqRDFsVO/hhETMnqU4vizNqQShX0dMrGHGjydksvWByCXeDYVzbK41REQhwyCtY7A52awUIw
+vsjWCXSwepQmfUPmr9AFKBFtyrO+WKt3G04AGcLFfbBC/OazjKmD9p/vgGh2IzVaWJpv+a8oVvJT
+iJbZZ8ONIrfEPzNaQrhftLchfo3VmMp+dgsYRjKiksk7+qsoyOpDVDRtpbmXvbr46uKLAY9/jyqX
+O4LSDv1gvlqyw1S+DbFoUVUtdFQ6FfELlZuSzCupkib6o4TlbigLOxVEEeF6FgHSHojB779JGqou
+eYFojdeoPbCeBU8McP+25q2NbzAJi0jgIJmlEvL1xYjBprDWFbCF7k80UY0u2ejgoLCR7U8d079N
+IABa3Ri+rsf7bSYYX3c0w1/okGSB1q7VxS+CyePdvUyUtKJ1t/rwNczgtjztD/DP6zoC0o4gMoqy
+zuJ6nVBY7mazyAowZ/t+YWxBJiNUioX8G2LE+OsnUL+H5jwaLVq6tyDIMUzWz3vU2CGkOGja0Bbk
+GyVcJH9aCKkIJgkenrmCEv6z1vu0w3yRD1FnZR6gXZgFBBWZWQghl0HAakCIrJFveqxCHfaaDOn3
+0dS/jIBfG8n5IvvafDAEt8NgVXRc3bWDdkFAGB+1vi0Ok6IA76Ie6Id5XStXWwP2d2JmGafdHmtc
+pdFP6xpXJwiQdbb2pTDc9ZX1lJpzFEXwfCgvy5P/GxkZEpmcfM2SYF+kZ/1CA0gsXHBwAP4De5Ym
+KXpBVJFQngOE95HnmlA/EUcFJ8zafBFtq0HCy0Go0n+Ydo108VBUJPdAGiLiEIgoQzJYrDNtdipc
+U8f8Y3qU3PoKZcC1u9VGAGqBSTEEqtWW4cB3PnssgjA2PehSlYCyLES2qJO64Psd0/dV8yQtiDak
+/Jd3gRMIUaeMHFpPujYkuOnu4suU4fj6JZE4BrB+oIxeRcEDislv+Of2o/3Kok2vbggky0uXsrI9
+YhMzZY1uEd6S9doBsEZJ5JTFDE0604UMUIKeEAUi9H9x1YavByPpfmr+W5Gqwe0JkEVIngQB9eTo
+nMOYXJoui9lCJP8WCzxo6jOE7HimTf8dB4Bs6WXPYjjZgcmsXQ8lrbkEJdp9s5UpS81npo/Zg6ji
+9qlpjoGLprfwpTrmUX69m60PUthBnXjiDkHC13iQFvkxlAtGvOUVRp6zqWnpkciKVjsNXxvZb/HX
+1wzQssBRisa6r4EIEHGqCyCx8twqouKMkWoUV5mD4X1oEzw2GOKimY/V1GHJVcgqzP3EUcVNNs2b
+gWbwYBVFbJmslsSX9meL/CFSG2sSOvFwDic2KIQcdDxf2OtSpLauQ/I79JYCRawo4V9HDBLJM87h
+E1UoNMVVplPX0OJgUcoqEb1S/1Pi+EoiNg42XIW2FkLDQKPYme60l4Y9V4aY6ZY4xXYi9i8ojkAJ
+pSZLU3rBz6qCEAJqDI/rbkvDjSVZym8ZDkkSd1iFYeC8UOEQCCIIGnCvJFYm/HsuukiJCyJ3/m0o
+kDSpaRO2gRWtBcm2S5SaQ3tb6DrIu8tWRf89SG04izYk90QbKlG2anXsD2lUzL9nLqvAtBYd78z4
+oUHKeQiJfYY/tcR/y38F1KK/MjxaaSE0s/qYVTNiXU7uuZbQQQeYnjB0SGXD6XS4ThcxVNlyIXgi
+LGDe9pE/lzUWyS5HqGV5lhkOHFt2mh7SZwDrY5bKMksS6Qzm5Yyu9ZhGZAVMWz/yc7JW5+oAhUEG
+lDx8qAbhFTBFQWSRy/SEgqGe1VKLlmUDlqf/aQ8FTmimADxmeS1z9ZB0Sj6cAbceBxWmgAleIjVc
+JnmYCoDwyMPL24XKwj0AkxdCCqYMbyh27lMtNWJZQsCosvPkkT0CXx9TqyzbFEj34CzHdK3HxIUv
+YNr6kfeX9S4PVykNcqhk8aO6Ca+AKQIji1ymZxQE9ayWWrAsO2Bgdm4RJCL7o8fUtmUPH0l/Occx
+ENeDjt3mAg2Y4RJSwzKRQ6gEiIc8XN5cVH78ATB5EKQwZfhGcXKf1VIjyxIEjJqdZ47sIfjqMbVq
+2UpB1oecWbIeeHpGAZPWQmwq23YsiVGACATIm4vKhj8CJg+CFKYM3Sgm7pNaamRZwoCl6n9foEBx
+QvOtx7w75YAEaooRwdm69VArKwGYvSga8nKcTYOcSy6/21wX1Y+TXoDpjUWjkHURjQEPXWppfst9
+DeRF/4Q6EtknNLL0mFQQUkyO/3J7q84UYC4MkGyQeW8WCxsNcqhk8aO6iK+AKQIji0ymJxQU9ayW
+WrAsO2Bgdm4RJCL7o8fUtmUPH0l/OccxEOtxePUKMMFlpJxl0kThqXFPxqy+QR+W4xkEk2YHTJgj
+FIBynSIZ8Qy1xN7y4wFlZ+dDR7oJWB3sB7VMa0apRnK5nHU9TyyqAfPmh/69vKmM+EBxEGMtjxzR
+SkQFzFEYXWFyaqJQ6GC1vMLy7wEFs/MmQdDZGT8mti0/8JF/AC5/rWfIeA3AHJnROi4XCRhdQD7E
++/KWIjLiCIDZi6AlSQ5rlI8TqZYXWf4woNTsfOpINwFXj4lVyxcIsjPAxyVd1tOkIgqYNnrkw+Wt
+zqWb1A0ZUtmgo20GKcA0AtEillUlCq4SU0sjLPcOZFB26goE733gY5bNMl8fSa/g4wyX67GPYAdM
+hSICA7JW5+oIBUMGtDz8qA7xFTBFQWSRyfSEgqGf1VKLlmUHDJSdO4JEZf/4mNq27OVD0q7mOMZt
+PfZK/gFTUYSAo6y3jPhIOTO1lkXoVQgvwHRrkUHIPUTEgAYvtUy/ZbgG9qI/YY5McRpnKJJ1sAf6
+tVVHvNtj4/TU0cFEuI28qDQ1tCygZsqzE0L/hcahjf8gtZFFAvquEAdMQxRqatnVoohSqlqazXLz
+QK7qH60gMQqNFNKex7zkCz7WOD9zMQQ0kAKKA5pAJCBPkqQNAx6Ye5CPHz2cSsWDaoYXlJW9Uya5
+C40CCgFQVi9ABBQExQMBBKeROpnqGOrUK6WeY2rOtXnpmsxuv+okqWOEEKIkVe9mVpKhEM+sMyxj
+UYAMFQcD4aLqJGjGJaLz7C6XEokJyd0Rkc1fpY26sGZGaerIVDNOYzka8qg5C304+PJs4wWCgdJo
+gZDLFcE5X5lXf0ytCoT58xouF1ofccgUiKK4FQcCECS0osmQ2eQK5truWpwA2ECrcWoRhwBVITMl
+cx9fx7+uXp1VPdVDLOKHsI5kRqbgPRIlQa8BwUDCzD9ehubofxNM/1qRvSxkrMxR2tNlXVdnrFLD
+rbPHxuRe5SJ7lBOrdsKMU+/VvFAkoboZZPYRIsscZDVkUyHLfBFLxVgSR1R2lU5IWJuSzKW0vEZs
+qqRcWp3VmJ2slWZTu1KN3UqE7na3WuvT3hs0Vq8qGtJe6sisTnW2KnlS5ejJwFjkWiR2wnS+cDMy
+5ZK/QFxOXjd0MnhDO6Lh8MMuQd98RyZxrvxzVaaTs7PfjLUyJJVQxFqyzeo58Tq1mTV4RVLyDM13
+IrXJeNmEPKu3fAEYgnbNcQnfmel4a3xAKHC5RO1VJePsGRAQMEAHOOAMMAAHAOBAgQkkSIABBmC4
+gAQoUIEDByADDBAyICTgy0pcJmb3oknCQAEDBI3cRVR2olPUF2hGE+kfNr9AeGrOCW/c+QPCgQHE
+EIemcrpDqMQRqeaGQlXiVo1cOnJYYVgSHZ0MKxDtnFweqmkNF4hqsWoeCrmGBwQIMECQIOnTnWrE
+COlqkXykwwoEjVIaulJkSIEgMbUT3Y6GXSCEOHOtriKD4ICAgIEBoYDEj4bGnpkZ1A8hPoQw0S8y
+ZkAouLRaf1XV+NnaV1RVN+5AnCFEfUwWkVhR7H5FQ9oTklw5RPVepWgfNl8quZKG+OgkJ5FRpvks
+vGWMnMRD7BlXeNMQki9FsxiJ8FwTe7543sGS7+pmiq7i+Y2qZX5irfl4q8LzbYRqbthwfhTW3fV1
+9k/p7x4zNFQvYlVRVA8ncnJFnfFfnCv+45HsEaCo58SuAIVvqET6ExH/NplGRG5FKhNW0au2+M4C
+sFIxIBysOA4Ihx6PR4qIyAlp8tgpZkA4FDNFW3hsczEgHP4XJypIpKZmamYO48KKm5vCbkYOYjkh
+OyAcaJzOZ6YDwmHa6tXugHAw2Xx/+oWG6HQqMuKBraqqsv5wq9n1er1eK1LCkuS0mI4HhMMUrQuf
+6+LAoocrqsgFUW/RbHjf/j0VDfTP/Zx34H+4w4Fs+0CL7+pQh/vgQ9u27eHAOXAOMgcjezAPJIU1
+aUl7sKWVSg893B3PxaF3mOJuzqY43OxAEztcURxeVUVVVV0d6vADFVPQCI2QkH1mPj3/gx3q7kC2
+7fF4LC63PFR6MzMzQzQHmSmIJIczQx5IpjjIyIiMyNzdBew/r3F3N/bfLBqnXX3D+3iJk2tx3KZ1
+JaQQzZXux1vmrueRa0mJdCRpt1tVLBk7IWe3/cLf8UAqiqoV1psRH1LU1PytK6bs5kcQZkR/NxAm
+6EaQHxAK41WO6FlhkBNjJ7cbzxpK72J5bH4y5eJH+av2zjIrRv7G1Me+57+hTLGnXDtmSPI6s9p3
+HJqa6sdtz0ymNex24kqyionRcOeF8dHY/YaJF/FQaRu3VaVHDq+3X4j3afzffL8Jh7fXzFBLJ9qu
+nnivKpMTGa8J3ys54R1VnW9sY6QyeW0YT9pI6m7wCJKSUemjGeY7CVGP9N39ZCRGM0atkVUto/ji
+S340MhudLI1Lm5ukfnJXx16Lfov55uSJG1/KSkhGOy8Uq+KzaMOo7s5Vqqn9qitFuSGt/DL1jB/X
+ajojaZUQtUW/sTq67brahDJ2J0c/e3F8ZW6VeHz9GRvnB4QDb1e/OradPHj3em7S7a2MOeJkdaim
+0ugVOVVWMtOYI27I5Hx0lFE6kR6PSjN6hE2x9zcfq6uzl19vtilddKrS5aKpldHdnKtMfnXZMNuJ
+k4xlnOeF8dcLBN2wNqSKrVkbPYLsnPXUGlHkylInVJZ5JGe/SaWpjMlUdUR6GypTxOqukbMR+2tC
+6jh+QCggaITJkHTDBoQCwsTM5YiZcz5HAIkbeCVaUIkhPsSUoBkWc5wyC8PIjBg4d8eSJ9wjLURl
+5LhU85+M8V7jNQzhm1IxhHnPHEtWDVlE/o7180HHt3c2XbpxFl3qqqzo4Zf4JO/4YXi2yZ9u1aLP
+qUQmQp6XjOlPVbmfG2KmWt2N10+QMr8Sb6OmL9jFXtchVkWjzpD57B+RqeMUh4X+GynfX+V87mb7
+y1gn/eWZsCeSsTqW+M9pf+p6ZQlZ/Ysk0SAhnPbkM+tHiUYqNBQW2a0I8b2VW59faMWa1I4j4rqH
+SGNEU5KYySlivCvyL0Nk5ugsHSOza0Y1pV6NWeoiqd9aFBL9dMq5HnpuXP0Elb36sg==
+	]]>
+	<![CDATA[
+	OWj6grWkk+kO+2dCdJfG5y29Zaexj7dDO/O4Mbl52/vQxOhOq/IrdGJVZnvqZbczusXMuVxExu4d
+ohmj4rgLZETuhSRCzobsMbPasOORMz9auf6MWt1UizNKhmbdjI3y6EjMNKgydyxNqnNTVgbRUFwj
+nMuw6lzd9LgMWUpGxhw5aUiBMNrI0cxdRBpHMZkhBWJqrNbsSIPoJ+aMToPuC7/NkOjuhvQvEGS1
+GXHkNtOONF7CWHObp+yaxEI1YjNU8paQxwtES1ciUuRTxxSIngOu5f56xCglZWcjWDnboBTxJWYF
+YspWPKKPaZxqjxx5JCVFMbvzPIqIoAyRV+XZeDe1jEexQLjMOjnKAlEmZUOd35RDMdqQTtHkjzPz
+SiLnujENVCXOQ4WBuJow4qygJ2KMZFXhAwQKCiptVkB6q1R1C50IT/EBoeBkAV+VyRPRgAABYhJY
+L9IbrYkaTVQo6USkOB1k3dSvu7Lxz8hk6Fp2I1JCoRNBNtl1MiKMZjbjs4kjEUZERCv5TZ9KA4LB
+xOtE2JgIqQmSVGcGBAPZ9sk+ERU2HOfsm4gc0QRtSnZCIvw5FaaJakOIk4rLf5knvyxe7yVTVxzG
+KRDThem2ZmISB1ZRGMx+qDD0SlyLuZLXAYEALAwFpBFnay0MpdJlVWiWIGGtmWaVgTjaZVdscu9a
+dnQlqCatrOIsK6qQ7tUookziYzUN1t46LSAKWq1lhM/Ilncdw4hpYsqjXn/s1ZCouQ2NxhINt9rM
+WhYGs/ZYgmfBkj12QDDwWJ/YA0LBkNVDrwPCAQaMIbgEV2AjYUGhBYagUA0ccKGBaYAKDVz4gHqC
+KsCAcGDAc7ThGD16vTHXjIzzVPeyunGak+igK3wqdzcUKdk7IzUkEQEGiJamBwSDSVj5VdBAo7UD
+QkGHxA2vRAAZTPiDXmBT0s35bN9rJHdBvAgWHSvOEYqhZg66wFQYXJxz0pxjYJ2uBTTgU4WhqM/Y
+yTVTlA05hqHS2EwwIDRAWswVA0IDzqIgO6kwjsyAsIDz5RtMpGG9fkZulXncz+iKd/rIDCLq97fa
+cbZhhQGioW2QBEVkenZ8xYa5qkB8airprIhWT+g8qhzXPQ4bYoaEH7m3/M6MbY5EzWSqK6INxBkG
+BEOJOgcEgz8Eday4C/Zo7+1KLkO8WtnpdOdO3eQonOLjFy8M/tj/mtwV9s8Y5ooBwUCc3Pkzojcj
+AzH2/1T0EVPJDar7SLyl7rFRD5kd3UGl+uohorPjTZX0fmIix+uotn6MzFJ1OiOp02t+U3YfL281
+znnhNLZR3TixezvkVGUcYrH1kn+4TrDuSmtbntFJ5+2sysjspmYk9+PHfiI1RTUZK3/uiSONaZ0Q
+scpZb5RGqf06dObdGPvZUT0sMZreadCOrWtCx7mfpuhkGaSym7ors7taD7EbUm0mqirH5lhWfGmz
+fMQa2vXa6knG2U4UnbWmri+UKySP0l4g7iJzVeLh+y8nay00hkgmMbJxdcJHVb/fzYn+qqspu7lI
+ndRJFe9o5xr6LS6+VrndZ6aKEBE5sq019hkbozKy+6PslyJf36ubb7tT3SATusmZ3TvoRMOOvSPD
+Y1+xrnGTltiMOSWeDMlPyvuYDGvruKzUy1Z3vHairjf5dR5Seiy6XpgHhIO5L8S+Fx4QDhbXC47p
+RfsB4VDbLw4/GegF0X2T7MLk0wfbIP4pgUkmaXPIBC6LbZuhXiE1MbEqF2dpDiSZ4iXXXWYgM9lB
+SHzfVdobi8a0n1KOfcooU2lcwmdVImTTFc16u6LdZyOjMLwoYxnH6GADAgEMnRYGmg8xhU3JSg0g
+GyIyISszK3tRViT0jfl1Y2dmv4yp5FSWDBWndhKxztzlKGO9833DHu3QbfvI51hTbMRjHho0xAv1
+xFxGNshj7A27oSOr3BXBQEnEV3c20yAhV3KtiBV415io9TFyIzhnW5tRNGL6qaLyqCFG5AjeezQz
+U1DMCkx2s7G3yg62dkAwjJmZkcnKbgVdNyMj2YBgIJuq7XinGRaVazMrUtHwVIH4/Ur24Z+YHNag
+OsLXi/im1CFV1o20jEqSQ6Zh1YdERC66CPmCdmTEHVK3EdXVncbU5RG72/iUADbU5ZJp6yoeFbHM
+xhaFCqLqOjEVlXuWq4vdeUeiMw8xmIu2pkwWRXw+0zK4psqu6QyjE6u6CJGMMmPU8s5OQ1xU3OBy
+UY1rQDB0WMTHi7BhDQgHGEDTVPayODNyZl31ZHM6pGSZnDyKxB19MZLTDI/Yfey5ZdRzb/DsiNDN
+nHW3QIhv3/w0r3tnxrGIe3i6h6ggZLmROROKmNxd0cfGFAmADAIGbDm6og5iDQgFJEFT54wOhzW2
+GleXT8h15quMutwAp+yADxzxQKGBBsoKxgMuzNtCAdvAEAECFwcfQFCzgNqjFkqMoOBB4AL1WkiQ
+AEECuiNejMEKQ3ErH6BJ8AArOAECK7zKhQYSILiC/YB6wDRwoAyEzEkjGRAa4N9gnXFBiKE42F5D
+NzhXk4iZV0a14Qk9dwUJyuGBBgpO4AOFggeICy0EDRTogto1gMDG891dzM61t8Z41kFG5GseU0Li
+ZE5ERtW9IYSnvBoOEkKcRBeqz12R9Dh3Ep7FiBEziREyttiIizGbsUftzLiMCBJfFQazmMWkbEZs
+7DdYjKhNYmMogwBxwwLCNpZx6kbGRuqK1QcU/EADIg0gcBVKQlBIIOJCsQcKZC1BwYEDhGVcrECQ
+bq8lVjfMK3tObMgsKAYEg9HsmYJKYA9tQCggiARxRq4Isi+GADKap4IHGEB1OxGyC93c2FdadLlV
+W/160thsiqzO5uh3VfG57qPIrESIaGzQmJjSTV7TUW6oRo2JOTl6Rs7qt9QT8Ylo6GI9n560NmxM
+nFHE5BczuU+ONUFXMnXF+hzViZQMFoiiGzkjsWwi5tnkUiZGhGT+UF/CExJ+WcUofU1Ny92tMrVT
+b5Ejm95MNDxv4/E7WCCOjhzvVcRKOkM2NbWV5cECYefdy2Yi5cZOs89d+Xd+FJGIDJ0UTdlggZi2
+HzN5dU8lowWiQgGcSKgE1qolUwYZY6hoRgCAAKMTAABAbCCRRyNqHIdxbXkUAAlGMCIoIhAMFCIo
+UkpKViCI1BzDMIgZQ5BBTCIAICox0AkY+quYrIWp1ZSKNkR/NTAOkBXzWVPxMUxCTjZSQxYDXsKw
+L4fCG5urWmbuS90q48abah6TcES9eohcQgfIgeVSVPzlDHNQ6OOUpSJIr0j7CUKRLQ5/7iOLuvxR
+0Ap//Q8lnSjTpBG2k5wYNPUnNoz80tFiR38AIoMo13aDrFyyjoLMlKZ18S8oregHhVtypCn69YDX
+KHia/HcbAa/Yr0def8aSpQ4GH2RBUVarIIVywTFIiK/cPnqFHCXyrou+PCvvetAxCn8UQ5pI8RoZ
+QnusiSnQIBVDm6N6p46Yl+cStHo0dH6Y7e9tLCoTA//E8wOkWqFYXeoQaLxN0rKaWvOQxUbckkJt
+USZRJOoQI/XLJIOVZawuNGiQZB+768SfhQUqIfiVl4LAsRzfjuhCgdl0W/AwF0x760WFG2QBU93M
+UeiogTe8t6r2hFmpg6YX+QSvqO2U00+JfLuWQGiZhP4ZQLWumTGcbQKjiE0ZpfXICCjGhiwBzHxC
+jEg2Te8+PAZjjHji/VigO4poXQD/KrWLNECOam90Nm4oMbJlpbNZSqpPj5GOGs4Z8NQBS0YkNwcW
+mPGPSIYyoJsFrNuJzaaTIVscnqkUR69QmispcEEhhUNZdw7fY+h7QgoosiX6q8VDc20AOuVw1qsR
+Kj693hd58PFsFrcw5uJTmSDohIDVJ0skJNbhhnLQFQwAi99lpqE3lB9OvCN6O1nzlNHGHDSrgwwa
+QDE/TOsqCh3fxnHVj3fN2e/o6EcBttCFDL+K6y2WRmjtQ/IRQxnNX7tiMlOiVSQa9X8Qppamyp41
+yglqhokkd48Vyzco+PXSK9sKob7xtxYZRfeETWy0tq2lXfwwSyB4W9+o928atFz0RofJYQ/lFaeb
+waPoBPJ4Y2XCG0BqDOxkAIf+itGC4mX48UJogBNp5I4ki7n6/3Z6TNLfoZEhX4IEjhcQeRat75zx
+T6KO4Pe1GShUSpxcdzpBQ8vIJcqtO9I5Gt8LdsjM+7rVWAB/cA+DvfLkeSQsCF5B4F5sKYrjpUdX
+2OLmdYPM6W6XxunU5awich8fT8Kr/vCpioayJahXCiS4abzfFzBGel5Xdzx10bnajhFAwztSmAmd
+RrHooywakiLChNHB2heM6ca9jqMzUSfTDRS5PL8SiL5jyU87zbHFUYrqESSEuHYRLAwjVtRyaBMR
+um5YMqbHls1AibWQj311GYD4pSWaMlMLFFi5/cwvUc8CMLQEJmez8QB6D1vw/s1trwoMCvcecUkf
+NDGkkkJBsygoscCnG7ZoJIES2Yvy8GAL4aKcHkvX3WiRC0IoN91yobBMFOqfqasO5BainNdpC2is
+UnyD4ICBFS8WYGOB7Io9Z0wzoMHWf0XkSs3HlFKIZNFI24q8+BbcH0up6JT7ynaXxEpt62+Wmz3t
+qCVuuUWSOQT4veJmQ5m+PVj74gHvHIF/DtbTrf8nvtAUUdbHrPxbmTNkrH9Cko6BI4MiwIBl/v1w
+0QVdlk074seg+aT9KvmnSw1+nsjoJpSrIvMCLQQ/dMGl9o1RMefc5Ym4+Rkyz0sxSt+Mr15lJ3Co
+o2Rk5JouVIljQfHyWC6owd34RJOY/uxxQCKyOcoLnRSU1SnzdE1SVKarKtxI48/Aa66UThiJsGZb
+ePOFW/4rzosG67WBrzUwv2tCdST+mN6JPlqCYx3wBFB458FKwvQjcdMcG2USgiSZ99i4H1id3gmh
+AwuEoxe+d7D3psjGDB72ziM+KagDQiwmXPej/Fps66Wj5AaSpSs2VJdOLwdZuv2lg2gDBeQVz+Aj
+YE2jlWVLYowQZSduq0X52PH9xsZDGvxYqQZcnKphoJVgTAcEx4I06VgFjmnYBZxcdfI3VqxjJGws
+wVUX9em53EB56H22su7AgtXQtDksRlV7NVvsna9JuPatOGIDDmZo3yf66SkqrCrHUsCA5MX/f4vU
+QnrF+iu372WXCDIYBbEkJjQhAyITHgAI1skBCBnjmDZbb3X2926ZwJhE9lCyprBHAKefJVk+/MQ3
+u8VDki/bKD3wG7wgdb3iCJCp9GQuCR0MfWcI+LiJH5uuvaAdUxedV+qx/FeZFRhXk1eJKiTYUGtz
+qDzPY5UQqiSrsIMrLBHSAilZk6A4q0rPsrQ252rthXepD5bGoIr/knKg9bUJ/req3VY54rNafxAs
+pGLjr7M1N5wDkBuq/ylc2gNQbKCCmedUtsegb1yCddEePscJDLKnoGDGkeYX5CLuMc4ERijyOw5X
+ZCZsh4UJ5o38vKb3XshrBmPazNs3WYqdcMiFyMhs9eTlXt/GGxRC22eCDRNjGIBuYA==
+	]]>
+	<![CDATA[
+	Jvoqs5PV2RMFYyn0RKKYBriAsWjS6qYkYQPuRfe/taUDr7t175UbtZyHFwyr7SQAoXiA6Ct7VB8E
+OCBNr6VO0ySfQ1cUhJghF0Tv9nzlym8hbmJtAJ2XNGb638ctcYrslgRuZu+mg1ZXFpGWLg8AVzS4
+H4GDYhfq70jIcY99/TgKsdKkBKcEPfhl4NyOKDmKa0f0KidQyFWCYE3ZIel30bySGAUtpOIlv4ey
+g8aaBQITvRXsshlQMAqxQzgy1oD4kDnolCOj77iOcbnjxF3hsUqfQZrV6REKh0H1icFskr5seaj0
+25NhoIeSYB1YZGhGrsW2K5x9wGVGyE9UpuPj5nl9u+gVLKczIr5O6drE/RuW2qDbfVafid7xtaBz
+R8ZGj7fNXVyNKFiir/w2KLbFDsYs/zs3AKdJrPMFpxd49em9HxpNEHl88b79UJ+yJ7BVRkhHoVAT
+xGliu1ao0TeZ6971IF6yOU2SqB3u4wJv599BZxe2ulz+AYHb5HwoaJB9d4Xub4Z3oxFuUQUd0v1h
+KlXrcjgpsmT0cYMO6wMj6jrv2wawrWERbarBR5oEhfWVhyv1mMazUb9X/GVKn0w22bIegCCRinB7
+kYSqmQFfhklv1Y6bXxoA1wqtH5k4iNIuJVBSrufMohzVRMBiDrBKqpeAff3PzDEbKc8zobhauM8E
+gqlutxnveAfPFI5v0rjEMqBP0nCCITh16qPWan+juxlcbWIlQ9oSXEFqC8BhC1bEzji4qyTWo/ED
+cB2E28hboO9YH+XjEZcWJUlue5lhIWHZ8sFT9B1jhylKneOwyCJpHh39+y9yVMdEK1ILvxlsQFB1
+lZs+QpPxw5xm1oQA/F3ZuKmQ1ySNqBtMy8Ro+vIUCoi4kE0QtMEiJhA3CpYITwT7qAATgkZjqSdo
+qhW6Qe8h9DV5pamue2zcgZAVjXv8jAfruTAp/ZQ8D3oMOt0dMugVQgdG1r0gKsc9330OYBVMSj0C
+1fEIg/tfpVRaeKGaY5ieKoEICiCx5RId7WmedbhnnwcWVyM7nY+vYbQtSqIH/oXivl7m9clqm5lr
+4Ftcc2SeGRZzu8DUwluTjSLnSpQgDc5wbXZiaYUDCrDFjrf5qfATUaQhZaUKK+rbdbZlW8PS7sJ5
+TwkM4z7LcK1xylgkt/G+fGBGGgCoPPWtQ4rPVnBqWA+a8r2FhgB2yz1spyIkJV4+2Ca4HY28wwHR
+L0N6RWqP/pEknBcdKuO7eBfEykzj8+463YuXhkQEdfXCkllmxJWgF4qiFLAYPv8DBQbagLOztHRC
+Sre6u2gflHiGqmHmIaHppnpwNngznkWMQIU2jVWiUi73o0QDxB/7YkENsegZF69Z3CdfgkU33TZf
+FKJzpsLjG4TKUBAeiEfBXAH7U4RZNdz+dHu3ck1y6F7KQ/Wes92cBsVaRjY45g51w23a95kQG7rR
+8xAh5Ro61tVfH+2FlrczOngI8qdSw+8qW/QT1E5awrUVMboGToKePTuv4iCEAOHciloiOII+kjmt
+vLMMlhj7L9dksP247GpXUa2cczo6H8finfaJQ0GgEEGyRIoqKJJ2w1YhQkd8NVxb9pfzqoDnkGi0
+vTbWd4sysDRmvfdDcPE2qvNAILbl8SH1PXRBA2OSsgY9kowYzzly0Y0+9W3N//8MUiXPS2thG8lJ
+e3HjW40F8Mcq53GI6PESiUQKIoWnDE1qL6yIwmLGqWpgZdENCBQ9RaInA4sCnj/q6hHGs1uBwqRa
+B9FWErqYVjq5UyCPLyJHIAd/PFO0TtetqxDFXTSdP+RqRd8b+1uDpqIE8aIPrNvPwvS5V/jueoAC
+tRop411eb3NxAXcOgH8eB1M/X1wyMuXF0D0CZkCrJ9vTvQEiLziQ5F7GZxNtJamJHLUBTLyAID+c
+aynIH84o71lhov/B0WJt/JBcOtwRPwTB4q2m4OuZN5KcZQh6pWmDhMnoX+z6z/MUTtDcvfKDa7ka
+KPykxgym7EhwhZBOxkkrco/RPlEBAJKfKj2M7FiJ0yzEcrLiuzbE0/dKObor9UbkPLdKJU5p/TfF
+IYXZsp7oaGJgBSl1BsFFgZ2AaW9NLKGiua6LytOYQ5D9Zq/YCT0BVWnGVJmGuesnXX/t0iUhi7gj
+rve3QBDFHMRj2GrksCpatTDAdxlGLeNil+7AlDq+8Ua6zFsncmXGyDyuQPBUlMjc8oC49sbo69l+
+1F0JS/rc1GOLgKhbpD5PIcQrith92mi+0a06Rw1pmqWpolx0dwTVlPj5RApLTCBAAlLb2421IOVT
+ikCguHQwZFYJfzTndblRHgi6fKXr4eMIuYkBobnfuBrMPH2lXI6ZxRYh1n2Almqky/GVqlDsYNgS
+9tgt5UzbumDYjaMt2/OgjamE6bZBcDEoGmYfQ+d9L6g+WsqTfEIySZ7B1FDcylDX+VsQxigDQL3G
+5XN2xWKawimxKhOfiOePGZhqvNUOcevvbL6C7Pj5R0xEAA+hux+CEdWhuo7TIxGu4L/GSEFlSNbV
+znH02snLK17ohKRHOZoT9WBgVQRRCC/AOffPhF+YitqU8n0q+0cI3jatvE1WQ2HY4zYR0rpxxohh
+yLODNl0DEAqFWPaOExYFlffJcDCbonERuJoIhDieUfHrksk4ASoYSoJ9eKNALgZ1/gBzjy7O+enn
+UtDYtTd2k1K388CI0U0UIqedMCWFJuP+zMjMYFOP8T8eUkCWZulRKazvABYRvW0LykwCHGVShh/x
+A/KRGJX5pP6Tbl7hfTUGMslAqY0SIecwCC/uHnIIfVxpajwDMA66FdsMKET69R+pP2BEVTBMb5qU
+NzGtaeMGnKapsukR0RbJHCnoNE3G2+SkG+4zZm2F1GnE6U8GmvIQWQlVzbxlVOI4swq91OtLqRAl
+hqc8aJzLAjmoSWQjIZ5SwPRw3rbyxzXHopOgP2391wdVaLaiTlCcRAiid40OPFAFBnF6/SH7JHh/
+7CSjTuiCD//oNUduOPnpPQ2YuLfGMFTH7FeuLBSAGkhbEKa75ADG7zs0Ftp/LpBkJRpI/FdOhcwE
+XZv8jU3tyo8OXLT60dhwABmaZWpd0gpniiOlnwJPDX1VSYuSnRSArbPLow4HzW9C7IDjKahc6jFn
+GBxCNLHUbHpISUWF3RloeJKtjF509Y4xjvIbMFbgne93pjBxYGyGSpLw1vC1ofJoKhlzRHNZA1EY
+l9xPVFujpfWCE9j0k+UEmXdw5fAWDdYeaLe9mwxMdJ5UURAauPoeG/mCcJv2WdKfx/ircwsWPmTN
+WN5Zm+dLSm5KPfsr2RzqmKoa6TEIp8IPuqBA5zc13O1NP26FoA5BD4SqCf2M+I6SFmfLqApknW8z
+dsWmRULHpURIirG3qOCnHZWxr0q+FFfBbKO6igr9niClQtIu4yFq4reMUOqkF3Uri979FoAEXFQs
+o4UKuTZKARJRnpm5JkgljV7twlnxalxqiigGVC8yOMDS59sy8ELCuL7PMEiHMc+Wnd98QWJP9njr
+7gwgDVWPiUQCkwxW0Pc7jjvKn1Z6JJGd7HFJpZEyaZWa6/plDzTGkqxL6pftnZhhv6uDoSsEgB0r
+UEekWW7XoorJsU5ztOnOtDbHZ+t1ilfCEXLvT6hJpbBiYE+jh+QVCFSO4oQm1Vd5z7o/I4nvjf95
+1alSReiiskbkqAfvdJshoIAbmWArYKd4xIPdn1Iy/oWOl6K/ceIbgSy1Fo6CR9W1tSjYf/tl561d
+8PqEvdc/lml1QV5PzlOpYULEZZxdit310KaV+Cg8k74UDocureMDIwrHR1vStFvqmfQNMywEngWa
+jFTQGhHgNCkzF8W4P1hDkemSLtpD8e70u9Bv6nrtwHAT+CYdUR+6ouL1V7UQja7eGTLiJe8DqLK1
+uBAqWOJ35L9PRtCidHCZkCLom3biELHJMf8Jhrvub3qvWpKgQiq0XZsH+MTrGk88cagCWWk/2n9a
+bvf55vRMs11XfyEq7g+SLM1njovB9aPySPBPKVy1lsgOTlpo/kvikr+Adu0HObVfCdh72zL7QQiL
+pEmnXZmb8QrqWuJJH9Ac43A/d4H/R+m2uiVDSOD69bEeFwoDlRxoUssbdOt6wRQx6FmMFtcJ8P25
+AWkpRUaSg45qhReo9cfFSx/pajEePlIEuZRCHuFqWmcmG6m8ggLAdAhAWnQDdX5vFxcW/s7gpJ6W
+JI14yuIxlAbdcSRYON72z6sACjgCGl04aj491e19/T2l0VxWnqos72r9LJftplO8EnQjb+6l8gG/
+4MH1QC8gsRz0O6IcvTpl4Ja4iGMAxJ4xKngXqBKfZ87d9YJt2FSuCDc4qhqf6GmFOV7N7bqHi4pk
+9XJ4xQA+PBj4YGG0L7W6DaQyzfocruUlbYuYcsOfrw8F+GLP0F52M2Kj2DdP7Aj6LhfUrCqz5Z+H
+9UA1cEuv/LCtNSpqmgiKhWNf9Yjbo6Og15oB4wWpFOA3o9OLLoTaT8ghN9rLacXFqEql6Bhik1D7
+AKHwEyXivJrIx4Ck9ZsXeY8uf4VrQqgjoILO2nIZyhqJIQzYMDkvBobOWVjqhAYa3oqitNsOISn6
+2YBVBGcf9DyqYd8KuQMjfK22gKHaJRkJ98nCXBuRqawElOvaQNurYLJ1G1R9GvNzIZwOG/nIoaQn
+w20ietKU+FcDtgqG8BZuxEMAjsbLyhFu+2+4i+QTk8jvhZuDiRAKrCQY5XLESKVraLrxcrVQwj9I
+Dcuq2v1/z5I26vTLB0OHz8ZxVsggPBy9EZMCSvwEz6f5QcwCi9AIxpdHSMJvXCvPhLpHH+Hu2j+G
+yDfO2sTEEwR6nRUvPb9bBW1Uld4F0Q72un9xOWT1u5PoI9jSeo1dH7tskpx6cAzq/XKqfSQmnKjy
+HmATBTvuq+zw+QOctjJ6XXbos7HOgBNRdYZmiFykEgHNni/HkO4zDPoaFKuPZYjqJJS52IdGqPux
+WAYlwJAD8ZDA1mU3e2qYEaLyxIQOyDIdi/AYWdWUXQyG58NAwm26e2y2WjAIDty6dTI0DaPfCZAa
+vO/Wad5MTxPYqEPXJxOAUETTlkhagfzIXtJmjOcA6c8TKr6xxiUVbEY9XD/SKEDNzCaVH4tWbBKD
+MrmjRp39COgcfpTCDKk43bRZeAzJHqnPrb53AE4SF3mpB98Rcd6wPidX8+GcfKWFOyuOHf9XYAV2
+eaT84IZfu4hvp0GdqxzA3x2A0cf0X+6NAjrkLYGAuccIkaqLM/kK5dQlESV12g4vC/+6TQZg7GCT
+3wDOAyWhrE7K5D0kwSq/mweRVuYhb57tV8rDXYTFI7OsD0JsCk90+qISV30njFXi4Yp3KtG7nJJO
+CFUdrFHf+g0lXdcw19Zrp9wUcg4nBK5F21AL3QpE+hoQ4fUdRqhSUpQsjL3IaAJTzf3OE9ehHBFL
+iouTBwqMSsLT1SEov4aHgoCmdJI2Roql9rVa5AsJtJZBASt2zxJ6bLn03BE8cwLiYA==
+	]]>
+	<![CDATA[
+	iQyvB23s+JqWwAnv0UZJsLe09JQNjXtX7bMZMudyl50GZmydBT5KGvPdREc0U8lEeft4A0RR/bBV
+iFBRynBgpUruTQs8ItCdbPw+lRJ77Koddk15xcUvxtggMrVy7i42ibw8PvQ4uRki5ybhsc5KEII+
+JM9ht7sssZQ/jyI3/o7SGLln6gbnmvkd2G0uDKVhsKBV1aslz3YcxBAIwqxirwgP+KllwcmNEL9W
+HmKGw5VOH9qq+rXFUqQjxCFGzsWX1yNvnz7x5C9i+xetD0cQGTGGBGD1rAUNucsG2z/iqh4oTXkR
+3Pn6so97gI7xE5xDWTIS6ojU22sAa/bnJkextjB5OsTcbuzPLgnVHsA/Rt693WSUQwpMRFoMDYOe
+09RirGSk6u8BNMUogW/6pgb9dJlU1Lr2AaYeoVU782ohj2Do0WO1XgWiGlxDS30AXbNxtySP0OAM
+IVvVFsmpA88y7R9/7m7KGVDzBGeyNjKqe6CRP7n19pRTnhcK3QtULXmi32DkvDXCu3u/hUtVSLl5
+1aRqwq688FuK5OQIkgFztwnzW8YSzSXzAS6wCtnq0ngTANGEoCDUEs8cpL8PGMWmlF8req5I+Lag
+jdp4FW62n1WcyFPAsx46dUwcuSKM0I/W8ex1098rQvDZ7at3YiyKTZ1C09lo9nDeGrmXf0J7We8W
+K5HtLPHMkcl2hD18US3zcvG8g/zXhSifIZxY/BL5Novq62z4G/+zezfdXz06VgJ9YnsGWKiRy6+N
+v9wS7kL5vEqZp607KANVrFDe8AcK7W9ACEqA5DtgJFEE1aj4VBkXlgmQAdWuQwnRADsjOo4iRQN1
+Xx7oAeDvea301vYEtQdWykBWqGTv6Tg4GKxO64dR72fugMfeVDClAQ0ti4Zk3+SCkvdSHOz2UN7I
+4Y4WOVHHyRG1LRpO+orQDjPjhDo3yZ7BPKzX7wdFnNYvvmQbgex6I64LZNVMMiyqjxYVusUnO9y0
+UCJI2PmpaVYI9a26AQyH9LAtKz/YGSwhOrYCcQpaIkoNx9hoovIIoVJRu4BPREd9BTuPNQTwh/2q
+yc4Yb0PWo49tgwDyEBRCO3ZRN0UXd5xCYDUIy9kKEl5X3Vq110QMZ46RjADBATG4kwwLQAsfbcdC
+cdUqE/Fr3ydNCpx8794ZMW1DI8yfxG6O2wEPFH0sbCqSsOqAh1Mu6mUp0ZNmkrfEh64QTSIqhdLS
+I4CgT3+fSR4lHjQCRNpZFVwRabQ4B4wizeo+VCC0DQQeUVqXKVXQpv/GvknF964BBa48BHJQ2FO4
+m2ujcAQ5ek9rNhUTiVzBg3vN0c/TQQz73ZhjEj2cbWUDJbCDd8DYRyGhTyUY4MKpOnGiFZtIxBVr
+Y2DU6dhSuo4AJHqaCGPFGXuwyhjsyn99FKNa8kSpCmQHiD8z6TIaUuJPVWDBEiYbH2tJjWxxnW4Z
+/uxTQaTIUIZKjIcTIhKmtZs4AOqEFJGUBHPlDqwl6CZIW8GFfd5LH3tRvpvliFK4tUGAKHlfEl2S
+iNZmwAMIBbSEvNRXyggBoso5AkaBpq2M2sMe/kbKiRSSodoThbf3bsHoFhHMGqk3c0URaUPB/8SO
+GswOFqbdEEQIWS0QR0riwAYGtz1MlbPmEx5cQ/QXL7F8/KhBG3tKqV2WlX7WrIZMNY/o0d6NkpMC
+aZbx09nGUkoLGVHWI72AwL/z0FS+tdDgSAB+4zXUZRf7GkhIalJB/X0FHd1gNTQK/5tgRfJII0qt
+RE9B6IVUvGnFyq+CFhXAl3tOomywPIUSwi0INmTrPuQqOkpojBSwj4FV7CLfB7R+m1WyR1sGIDES
+3QYcGOFKJDiWgDTxAJkZ1vgBTZYZmRmOnqZghRYqNmigA8HuBiWru3PmU+tlPt3zPgvhMywmKQIR
+uPKjI9amdaYILCN9t+O7AZgSDTf0NoOTDAvfY1l+KqI8NG4zQp8sDUjCvs0LkhOgJAcQbeLaFN9d
++/qBbUa7DmWtBaijOJlJWaFNY9xoW6FCnxH3lAAtNT49PH+aQ6FooBeALWSM9nKgxlPU1yYXuKx7
+Mscz0PQnvjAOvImJ/QyC634Kf1Q0A9erPxxZBkDiiNLQxa4a9ipphqG7or5VBSfTT55Mq2oIGWtI
+QU3RNS+zomjSVQ6/tN4Enj5o228+C6tsacTqxDoxE4MO5vk2pDULmYabAxAEVAGN32b9Saum73s2
+ZgCWCP+UHNlCFcFSPbpvQ2L6uU4ta2AbpgWM9J+3EugYdCo7BgyJ54VbBByaLAWwY+1IXyYVovVd
+aMKOPa48WHCxOiYIGcEylECU/GxIwXMm11wGB62eFAjE5mkN2wGh8Kdws8Jxy9eoOqrJzSOlJG/Z
+Fd4ERcqDXToDf+QCOyg3gSQ258TKHW70BhK9idBVjOl4/KBLdsgcR8700ZyD/D16VC9caocyMzhC
+/DMNa9RGUNIma8WgDVBICIJ8NdiwJaR/TUvN634iZo2q1lJhJjc9pvO+Db3dhoqUDXDyaT4REt9O
+I7rBaUX3Xt3R5axU7VpCzhSmY1nVWUHQzqk6TmktAhtgsY9xuahCbr6n19xA5aB5vwzoVpbBG7pt
+NBTIXPiFux6DKnrDG3PrO8+lo8age30aoDlwZMyTCScCTqKyS3nYAowjgUx14g9xDol6Yx2qJp3R
+g+LuWmq7W2aKuZSCLEXcdNBEmcANhx7jSSNCoP1U6B/8KwSpurpt8/5RWW50fan5VfHr3elnhyQj
+dgs1jvurrCS6qRxlRh0MuXs6z5IGoNVw3D3D6eo3xkQAv+jbqgC9xPTkdKKXWpGPkDULliyXSrsg
+kgOLfJmEe6WoHfQoQ+xNIAXSuF1Rj960Y2Qtn4zA91CgusReicPHY85Yusv8fOpz00cfRE/vn+Fj
+hpfn+UYcJD7HFpaPXmGt7KyN9sy5mN/LZOZzd9zBGH4lVHG23nXhmfGeI8TjZ3d9ypdFL4QhNgjJ
+OE/MwfFoZ+c+dIW5UTYdv3/IusTLOiBO/f51MpyH08iE2BMVyEGyyswHP93NlqpxUpx+898S3/Jy
+BS/u3xpteNmRfVkV9RIUUjyqJftWQp2VyBgHui17bjxbWRCnSE5oF6hQ3tCb4aazAdDh+7alofHJ
+vqZQuplFdnWg6yH0MTFybw4W93HZs70Vx/Zx46jlGCwmFpbctN8V5oaJ6Sn9BjNofKRwNyvqV68R
+dHbQlHIXGHb7ly+0ejTSEgDpf/G7cb8XTBLsvUNvxKw2B/WNoYw+M+G+nWf3K4i/t8nQmIHe7qf6
+k4/9lIp4lDsSrahzyOoNsA0mwDf5mgESERYIJVW6vQNGEDN1IfCTeR53mzF4T6gY2g+pdbZGDQhJ
+bUx4GAS1fzsm5VFCgIsyDoHzlCmYF9wbtSLbysqt3MgmtokV0MG/yzfIiYWlQvfc6r43M6Ipc3Dj
+Ln0n55cg9a0Yy8ViYTrDMZlYuaqT4rUN2teYIFOfwP3PinCNw/MJddgeKVH4QEWDNrmgCoXJ5a4n
+Ri/mYejQXMR5Ri/jSy7vH7qD+QVQBaOQvg/inQnQXbei4xfz302p9urdflFSF76++F0/y02nF0Zv
+ZjUaLi81kF0jWvMXncyIrSu6FyPXt7v9ITpN79AP9mlM5HLmCkC8jq4ki6fRPKBAMaEwgDRtf1Da
+6X5NO/9/nCqOb7DcrTX2Si14FKCIOzoQWdatiDgKFSC2MPKQuAmT+y1yokYEw+Az9/qzq+mWwMyE
+RNiAbH+Lq/bU14pzBS3+050JAfhKHFpYvOzW9SjJMEClh7XGvpq+1/Dnf1bskYyIQawUQ1/pRUJ3
+rIvk98HxfkZQbHZ/nv0vNL5mwy4IdrlqJqD4IJteMQVAQNIcbke6RnL6WMJRKo3MUInGWFKOaBTv
+wHkzREwqh7WTn1LzNJP779hEQqgmXaW9AMILEB+XSRig2GvIJwwgxqC9lg+7L/t0NQ1EaJR0UBcJ
+/LcfdEKZ+Cj9eL/tAzUdCye0BfGnuVBzwgS0CVbda5/E/TEqe522LBA0tADUeIcokvVQWChEh4sf
+51dWwyshnyoq/D4SwUd3wALmjCYcScuyTSRHrqKAx2rwg0xQ4iZcPOSHUs6mKqrQAu/ANMgWE5Dc
+OrEC+5QLmUgBp0YeNUeh09TiPPMVD5C6OiOWoNRFECBhw2fcbyL9VgnEmCmegDjMFpvHOGm5qN9v
+RCiJ3D74nFNMuoWyUXjcMqn4D+RqehgfBTNyiweVumEe+/+CUbVHmqgnGK1QJVLC26xQzZjcS1rg
+DsQJPD/K3iwtDKrvAhw3DXtgz18FtBcYWQc/r9ARL+ZmdIJIyNKWRpXnOmwvAC2b0vCEmZ3URgB4
+biGcq8IZeYzKxQ5Sfzu6PQRN4wt2eCnaRzMYRb2a9JOJdsibItr7eofXRbBDNW/I3gEBWqrqhnHo
+FcWaRnhiPZe0SEXHe/x2hzZXSQ3i9e4aTq325g9zRWpyiQMgDUIxc0kfZZAej+mtJ8NpZWC+yHfC
+gpc1ylK4OGDvkCKAojXoxpjozg6a/lJavvGzlCc48TjGxOU+MssodMc1vg/LrnVp3ANgZJY5Uc8o
+HtdnbqsQOhFYnZMw7dBZrwzRXbBgYG/arndWY/6/41rqLy8aRchldfsEBXVLEoszhj5Cb2Bz4yFt
+wwjEULdVzCFX4n/9A8lI8kpd1pIVxLYrn2SHQN1aJslsRt3776wNqi5Zu4Mko5Bv7V+bNH2NuKFb
+MFBzn+hpgL1idsa/hOv+TsPrdq5Oo3381dSd5qqbwQppdQVephqgTAMOhhgavFUxEWJg/Kc0V0LU
+HJdz+9PLML8ozf7ersUa6LaFsdRdy82ic0YTOVONF4odeNdNF2o4YDh9dH/FvzQ8VDMLSZeGiNK2
+uwICziI5gc0lCo8HnDoe0hFXlKqpXAhQfT9w5hFz5CqQQ/XPyI4su/8JhS4UGfQekhNIe+/7ea6a
+oOVm8YqPkjMSvYT2eRDg4lIdU5t8+5EO86Kp3FPLtprbY0TPH8v6Yxg1f7ESvx+v1bqvk5D7rdAT
+KNgrgA7x/f0C8GIyCxUl+Dv8L//22UsWPwJdmIfoi38UDWndBl/1GKe28FEuPoIqhaToM2cWpn8r
+9AXJW/wcYek+z0RZ2GcPoVROzEoZDSOLlDSjYT01xHXH6uKjGMieOtlKsoPApz4/mjI3qLOybKkl
+5Pj5tY4BSB8y+Qkq1dSV7XUHMEw2zyBeGcKUdOuAPjqjWP9q4guQgOrMcWH/qPjKNHDkoBGPtqIg
+YCM/q26fNUFPrSgKLwR2kWGb6DWNO9VA/1cjKLuYxaGa/DIDvvWP7nYGXoQxvq9qk9c547bkj22V
+9NAyQPcTkqHBNCXpBDlkatgk250BBWPyPXvm/ktGSMOYexrPM0qsMAvUQiJkyZHUYRK7kv49D1UA
+yQ4UTXJVephksEdWkPo4nCPCwrlfeYScUKVnNXDp7za1MUgPFjrpwKgAnUysvtE4lQ==
+	]]>
+	<![CDATA[
+	PEb9mvb4ggHt4+U4zPNXehqkDOEOmyWH3j/iqwMYLvV/2KuMFkK3A6UpuNCCAicsJYmRg+hqshD0
+pU212IPFiy531v0g365U0mlec8QhwGTO+EmADGFV+fDK9bSwWVuXDuWjWPDorH4HjxqnU3f5DgP1
+hSzDGNDoYv5Da7yLlrJHFJgkVF74KV2hq9g+LKMd8oNeFWeVIcqr5KCvBz3wLyR6CFAerx9kyNHp
+zFIIO3Gz9DWlivQuV0gwg8kTeVJd1wYGy1HRj8JHBQaQgQR/phA1J/cIJ0L3QMhpNANUugf++i2j
+pIJjrsgyqsOSwpLdsBOqdL1IDMEKp5DG/nZhGcYahrXViOIpXKpiiVu58U+HHCH27MUVrJiaR5iU
+EL7EzrFg3KeNh2RY9+vVrhnWGNY66FVP2XXYB7fPgqOb1qE43LVF7vKyMewabOh5xGSIdRMrNys8
+ZUrDVrV8uckW4b1KRKaIs86wew8b4Mga5volcokdFIi5IjUbAG0VPbklTcTO+Bx2WB6EZV4xpZFg
+TB7ixqFKwfVW7wr8QKLPb8jpZGowUhUUYmEiW8HO+vmRYX3KpqXdMZd+KPG+uGOgjlCsY2Tmi8nq
+BFMgE1wwKTUQy1t5y4kcxoOOXUjUKgIU3MD5p8Erg2QvoaubEaFBuRGyTs2Lk09utrJdyWtmsfsn
+69DMmFj/Z+wn2WeJ7N84Ra8lbtK+5WV66Pa070hq6eCpFsdCl69b9KxYvy0OikCoSgpGyh4BIYKz
+pvqv22TN/yjnEEXTH5GFOCgA2qGfBOWgYZ/Ar6hRdyGh61pa/e5nJKOfWCL6WWAIv2JHbPhPbvHb
+SUilSC3aThliKsRuYlSa3KA49sL6r5fZOCOkPVy4Lsu5DUUSTG/EQIhSCHCBzlEP/Rcu89s7qOc8
+QQShYUAXPpsJH/pmAvwBsMxxZUMDMTvt4rLNirYJfZo2oJupW/Nj5p+hRQx1rTXcQUPccovhTq0p
+pgstM/k6hWy1iniAC3jCmpHInoqCQ4JcJ4a6W+djmsIb5hZU1xkV50odlRLwgD8y7CJuvAaQKxv6
+hQhDjyrHu0Nz2/LIsJHjatfbJa0/R7d6WsUJuT1VfnovEgYOspiL8XX2lO7TBwYgk2XVhaRIqeB0
+XsuLjQ6aDBa8O3KNh2vncLIZojCItgUC+yUWBWS44Av06rCsTkCQqLtAiHr1847GlNpA3UQe0t19
+vXbWxk7lU9HXIl+o/GXfGL0Aj0eF6o0wAXGWwaDEveCjr6oP/H/vb+hjWDSbd3A1Srdet+zjm3DQ
+VzEBszg2CZNfZ/V2be+DXzbqiRKu7Ddz7cd/zrhc3xmI8koxMTIQp3ALnkrgvwFbpL1FbcIRynzJ
+eUCQPq0vXCCYzbQP6HAHiXfGTw5i7/JvRNQEwXz60aIM+UmyDyR7r/suQd9oa8u07LaDbtXBvUMI
+cKOf4q49J7qh2AhkQriW3fERmDGpQe4Jw10SvWCP/WQEc5S+C9uZ9wsw4p5M395SJrw9lU2skQQ7
+slqoYFuUR4YEsvJADkJjHYt3L4cGccS3bY5HxXLYDfQol/3HZdGMGgdjmJ5iY1O8/PvSmHLTISK5
+BSRefG20R5+VJpPHEFjr8boATzRsH2iFMl3RQWJHzkBUTvlBIqt09TNtvaBTDSWdCSg4SY2zLtCP
+9mGv12VIFo5ZBozRHnVb91/8cYZkgKD/bwg0FmH1vdJQLNl+Om11kys33ra7nY1oVD4Q91jht2U1
+KD8CSS7B6V3qTpbagYDfaZiV99iNDNzQVmwpeQIh/n049jUdjHRESN7z9R2+KD1JOpn0khogD2y8
+Vp5g3WSwCU7AaqWivAGoKJ0eHjjdEk5sBMH4d4lb/JReFaAU0AuX4oINqdG6IT7iIltEOy5sNauY
+sNY2Ur2jj5xAnHX0VdzuNxRw2mXjOmIWY8IrrVEyY6yJz4QzzEBxQrV8HYxrSUU4UUHlrRR4HSpJ
+eB0Vg63HcpOpArWx7vWkd0Lcb8KxI+BWMBafez/X8SIWcoPgG+80Q+wM46KJ4hUcXOjDy6pUeDcV
+6Hx7wNMnRBkSN24S8wwu9hdi8y64jPjwt5WxmUPu+oP/GVAzeSdXkP/SZ0BkApGEtArzec+s5tWE
+st30xNrsQ/OD/3QcDCZdF4RhHPd629jkElxG2LSPVwuzyYXMbGsjtHQqgwCr4RxQbhrwqeMrHSYS
+W8r84glyR5XwVYMKGunLgDaLepD0/KR6kQwlEwAtwOAdXZuHDqoDuuOLkAtuF/Xxr5fj+TAQ/PpF
+hd4k1M16By4eZO34hCjQQWPkyID9HhPzJeKxBjyhai73t3LOgLyaqAFWECG2yVkW4hCbb4WT0xtO
+7t9fVyU1DklB/5U2ROnADTR0+vQoUzIykBQVnZrcGnLdeJV/Y0NrJV9QKgRCyER1x1ZDT8i3ml3I
+HYhG7rxv9ugLai/g2X2VAk0pZJTKlJhVAaasIQoCIUbHhXZh19cQLVE/p4cT+pyLjT5w0ufzxBcr
+LYqeuRHd5fk6/RySpntzuAhdueTs4LwmfEQJQ8//4kTjLzg06s3pqKQhp8I14SF93IqLUXiN6l1o
+Stci0THR4qJF7cgTBz7HucKt2q9YHZpEHTkIoPRvOgVmN/NfCm7AX+EjgYNw/EhsKZ65duxyLeo1
+HY6i4hqcfYw5gJIxqCSZViUKEcJpbSmPaiulRV/WytWbHQhnfEvsq0oVhibUMp5RBe9HF9u9uKj1
+1/oCCemm37s0F4MFo4vOC8bNr0ijxBZXEXo+2oyNrQiRngG5GjdBxFWWWi22clDt2AA/4ZygBS4N
+f3FDLyEmBPweZ02hiOb02YHef97zkQUNAV3I1cCzaVT+einEWaJglTi/Ao/1A7WyrgKRki6Ubeey
+f0QjRI24eGFBpDo12iH8LqJdOL3fpPvp17u2KhqDBM+sQWPVcfmUWt0EpyXaIt6iw1RWXBJsj4hP
+33ZAwqcfW8gdKR33Z8pXQUk2aVtocPEr0zT/NXqxYQfQqktmR+GL1eju0iLuhSppo32OZmpj6eOK
+BQWTo4sVfSs9TlVHqW2AQ083wGyGgseW5NAkIJS8TqxRjpNmGN80xnzQ+C71My8trDgSK9PLevOu
+p/fvfnFlU1l2JWCOU1H2+BrR+1BQpQv0kKL0dIXHtrGj/DrKYHfvWxfE/212+zoWrsKO/QqMUk+9
+A9rHnhno7rkOeLdO2CDOUQF562EfXqi7zBSywH+YfUAp4jQL8qEMrbmhqYw5AFlZIsqCrS1kKV2P
+zgFDiMMZoVfkYQ7BGhE0oV8Q30/hQdWcmz9JO9rd+wRstk8Ylr3wmBPA3jbU30tHiIOjRShAzaTD
+r9zZI167RcLZSjnPiBNIbG+Jqd+A2FHX8TNpKFLVArTcGaI3JuhlB4XwXpYBqikIORaWympfzE7N
+k6kPHyb9gh3KqjE/2LNGPlXtHLj/31ACZQ6pbqtpD9+/25AbjvOagoF8jEavvrhChwml7uraxo7Z
+50QetEwXIGdB6OHhsGhEnaEYJwRP+BtDu5N5yBoHDqAh9pTSvf39maovNPEjVt8z3eBYtROHJJUm
+qn4YkCAutxS9fLpvD8UI0XLJYNOd7pm70wL9DwUTPn4qKwoYfFszW5pn27T3TI58L5poytJYdB2H
+YhYyLdTmZeQAIymECvvc7TDj+RSgWw4gfkkdRcsfBMN5TS7Yg0x4BTo1M7O7cWlwddsj/RfabeK8
+dBoQ4yr2ChBpK4nIqfV67/6fuJco7pg+V6eerLDH+XuHyKnIZ5d7cmQCHeiwNj6JEIyWv9pnRgnC
+1MF3g155Y5mPx0GvADzkfsKlIJ+M7NFFhTlMqquFZKLQX5rMYUMHhBwX0BbiAtxipH7ITz5+VW5E
+itvfD1vs+xEAH6kzN/junkGvsiumliCrt+C/NViUdpaYgT5ZDZniYCnE39uG74K/hKBXdHxqTSie
+QjoF+WiixGw1SOBhU3KQAhSNockHTOi4LC4mFaDDGCofsu2FzGW4QVqIlNVilKHUNAt1UzFIxCRH
+R+jH7m3D8hZcAu0pPSegUzLYiewvBN3RlmUTM8bh9IWIn8aJFz2Vw1Qs39d9lmoPErEwJR6311Xn
+1XgVJjKxyCJyJKzkhNEO+TY4joFEpnI0gv4w6r0dBO1I9CPIax50LZHM8Hz+Y0zxHpfis5wE4kCq
+jcRRUMw7aZUCxMaIG2R17boQ8nxadIZMteU1OXrlldr0wzW+O0XuMZRKlgXaZwNZZ6ccymgMM45l
+T4zI4E0hi7KbCYi6fddoS8n9X5oJGMfrKy1+vokdfdHtx3FxwebE/ElbyN5VDvPZopMKaClwt+R/
+dFEvfwq04o9gKAH8NnBljEyV8lSHghjLz3QbLCSUFCFD82gIz4ZbhS9WPF1fv/hpnLjpRpfRq3sD
+821MIqMrxRhkRGel6Wk0YxAg6CRLf6CvfBGUzgUptOpPCO/bII4QMkXKUj0KMhZHMZC0ZuFj0Igl
+R5rQv6Yw/3aoxQZlmbIcw5O7WH5P6DGiwCwP6wobiXtfso9MWqlh4PALf3EeVV5717r5jo4qeZJD
+n1P20N5/h15DRrU8laNP/thdDFAHrT4BvcRlTw+VGTbM3w5R3cB8D1G6N55QZCdQBJHE3JPIA2/g
+pwvls9qJybSlw77wmeR6PCdjRQ4led+LqmzA/GVo3wbObiKLRvlWRQl2QaWAQFPIjBWj/aG9TPDE
+bl908DfPGN638Yx0nojnPES5N3DJliJJoWOSmwOkLZWTbVOMNnoO0HMeC4Y9q+BkTWxky11NNtjB
+bXpNgFzXHx6KrC5lBqpsv4Y9p75cQM+4vBVqN4VxG7GTWSFkqpSnOhQUF1TVQkPeP7qoy18FrfJ3
+JUpq1DQoJUXmFuhExN4A/yI1SILlpgNKU38PFXnEdI7QJIMd5b6qAKE5YArBevV/m2wU9Ri6cMnd
+Djq3qD/PeveQ5QQ/aJrcBuQoSTMmFmPd/E5GPgM53UTXD9UOUgNuLCMIGIr1T69YQ0+iCk0lwk6v
+1+fQNjeGoiDwmUS6zZt/zXhgDyOTSTk6RwOV8g7TtosZkCdQLjKcs5+huwwcSKLufT+Lydstm0Ej
+Fjlqiv4gK1CLc2sZQIBQ6I9epTZC1Sw0nGDfly8IECwuuGJOu3u8DZvhegyypMqeBpUx6t4vCKVr
+YNENEqnkaQn1sxFKYAZpThQskqEj9IehzkhqMM3ygYFCUX94KLKuWAUa9gl/lBLHcXPshQFR5g2m
+EBIrjEyV8lSPggZfquneAB8UZpIjkz6ievnGRHkCGbVB1x9qNl/LGwNZW2qeF2kw637bfuxVFADu
+9QJa5+ZWFLs7PJGqGvkFDCMQnUnkCTs0FN29f/5tN+TwgcIWOWqK/nXWusz5f4LQYCQqlJcSqrO+
+e7/58KO2EwDCGSgIUMtTqSEMfSnr21xFiSq8twfnMx/ExX0ooNbq6vxw/Cs0jISaQA==
+	]]>
+	<![CDATA[
+	GDJhLafN0QvHvZ9vG3Hkd6Hmcx2ZqthE+VoQImv1aKQrlM8mCmJgI8TLjjvL7jXryKiWJ3n08QfJ
+fMzGewEtEPlyZLGKIowgpGBFZ3CYh/Hc3qLi75ugIzB0GFf+9h/MK3GB7lcaGEyKzuyLq85wcAih
+k4Qs8haVY92gTYvT+CtFZFaRJ4snuRHZ2w8yDhQUlSEj9CMXIQUVkcGBVcYke7RA5AjeaYwcyelY
+I1l7qFrVQyiOyLGyRUerNiGD69+/v4p8uvKHFh049SzAauMtKubOIY3yWFCP1uhtGNWKHrwDgtM+
+KFoOYzWKSphywjhpxnA2mAPt4dBLYluB9AQYJbd1CD3imMuYff/XClaYNRFf7kFcv1Z5Q+/m0Tdu
+rulOqA14IURwTJAFWetHIb/Y8Tj2m63QaNjofhuRkc1iQtlaD5VR0sbyndBsh78KEQxdqcgfBzpF
+bMYQS5bBMSWyNnpX2wr4TzDoR89XELH6ddk7xLDRzAop1pvKDBf0e5ZwUnxMdESSISO0H8b2Fb4c
+ghmin/hCvT25Qy861OEdaIIKNuWiu1/oXIbH0ZqVRwceaogMDoQzom8tWzRF5BeIctK6OvI07I37
+Z6DJqxIg3Bhwg0mz3znCBuEbadyMGfxEqTLTzQHlECENqrnnwOPGQZX6EOP+BYoJCm1uJW2dsCyM
+Wna0c1vQ1SM02BAK9bsDev9l9WtQDrTvl1XZ55ls1/AvK020EHDko6b1/mf9pWO7CK9x1LQgz6tb
+I5i1aWhlDxc4xwyq1mUFtHcsbPyrJVRJqT2FjTWIvimaSpKMAPgOKWzML3cxopWR+Rz4x32dQU9U
+IBtlslqgO2oxR5m+Ps41D45rf8xoujIX4tnDX3aiu+cYcxtb397WuHO56dKKRwQHyiRyDBwq0bs0
+E2dZTkEKZSxYaeYdTVnpauQZTROneGqpsOKAdaPLGEvJ+mCbbjZfrXF6UDoH0ZxN4whNj/4u3ipT
+KTPHkQNvFDchaPVYqFiDZ190saT0Q5a3J5WAnEhvcFNGQwEVoAqsXxXAaScIZf/xn6UwW1DUjTUX
+iCLMWKPDecQslr7jFTAoVvpSOJYkZF7sxFsmMFIuYpQ7RAIXPyN5hEQOdStEBGPIorE2tC2TiT9R
+HEUL7TJjfNFPk+AoQLuMBSKVdZQ4+fFo4qQWC0TO9nONH2S9UX4rhwuDwQP7L8/Zx3FAGAWA8nIF
+8wlnW68kvs65vtRxTxYCEcIXqhvT5v9tA63EGFazezI4Gn+g40K9HLkPg1BxHjkxxDGUjm3DEPdx
+CXsITIwPil15FBC4cnQkXyh8Dpf6/QZDePHYFBQaeTJw6dvbbxSftNjTmzNgZCqiyVVBKiNpzv9D
+EoeWF6SJMaIoGAlaksklTh511rkqweG+BnoEeIyD4uSopCQJjJZNAsX46Cn/LJAjxIv0fjpPOYFZ
+2sC5gD+06CiQDSJGWoDvhMjesLv679XlBnjdd14ARAo/lKyOx4XYnENQwavJWEK4ROCJgFtkvNAI
+R1D/wElhEblcBPJgWrGHnECLaRqHWMRhkOxcaGuaTMVtHHqX/k9xiHacEAxBWs2gI3kd9CwKdRGH
+FIqz5CgRuMqEvgRDdodm6XcSo2dxhyxXVD4uSGElNw5tbGWZfnUb1A4ANRDykw82j50PyjNptJv5
+ar/aiJJEVwLrgHVJOiDbFQAjfAwO0CNopmXvRUTMbbeuAryuuA7ftZxPIzscbfhYAY0T/ZtW65is
+tn1+m3T8RMdH9OXBzwlAGEGSvgxKxDaADjAOgBaJ+wxBdWGAkjRcZAVhXaFKvPW1swNt//kPfa0A
+ff24vjMEMg9/yCNwosOUoB8/47cuvG3jAMXxcQt4eR0OEqpblMPfivwAuDL/IbusUURP+ELnk6xK
+vKcm8co4SEjrzLj+jpYnM4PyPgYE9AG79mhpjR66lfjVlXlpcuBTL8+f9aWJlo+c60hjGDqEaObn
+ZbUTk/9vr/IaWCl2jgws1CNyGYPW4gxyWohW8PJ3xDJspHq6IR4uZeQjopkxfWSjHwaTW/p7Axg9
+OVlkoAqiseFPYKEEAYeJithyysLBs8odoxsIuAEvjCFL8UJuKxKNbsg3t9whD32EK5nv2IabiwYy
+kyKjrEk/z+yIbmAaFaAd/2N9BjYqVGiBG1dV3ddcLtb4RQSFEjV1r9AJkTxTuhrZNpjFhzJJ6BEw
+9mg8IdHcp45ipKGRZSx+2w6lMR2nkONSFYTNxFeA6ONDWvbr8Oc1uCFH3xZ88UJuC7IZxHToGgW2
+bafd3/zJVxkx17oaSuBR4GhuYXPyoImhs9hwBVKVhx2JS08hSfAiiUEGhibFtGwVtDIlpt8eeXSo
+VwUDDDHF23J/SFy9laAhPaCstS3kEYPA5s6hCzKwKpZakWT0tVCUEs+OAGhCW7ePJt+w+sFeyi2l
+FKeWc0DcwRKiGeFG+Ti1FMMNjCYx/HY3ZJulwJBHXxJKIDhAjoLrtM9Xfg6SbQSK0+UsELronW0T
+bdBJ3jZtEK3eGF2y55XuOfIRFRNL2ViMLsUNL+ny13Fx868omr5CbN/kw9BTbBiH9MhD514TRosy
+v4LNx52uvs5CxbRsFTSqZyij/f2Qstv6GMknYPKyxU0EvtfZkLUpU6wd7IF+GQU6TuhvgoEsAxe7
+DwO/CDcC+pNPEkfig8KJ+MLkVDgE6JKhRODNwa2KkeiVzGUWM/ixHSBmS5xXtQQJ9ZDJJ1N2Q0+5
+tWUlrHIz6Midy7USxjDC3RBIVJ8iZY0KKIwT7HXlOryOO9neLFXHqNGU0FvnMIjiTbl45OWGMTYh
+5KAa6mkcLik6xsXLojbledgxaExM8dZQr4ABuXinGCRLZcvdjvcMcvMDyDMnxlhYlI2NjmdWrtnt
+rY7AQkLLQee0jQExDhethqFDMkjiRL5QTnm1MCcVDgH6ZFARq1HiiBtACtWWwzThY3CAfkJMQl1G
+xga1IG6M0R8X727IiYFZsbs7qgNxfscKO9ZvN3Yd3CeYJqBYUIiD9/XEUZB96e06M6R9QBECX/xB
+D4Wyc9EGoK8yJ9qoA3Xmsal8ENHq5h8oUzTUWT68L1Mssahm0G3Gnk2Xc3+RxtfE4f+gYny8Eu/a
+oJoRxcty32rAxxa7ij44ysfzho4VjFkAHXKVlNVYMpJEWh/TETGXE7syNFghCIBDwGZy0OngRb2Y
+pTNAY9EZ3B8vzpFdYWL908YGmY8e9ERkG9hQ3OYvLQeU9d5VBkS0YIvkREq4r4f3ZS4giWpWSNuC
+0E0SDBUvh3OtRoao7NTOc3cEeePQsUTjYlwo2pE5hrzaRyA6kegK4fx/8fDhYrM8bBCzvdO8g8jA
+4VzxblBTZnHbn748tM0RAVJBP7apOO7bgm0SQC2nntKNjSAJ5S/Pmz9GB4i5KdZBKIGyia2mmCA6
+XcyhjVg7pTlm4H55f2xlLnEljuGlXa+ykbhEEsrUcXlx8L6+OAqrL692bpZrD9TAUMIx4DAoOw8d
+0NHreV4hJY+Ud8jDAAYoK16Gs/P+r0EH5iTws4tBc3GCHHIIqC6z9ft7VCtCoTC4IB66VOzL8wrC
+Nk9N/gbZdDgq3i0wLhStZVaGzPakSIFkKiBkok2gyLwBjN8AksFQniw1yqE3hrZgSiSSOWf8uTo0
+8jEK0sVBTrxX5QH/BqwDk+lODynqKKWR0/tzHjFCFuS3Anr3fB8dgKcgaQMArDhHtAEcRWu/owWV
+3Ztbpsyqu1EXuBDlAe0B5gEzA+0E8cx+vNaips20JhFpisZchEPofNmNcCjH1PNSWtn1QTcaM1cw
+KBRo0u/S/BwmO8JNXQDMOd9MEK7tyJwvzbxZT6MPRsEAgJsxqtFsTTUN3xkjGlhFg8ZuctTlUS1g
+HPhhNywkCCsKQipCGdop1rTgWF6VGV8LpesonmBQsAo04hVojK9H7WcaR1okIMADMIDuxWMcc7ph
+tOEbNG76QH9Q+qP9cNWocUujcYRZGkeCwVAzR0WjVT7j9egYVYKBAXQvdIg2RFgts1uTsMUZ+7XU
+lbB5icSil5uppQn92y1O7yciOp9Wz7SzZ2bM4zdu5ByRs2NKk21CrPutWJWwKfGXlZdVe5OHde2g
+XcM0D16ehtLO6G6FWQhAswxnnuEsZ8MEg6Gueq7bp7SpGZKZCrNmNlU0V6PWy39UodKiFknh8+3y
+7dutnGXa931R9m3+rRB8379Frnq2DACUeF4+v57PXc8fzl123Xf/cc2PjF+2+/j7L/RUVeKIR1Rz
+qs//ORZcVq+a0ylbIl+/Tuq/5dp9rS/9tNVy35p5T7WZ6XtRLsqVt6rRk+quEymq/4JBwfO/dU52
+XE84t/OMK91+h1g2U1P3Js49Wc8bHdW/YECGXv28soRdWYJBoTWvbPkBWBmq/mN2V4kqYQfEq0RN
+ERA0HHHMJNkR0iS1sFb7OPMnDf31XZdfrypUZ3dVY0QnyejKaq0nmct1V2YPUs3T5oMmyiLyHRbn
+xUV1aTYaXR1+ryPXX5dF+2zDW45vXpQ+jdGV8SORLnM8ePisKrrM0jzpGatyGZGT0G7p+iinqtqp
+sZlj0zos1bk8xvMN3rJqm9HQyMciskLQiDRUCNo8Lb8qxENNCy5XFVKFqJBpqWtKpi40nVZSTu9V
+TqNKumvN0h9DsprTYZJV3efGmDZmygBi4dkUz6y/y071eplTYsGAuK7wqRXI06nRVDAYQICbwOoR
+6U0cIz5HtNvtHHCuxNZFD/rGHuf1gJ1kB3OQuGgsDvY2kCcqm2d5HRRYRIBgs2O89GsyxXqKouqi
+i74BBMCWlbXWespsHJlH2tBe44waXSkNh7FIiVb0M7upJBu+mcnm1WZalpYFaqhw7MaUDBNx2FkJ
+CTlIsLuzwdaqqkUuPSTYtXRgbVa225iSjQQU1o+7prHugzrHocESj3k1Bq9AbzrjkPzDoQ8r0MQi
+k5kJFZZHt3QOY8yjXTmoeE+fjXlDxzw050DBoFAAh6sVB+EVKGPa5IngbLqQIBgMAojaxh8voeia
+T6IhLEEM3lDaqOOKBZKwwxUMCgVmSp9BtgU291wx42nr3J49pRtaVFauIhsrT9NSiY7Ip3fVWfVU
+fqdH6uw+RSckqwgZmevud0dyxY4tOyUyayO7PLTqTUnv6mdpTEkST/B6PapLrkmLRojkCt0mItde
+kqEcQuivQixthlRJXYvY9lAubuu7RHrqYejUSGgEbdePsbHsGyMrVclPuzxSS0iXNaZKNRh53SXw
+SBLfDS48ifL2IyPXBInJU2qPXBkMq1MiUkNKhZwpucRDlTSYNIfLO3QYtrt3DB2OtF08NHLQyEGu
+s0cOjyygxzqGSqytgS7gQNN1pN1XzqiCGb08SqUbU/KRNiMOTBroqkQk60BnYo3xZxwVbuouR12G
+p2EjdQY6m4fFnmFf7zqm8EZHlkcekVWOoUIjGXgDPde5cQNb8M5mjzPfodGU0JDWJQ==
+	]]>
+	<![CDATA[
+	d4XaRlMdpmHWHHrGDKu5qtvdPBquGT+3RqmMRsl29sEZvRlDk5Mjy+pupH19B7oIa5wLmziq5IdV
+pAnvhGgDd0Q15cDxxubLHdJ+aWfamIGyTSa9ljgNU245ul2lhvIcoLM96f8ejgAOWfkGqD7GaJvD
+v8bQ5pVDJjR7sY7oqcoq2YmCGbPQQM2ACwGXqQ5U1cuIVGdmSoLQA53cfJ4W/VTiCn4HozIeS1Y/
+5+9t8MozAoRYuWNJLMGAvFqG8wHB4EDdomTlNq8/t5kPiDR6KYJFMDjgi7z/Is8Cb66gP0UwMHBG
+CI9+9KFFYhGVcp5kkziMN3wFxnpHEMfEzCGyE7360dJIbh7+dXYiXMhZqYtgQH6nSwHgDC5v6S5U
+Var8YsWs0F3xEUtJwWAQljZ2H4iIV4oPe9LJna93idTLAclJmMjuRVgGKmQymagMVCr1SFxLQ1SG
+aGjIBRERjTYafRZ3RHdXzGzmuxzTv7KwOBc6KmlM276WoWQxM7NYRMS7u4q7sytm//N/qwxFRMVs
+uphYEhNzKq4vIsVllvRhuburE3dWUGBeOSspMDHLX65KvlwJzBInriWJ6JE4UcMRYRcnKI/Ef0mi
+MkURChKEhOrEEVEwGEQKqjNFGt2HbMXzzpWlKO0FjR4aIpcqK3v5mJnZvZxgMNBdwYJYSDAYEhMv
+ywFgBDGNVCMFgwErPlooBZ4sL/DiN6ycYECqNJEIBqQ08U4wKDgkJgD1+xRcgD/AEHIKSchOEY4A
+A5BQAxTGgCbdyv7x5u5jqkNH48KUk/VxjtIRzeQrfbsNzJzq2OEYu5VZ9KoZLXA3Sowd4TwonNVK
+4eNIp1km3ryoLrOo7EV0iS5xVucxokpvKft53cbkGdVOdmZ05TKqkxMhE1HVUPlVNfkfMauo3BOV
+rEBosxtr0ukBoSSoZJgaT9EMAEBAB7MSAABISCCQyKMRkR6qetoBFIAHPjgiYDQaEhowMFZSmFWm
+JIcZYwwygBAwJg0AKiEBFra2J1pYzeOvDBho+eeXBTg0I9ElEnHax9xih/4FYv4zRvywMgGiS9yK
+EhYdqM2NeIVfCC/jUtmVR4/WBL9y+0/HEDrQYOKvWCbzptC+DJRlZ1qr2UJTojEgjbZMgRODCp9t
+RMpztteCRxqi3udN3eVv1aeHS/zzZ24Qg3oHd+DC8XLg2UB3ABuaS0z86jsOX+GWhcnaqDal814p
+/Igg5uX1PwNamw1iIg4jmIFRdbJd546mt9HTXGKSkkJ6uUrlNLZo0Mu/jnC3sA2PhQiFzlLp6hhf
+HANmF9PhoLpdrxGI+voF+3wr/NdxZAhSDjfw2NPJAy6gChWLOyTORVpSAIT50RX1Yp5qmTGxtBWw
+q6zttUVKoxBGiWz+ojAOURBbZR8C3AAJKoFTSbvtwcoyAEbWMTMlUZCZ0w5LkNAN0DYWTlCd9H/A
+DJAlmCWfHThW0IxqCoa/iTgab/tqhwqxii+5h54ETcDuJxHO9KEpFQUn0eLU0TUlANSlrWQN2IcE
+qhbApeSm7QJN0yyZ6z30IR2ETB7jkCClohjtj4ABcb/2g+fy3wzyBGGUBuemEP8+GAGQMIGrlmEJ
+ivpAmjK5D1TxLDq6CENwBcZjGS76I1slf5cbxqu9NkDyGH41GkVd6DWEqevxT8TlTq6U/+lq5eiC
+ibpqYFdlPGtSZ+vVN117yQ30xHlYWBHRhkmzjVdGiNngcpCdEBo2rTxerbk4zhYuUgcpQ15ViWIy
+UHg4Fj8SofQYeP1/V15JUuPXk/RT8+VCwRKyhZeWblkbz0QLeRzhgFcvCFGSV+VPbhoNOFiBJFSB
+wZnnMcKjVfWssGkmmRasR2P0sbhge0ZE6GA/t9tlTy2ls7H/BcLY8U6g9yp5hKOcWv4x0dElGHrr
+Sn3wCGx86HLp6tXzTpDLE5me9xYiFbEeAHWdwIKFooBTZFFIGVBWxDjYhRAYj53jlMqrgGS55iZy
+mXFkBrLfuEFC4+jHWx5kQwUWP84BPTR2jFzL6isQ7LHEzpCyPIqybFGI9wjQXI5XQAPVs/6BCIE0
+z9WFPycUUMggrWch9MbVDDMiVmj2E96KyzwGXWlwI/DbTgHIxXM7TdJFiQ2i1u6kQncZ2iDkIDMn
+lnstzuSJZemaX9nAiHcKxGKf18fgSdzckgeWeMQY9cSFHN+AaMpNIK9zICgjQkB3CrqY02nf9bYv
+vO2J0g8ynQGhGYpjj2ywh7zWyoHQCDKbAL3py3BPe6YeX+1hA3fFwPrBEpI/2Q9sS5fMTZ77INqA
+hbaocfFKsYIce8IvgA0lvcpkVoQsOlXg4RsB0HxpCBlVZkqhm314W8UO1OM/Dxtg/wAyKLuk4LGL
+lGjgRwx6GbmX9SU9dofMCSyxEzGRqpcQsIg1xNbRlLLQ18KNEBWMNUND/7O02XtW5OUC1Zc9QDCR
+9dG9n5SgynYhj9vn30VitlCp7ADEt2GkbbkPQoRaD5/6ywf4fgnZZW0xkh117IkshQTVc+ZGp9VL
+Ip4hmj700IFZCVPmJvRwqtmQtCWPsGJ6rgU14kF6Gb0XlumEnsuooGQ3HUko/QizIvSXPUZfLvI2
+BWrxo2P/RdHSdbNHvSo5jxX111j03k9e3oozRnklOY4Z5Wvrz3srMvWUDxtbGAkBy09RkMhJbiLT
+qYlNEO73ljA98pEJgXSedQVrEgWIkNXGdyKBjCAiOCKrVjzzC3RPg4HABxYszGzI/XkbpFyAByD5
+VIp+eOiTjAeKRTskFDEH94lZATkMxosPC0QxqCr7Dh5sk8zvGQicYsibxTU8FYkPVeYzY8S5NTvn
+8ZiMfKhyE9pgsNPVi9tLZZB9C5UaFF0WM97a9QwSunCAVEcZjlbLHjx7wa2tkuE/1oFSt0nkMMaP
+JoFe3aaAIHLjc7hEl5W4imrs/j7nc04OZEBUKtfcXm2w8MWLafJnBewRo4lrmg0jY0oBn15Bmo/w
+3m82kuTwnNbV2R6u4P9ovqMpkjgbS686wScNiFY55UAwOsMPCj31bUjeqJaRTiPq+8OFnGAkDReq
+VHXskY6TDBQFI+LakcbR4RFe5+dpQr43KXI1QId7zF+8nSdQbsofE2Hu1dNvPhRRm6/hjZFR/fmW
+x33JG8tLq0/IblLWEzE98U3KFyS4NHg5/uv2OsTAxuHFElZG8hEl4Xi6OLYBxeWuZXQrGyaj8yQa
+bSKrDp2Pb6W62rlSZDqPKf1NSA7iIqOM/DYVs6eS5ueyqUzDu0Pg04Q+dUh2C6UUEXEFTQeb0Guw
+r/7mdGTsJMoUa+Ol4GdUk0G0/qUkyPBFpLRJECKbV7wocu7UC1zmVYOxy7I+Qg9k0UOLKrI95ZvX
+qoltQoAiKWwsFs1SxnYmm/jNQTtaQmcgk4250TH4QgASwrN/WE2+lKi1fwadWQAMMTrAmrbCvVyp
+YnF6jzVEwPUFeTGQGddkmvHV+PxSHeRAlI2zlbI/Vh7PEOcHQ8eaATWqHW0i5/gYug8gQX+zyBBt
+s6lvrdK/yeNCiE0j9vOIisn0RxabyNYR5gMxX4dGm6X3Wo0GYzfFIDmG+hJKethJZaC1CToxoFgP
+pAdEK9S4/JCGyJoZkeBQwSGvNDGdPuF8TWoJMggIzwo7pd07+V9Lmc94LJNYnFPPjbJE+T3xoqDo
+0JWCx+Y9ap2+JusPRWya9N59jUd0x2+zQGo+wEcv1usXucNmDm4rEDxYJE0dkt1GrQApksCu9al/
+6Y8yHDEjZ3wM6KUTqqjJ1pOzdXShLExvHaEvZ/6NhKg5TCmb0j4IMb3t6erYMdTfp9ABmK5kmBsz
+zNc1iz0pPyicVaC+QwVhKZAtk5T+ECEgnRAy6a54+AjtU8wSMPIfUkBIToK6jBmowCNiibS+jMXM
+lvMmOjIDKte4nxJezniDW3x9s0m2f1EZIgurpG0LiUBqKOB+N03SOyFGb6FSgZIng1H0lTpnXj9P
+KwqTHyTF0d+VGX62SS+aMJfMtmxK0v7LDW1EIRYH2Oxoz/0s5FWpb7JGES/N3BUxo3dMRjdkATV/
++0gdehT2UMRI/J4CYgKTYuZ08qCE+S+AnWGTtxgqgdHFFEh0mL9h9eT+yRgGlwUcGPKHEptI+yqQ
+ZTLrkPpDKOYGhURq3ygqdQiOD5iySDYIxSmjAythGz2EhMtKQ2aRpcmWbQw2ApA3Ydk2Np+zc094
+Vo8WfwR0bhRPe7T78aPlwOWHvKrkPy9tRMeB6sgk25Rd+478Jykwkm8oVagOR0PXV77/UpumPulH
+YELOPuuvBJc0mnIL35//IgVEch5B3bfACNsSJaeqMfO+ekoyUaZNN/oS9YyZvQ8ThiSTzqiEupAR
+ED0ecYbBsPldGzvGURlys4xFRhJ2+uc2ZqhUL8lqyg99L/7bFJzkNpSyuBsgC1RyTemAzEav+hR3
+fB66OQh/GmBS3JQQ9yb+/ykAyU6gRMGv7EXCVOrViqvdFo1F/vg/dEzBBY5Pfv5SG95P58j0GtoG
+rQMZA16mAkyyHVGDSHP2B0R1DL7mbF/1ne6pQw0ndVeQQE1NsKkqUmJQfkCXnC+cUjuLjlsxM49O
+HkaSw7k0DOtgI4hGjKa+mZfnJ8UI6czRB78yeReu4aKlVkp/JutcA5QJYerM49MQPrBxZ/WVuowZ
+g71hn6ug6syPSIOEI2EK4MFXxMgKhF2aoMBi2ATliciiSyGM21gdEKS7weibfyV1TvYQBS1OymN0
+RyUbKIkEG75vTkfGTqA2qsAOkK6R3vgyKNiRxQjNyS2nYba2hYBYwKfSbnVpEND0ePIxUgRtAb1s
+OtGRbXnsDAMmJGkmmyRgIjd+9Wv2qor986o4UAnVT6l9AY2hbC0fL6PyTYpqWeO/SMGSjEHdrfoI
+3vqhkOiB6DOPFgihoqkzMU52Y/NRWbf0R6DIAWQctijaV/rHBiplRm6bUpW5X2qsKRAkYIQj5k1b
+0No3D/C6zZVkQ3ZEE2CoWYJJXoC65Az/HQeszFHRyp20nyiN1ocQepVVDmVD9IkWHzQSy0dM/SQr
+EuIygoBkRpfxVzqjZiLR3Zw5MYzTQqmoof6rapwwJusD7vCZNHVmsiGtFi02oZqxdhZgglEbv5Ka
+t9MxK2hDnohxv2xTrJQx2RqUKbjDCQwdNmEmwR79nafD2E5Qi/3yP8mWrNc8YiE/0jEtiqkrZMdA
+XYB0UwriUCU1k9uLNJSYEBwfiYB7CuKiDwVuy4SsN2noLhQBDmrmdzhalOmVbYmO5PaJjLgwH1k0
+oW07KyEKfZe5MiG/rylv6ocseMQN0+o+tDBeGXwaTwHMGRmbUeXa+4GvykCa7DGvi8821UcOHgqn
+nofvDNooFhHEjBcmiM0sMsdj0HUKPv2O7DJWPuZ7JWLuELshl568ZlF53kSENZG6makN/QQybgPN
+xjz780oTg/Wyxd+ekiO/jYDy7xYxEZ8HvUMLBPVmjD3xx2mhqMnzWzlMYDNFlhdYow==
+	]]>
+	<![CDATA[
+	xkNJgUnbOupq2KZ3TybZujiT2NQoI8dR31Jr0hObEsEIyGYEe+J7pNzYlQeHAWBERKbE/YGbgJgR
+cahR1R1y4K7Iqs2uVSPg40t9kAVGzE1a/UcMrqr+j8KO4Wo3MUeOo75MB1iGkLsU1GeIRmLef2UT
+4SZ5my8GYeokoUukZpP602OsNsSKKpJAxVrSZ6b708/9wMFMhfw4wge7zyyBrxIrTkWc1TExsiQo
+FaIxd/2HPA/MwUHdpsj3HdNGHXC6ghE7MBTmoi/DZ1xOvcfBoGxq3gAows2xHfiyr90z+7hXWtsq
+SOBdq6r/aWgnpWAeRXqaGY37lgutaK80IM/ZmUj85pJFmnxP6KKXKRmJarS0yFwthNwA1/k7/QlC
+ow9a8N7IV0oiF0nqRtNyKjryS/Sv7wXChDraWGxtFlyNG4FgGccb0Z3EXrUC8G5nSKypQdeZGMNw
+y+3S0YswSoLGQIUpMYrxN1CxT4al8P361WqQeT/Dkujf26ZMSN+hPtblGCbwVWLSqayBnaZb7U0W
+IpVwApLRSaEpEcEFqD6xlBoJQ2TgV0qNfzVoliL9QAP5t5nQnkdhhyJKaSKOO0W2q0H4wNAnInSI
+s43M4LJw8gBnQBThTsh6JrYxcPh/I8R76G8rQ0Lw5pMo/ihNc1MKJLRBFnl5MJFQQ5t08y0u6cix
+dHobi42A1tQBVuHmpGlkvdfaZJviQk4c5ZuJ3QWsuJgwoum5FxhWLMsjLCN/XhUzUOzME0zP5bD/
+JUrJUCMoIWAK303naM5ZSTx7hV0RnfnYcE6Ilg1KQHZEk2C3LgOanKTa5LBQoHMaL8AraVztRK81
+ST3hHj2HsjLqfqSe5DJLmg1h012KNTkPlMyaXJ3w4m5oWDPGZj6NJn6pp0dZQbGSd3zjadlwT8QY
+T/6TSPbalUY9UU7nr05oZ7U5pH7tCmBs4Sw3FChgEIlPIwNQoDI+auMOaBzZVEzqEtJP6JKbULRT
+Geu0B6Sb/teYOzNqAqVojmOypt4HNmjJF851GIMHyNSMqqD5/OTUac/W9+HfR1tydNVTJDFvmzep
+dPofC4J40KnqP8hVQokpSL04jrglJ4vCSTOpOJOj7TcLD5o2I+A+gDYRWZ0RquNUFiaJQXIZfyEl
+G/lchC8S8j9oKdWeEf1HcA8/RtPpfSw/xEoVWL9/9zwYM5NUTW5XKDaQQ7yukvOb2V70wDjXA6n0
+Gkpg2DR5UmoELvLnWX0w3ClpH9MWfAJnHSSXiGmL4b4wC6K0JU5oXuJbQaWDIJFlQnL+Do6FIzHa
+FeESia00KUo9J4uI+MX558asXjl4BhSDArhjOqGP7otKOTgLSG5P4CTlMwphhTY56IsgYHwwkyqu
+E80Teawvl/+KubLa27DFdFsIOB5e22HM9LvUXPe7SYxwI28kZaO5NYK2sh1SdXW/zikBx3Ms8Eet
+6CismNqgpeZ1jW3FxsKC8D7Vg5wpiiWro/fOKuBnzu/WE5IRbmNAEZpuGR2vJOnvZhgzj0j+p5Ce
+UdwV/RHkTUWzEbX7ntpVtDcfkvhEa2vSLj6bqSWTJVnJ8RPmV96vAeapxpW9K6i7FUZngkoiqMbJ
+XbwKa5uenRwe6YHOWIfZsNinOVBVod+GPAuaQlPWIHuAasqXjLHZrxIKnQqm15oi74TR6EpUw97h
+9g23pAidOfOFVQb0CzdYTqKS/OwcLP2wxPyRidbbvfiLiVvYeLQpVerni+lsL5gYSo8n0JFWKyKl
+gJdCFLXOnIz3con+psiTubF9qBVVSFYzmkm5mCBVu+JTBKIV5EOkrJDdQA39jw5EpYav9PBJRKZj
+c8RfRBtGkUFpalZsBXBuwmE4aJRHT/8DvgHRCPRQx7853mCPALT1CNuGVkrSmVcgo+eo9ejoddu0
+mSzvvCLlz8b2EDZla+8B6rHq+dvxny7UkTN0WlomghqJhckJ8ZiOKF6eoGnhhWrZH9f2EcNBX7lA
+R0fWXNahgO1vj3NTqe1OXzZACU673xDWWusQ3GKzHfKHB46Bt8P/NIT9okTcEY7ez1omsFs+iEqb
+UgFPXf6KnRyBuQD6NyAPmTFNHmTCyHWvtuhK2xKIOx9mGZi5N0ii4OomgBoId+t+CEQyJmksXrui
+M8kCDXjdcUXT+Vp0aCbkI17/hVpNzsEHgca+SOwcm4hqAMyRYjYBigsdN58c2vpi39SHxyxKUdsH
+Pzvw1ntJnZiGMIfIRkGso3Y31Ljog1bGdPIcGkOZkDb0JAn5+hRgBqNquHOv0cTzdNm2KTYc65qN
+D2EmlymQFF9ofH9Nz3zplfPQSoNIVaxkzn2GAW9blQgWnsVNWFt4I2eeTKJYlwkVDpj4oHGITOfZ
+1HULFA9/0cJygwd1yIlIE68OctKqgT2VNrT2nk+WzXN5E7cNCavFQM+76FSspEArW4RrBtiKxjDQ
+XjBu2rxQ3l6DdB+WGvGMUM0ObDJyDj5Np5RcvGZuWG3yfK1p+Lf6CNrTI5/2ICG1SUohtb0tlVys
+pmzw71GyK/lHLc2ZxTXjSyAShZASnHZqlNDijL9EVv6Dn2gagUjb5ngYjtME3Sp1OdQUHVlG2saB
+U5m8efYKzLfH4xCeZmvvBizaoPktdjr0wTnhFs6XrBjxpVA2LieT6rjwA0Z6k4NlTUc50nPQQVJb
+bNOymVnm+Rf30KN6Hqa91cPmQECkMcRlt4Ju0ToGzdREZBGq4GA+BogXy1EYnPYBiKy9DNDICSgI
+NLVLb0CRNPgYj8+kFNd4lJnqddPIJgSZpubNtPR79mviKQGQhcm6Lp96pAWutmumhL8y+H+Tm4cA
+O8Dm6s0w/oPIXF3uTxl7XU16CvTEoQ6HdAwfBa43ksE8ZoY4xFN2xIGTc9grhZpnvyXmERetJ1zd
+ENoy7gDgYfU5EOfuXd0Q7YykwokCe30YSszhn95A8B0nDv8ENztM2WdURqouTf+xtVj5NDNC0UVf
+HX1/81qPWpoFJqYpTEqIadFpyo/vNuMUhejBwlJnuQeyzryhk0WNugWhseys2qRAcCMHqqVTw7Yp
+zsBlnfYt7CqYVEdBTyOD4G9Ikp8pyHGGq2r8UnjquvIcScIpcODhntJpBE6iGC1Qjmqv5IqakvgR
+4FnvE7fRsPLB2PDQbFLq7+eqf3FZ0L5F4JgXH0YWPMmdYws20jiK5lmzL5PVTKDi1q2A2EiO0PDm
+MjykmBGBVkhq1AWAb20xEXAlv4wth/m+gn70VdnB+EpL0yz6X7HuSjDWzVxFQ60IkOXpSxihSVis
+hVTAR+nxuHZ/U5k+wCZevQuTQfn166jP/n8y7WW0P6TkeLNyJUIAbxWynXeah9uZ6KLyVMxNMGfm
+vXAX4DWhri2j7eDNOCImHFVgqiupdh5/tGW9WKYMqHkMOJ0wGwl2E67fTvBni6QN61Q9Iv0qpzmD
+rbBLN8aIvZ3arwr20LfjPQI1pnSpHbM07fS1jFHsC9AJmvgJeKCa1C7Qn0W0K7ihZyanCoe1bCIy
+egtH+sWiedZAf4nWFj/0mkA4FhFn0dT3b23OPysz+1qOaNFgayBKBckRoJt7sTdmP6z3PzWehEup
+FapU0jFkzCaRyzJmsaPGfNX9CCXnxoL2CMpmPkSypa0iAmC/SBSQaGZhpKQISQUOT9+iQFjxTTrs
+6VwzWmqV9sikRR98JqLZEgX9+Bem7xcQaWgztkX+L1ujqwQHSuLboZaphc/9P+R/1Yvv+BXo6k5T
+DwI46APahTtcwKD7hqSeEKOdrrXZkcxGyXi0N7sT03Ks6KyPUqRTWH2iAGV7AnT8vA8VtSLyKS6+
+w3JbGbxm/NvzuQC4CW1fKezbwlachuSPd9KKWB56lZZ4WYpzgQuewXqj8LtcNJ4E2VE96IzXciYF
+9m2dpc28iCdHfqQb+pmjyiqLrPOd3UuTJPg1CFjWOn1AG7QRwoPzwMh0HMAc0EH5P31pDkAXaz/d
+tnQWkZzmYNbBRxsev7BbHOcJM6CxIVkaF78053gjS3B0tYiwH8jlE8QQ1Lf1+0Psaij7FRMopigj
+nAd2bLTgm3FNt53AcMkd9TnmwrEDeGJ4KxoGMiVSWpJvO2I8azlhYBSo7v2IPvB7157xMvEBaCOz
+vyeWCxxdi73GJtB0hi1mlxSBqatH0RJkBWhPRKl1Il/b0hpoH6jBVSQoRfArEDKlSwBh7ndFoCSa
+5Zp9LbzQCxEeUoLGWXVJPMRLkHWkvwxOOVo3pIYfFj5Fmmv3gu34s7GS+P8XhBX4C3Nawo4y5riV
+BLCzJYkJTVuaNdlQ+Ff13TqIigMDRAUerNe5pt7iNhAxTlWu2rhl1dXm0AgbPui4/pcXkOSE1ttC
+TdktY84pb+jG67GnETIl5mR5OBM4RzSX6+ElSzpWR6ykCCnkkNGJDSIBWo3dy2g9JpLeG8Mn2QxN
+7eTIix4jfqRl0GLXsP6h/aYIxFeYO6GqPUtXwReIHyWjNVpoCuXKBdqMcZov2Bw68uQkvuahMGkV
+agOhaqZFFggcByF5Tu+KWgqWOLsZxCo5e7PLKbIW/vaSZOs7yKzyxibyu7YjQANFtmST3/m3dQvc
+47PKpEoJpALvYUAadGwJWE4ktHv+oVAMwlbbaV+5VJNlrS/T/1MYgTXmpCFxoh0s4BqFKzryZih7
+euVCAhD2D/fOI3jxwOEguv37RxFIKuiOtW4p8bF+DihGKhqz/rosZhTX6NeyudQMhTqIO355lUxt
+33SoIklaTwFWPTxI/xfdPqxLqaHh9iEPu15IYbWZxPNAp5betJdQoP3FaI0Ux8Vimp0CGuKs4r4q
+mwXHJx8MUBQDmIwyYpsT9cmWJZ1ZiVgerfvJYC2ra9iyoL2XlAACBJUkt3ky+yxvQi1/LkVLML58
+GlAPIMry7sthX/qYA07osIpAC96EbUrjGoGDVf17JZ2/qkskv7SoIHE5o6/DQOCkUmKmteYSKt2w
+Xc2EJojDTiJO4IJW10GTrKtaEt9FoxdvsicccaJNtYhMDEuzUtsAcHeUxp4PyBOYExm37X+UeY5V
+UhPAM3mCL1+1kaKt8Fw3JOR9X4pRi6EraKokerKjIfeOEOXPQbo7ANiy1AkMBZXGKFjL0PXUh1BL
+fSi7PGKLJU9LDhMAIf1W7iX8Lj6QwgU2fQQDAqV7xL4YOgElOJ0DjaLBjYMuRPOJCfEN6AU2X9NX
+rUlVWd9tFI4swNfepyuw9Nm6W7BIYYRiq3dXtZCQlbz8bfHhu6I1/6g7dT503lgkJvgVN/Ik1Ukq
+NnuIq11ANNQHkZU2gPv4uSZiwHIupnKUFV9S5eF8ufMhYHsezvwvMvO1pssaV6mkwy2aJzoNthh/
+a3xR3Li2eBjkQHv+Sznwu8R4TD3SAyPTJ21pXTgW1QzorbppMrqcgFMyM4vErYTkmo70InEiEkkg
+eSDZaApUy4oigxsI84GEBCBhBpaSDm9eDVcKpEz3EFkA9++LYkjEG/uBLkWgBDQUmg==
+	]]>
+	<![CDATA[
+	dKkeXAB7u0wlDuhQZhamP9Wv7eDmH5bnBt0wxqDhd4pWvr1HAj7Y26OcvaCjOw2i1YrJUR4b5aIn
+5QaLiEM6XQ32qpB8GFRg4Sy87dPSGvTJZnFp6l9eFSWa92gyXO7ZGK4zSh9aGXjlwCmZUThnuBg+
+7bCDBabHh/N+v5dQwHKbCa28ITxkMRsqS7a79NeFmqzbVqYSluPuE11NpopUFYjSFrBmIboBrBH8
+OwLFDUriDT0N9Q4G3PUaviNS8cOHTgSGXcWsABkjKJ7PMgXUIIwtkGjKqxFTxYrpBVo8fqRpodiu
+zfcKEcFkG4LbAbh0J03WdmD24/E0O/DiwWY8IfFSb2t3j1c0cHmcxBLSUGzdS+2mKEaGTZ2RIjLu
+NEZ/OFcaIhmgv5gYaFYbUtMuHG30g4KtITkKd0TJAhvWSzyh3ZDcc89JZw9nOLagtNk4hTgREqqH
+FxwMRSIgMud4Gj3Ez6ZaoX14nH4Sb/GdNYDirUMR+YbtmAq2dZbn189ygY1bi8y0RuR6uP1u0byA
+iU99kciiaCoJNFET5hHjaH2PA65QShvRf/R7uC1JfXOX4jA7k/jLQhbEoYxxDLAudxNcDKCm9yn3
+dUgpZIla0PUSYhIJQPNZTHnGS3TktO1ImEgH9QapAaHTyeKdAOFZR8CikVnR1Pw5J0di2mppf0Aa
+UKqog/h/fgfTMzi8Dp4vm1wh8ecMWopTVGTvPNVFReYa1dTY3v2yT65c4HAcUsKlTNkf5aENZ9BT
+CIBXaVlwAiodMc27mtwips9kuMiiTOWsk8JwXA8GNd/JbXTc+5UH61lqIYf8QmV0m/o7AVF4B8op
+SwHt+ea7XobijKlEecHjYhdBKbuzpvIIRVIsJ8rhDQu0OrA4BoWihNKJfQcKh6+G5WTVIs4Ubip5
+JzDG34AkQsm2NAa2h7MQcL1gq4+d1qrbWCGxfMWkxcIFkjXdhJbeOFks8NlupwLrsJNdvzeKmsYg
+5vlUoXTcffIoFLWEOBt58GOwTYHXMcUmkCaX96hyzQOm6ASBSIUP4HnFrWmC2ZSUHmPmXluilNjP
+GQ7gdMgHl84RCkBzBsDqWmjviaBjvlDQZ3FhEcrBAPmslItd8Dpy6McXqP9F4xlsMFtHgvaKmT3y
+dkAQM73LQuW9ip80XlOrchcvCu9HyX+bQRDRNAKi4ET3KuGdUpJZoy1XdVxrH9UwJMI7p7Tztx0t
+De+Nowby2ArbyE6uhEZURw8Csy85FqRlFybaEE93/mzFrP4WHtve/vPpGJi/KQQHODfIEvJRaKlY
+xIwPcBqV950/bGWaU+LHTWQDjpgyTrKCvkPQVIF1NB07ByVM9gn3NPL0RyQhIkdEdHefk2Knyjhi
+5CH9dzq0iqLVXiPBTo+hY9UExJqYm31Q+ngMirpvLnuLgRCkbAR9D+8OIgBUVUaysci/g6MyvCMH
+TvHQCBhQT+y82rRvGyJ0e8ctXQsG9LwMXp5lPOh1VdQqFZdZgQgqZzrFlorzfTp9oFdu4obatz+H
+XuE6vSWmn2yeaqxdKXZn31HTYUYaxf7sH6Ha/UqrewtwWZQAMGEJYhoOa8wbxPfXduh1vPZnugI5
+3MAuJUneLXuYNX7XMrnXBuNXmQj7/58Vtq8tIdTqyBvVQyl6Uz4rGIsdmCT7ICd+AgIVac5os68j
+/xt6rpaqVIt/3LxBOgjWgz/bsximM8MGzphtQC1J9cgT7In2LMssLjfaSW/khNGTKFMzgSsov3UB
+WlaeXpWFh11pNNQMgp3PrBsNPrC6sJRkKamzu8FsfyFduuM5D9lAAeUHWZpeoRVryGqzfFgddF0a
+ABkAsnugM2LEjfQBkSwcRHV+9RdFikRbGuLQopvFbpbgHnx2uVuHCtOQQPtTxNsjKF9mFlP9Mb90
+A+3I4+UppdTcOVSFMuZr8Mn7steEAtnwr0JrlpCk3LTG9QvlJNZuUnGQj9SstCFlrq8FPVLE+BND
+32woxevbdu9iiLVlNZpCgGJTdkRoT6BIfA4rBy2u+BUPzNnbUi0SyF3OhqIYXtqXcdRGpFrNiwB0
+Gbd1WlXgY0a8lgVt4X0523alKJoKU/2K12KGlEdQtzv7Lj7hFKEYPCV/4JCF0QziB9HzL4ASBcbA
+F3f90g8ogp+Ou+lplI71yMC9fN2i3UYlqA9hM7p2ZvIgr2F8XepslhFtNEV29gN5MsmDvMWqJ1Pq
+ho3+yC0S+O9u8gi6TwMRyqk1KuNoLO++GIFeTqsZFSsnb2vVcQogTQWVjI7zO9QW0Wua/fw3lHDw
+jlNO5uXJtwydgfVZdaaQ8IC4C4UKZwV5chjccKgAFBS/Vc7VzBVMLo5IAX0A4ouv7YFc7Ku1Gl4z
+A25tBBZQkUN4Gicn/QhAxE+RuxhuLaXSVzSGj/OzNoqoBmIdjgL+KvBJny4G7EAvyMb6GFXkUDKw
+2pOIr3CJZinBWIpgiaXv2lKLgQZkjmwvLIQr1OUC1ESenxbzSAOul1MiQIPixqLkPmw1wdPnPDWG
+8CTbY7gMnK8F/rsUqTH08sV7KNbwjMQSa/ANXxvCQ8e4eaJKoZgRRYvCwl5cZA3NkX4eIiwcujwL
+oPSUgrg5RfUKhLY3qe7Yk3s8znRKQEOoHzszBkqEHRwMgqa+B6WYQUSEu01OHBzi0lezRrjNbuJM
+X3Y/OZ2PKmd22B20AF4pBAdRn1YzPDnmvIrHJHsYrJtSTaxA6EIG05sb9j2ZJLT34JxeyQFgkaH9
+zZ2+k+/+e8llCL2cye2JPtA+SHcJ0RNL1kOwEc9/kle8hRRrZa/PIYECearZFJteHqXhhJprAQ5H
+LJA/nxD21yaEip0jGYCRt2jd8kJV4Ip2+4zXAoght01wCHUqKtSfPdvxZdOUmMqG1EEyKqGX3lJO
+o+nYoplFVQlDlUyp+Cc3xDQNVnq4GwvpMgJh793kwDofWqpGHXU9mZtj/KJn0xZF+xCgKTvdNOtH
+sMALWfpPRwoZFVjqQVo14DKXPvzMZ+nePD4hXJyHNFyIWfDhuELUiyLkGwRHC9qoJyW0flUcjtC3
+7na4wheVg8WrDbqTLA1By0BTVxMEsKjPc7yNTA2AofdKDB5MBg+nSTclt4iR/eb7vA+sSVHIZFFc
+LIV0x0CbfxFqHpwG9sHDsJBoE7VTMF8btR+p/1ioPRYerQ3diaBP5LQFMBe7Ei9KrWkhs/5o+sDv
+LwR694dywoANk8hpTSGhLBtrQP+AfTwEz/uQu6PrSnWluPB9aOcqXX9ZkiPVIaiEUrYMEe3CP3FN
+vk9HwqMI0QRXyPVhBLhGI9vdvgx4yxxO41qp/x9NGVcltOhUYKj6VkNHKmtBFA07rcjcfgj7gUee
+JK5/v0jjZtQk2Az1XNFLXfQhEUmxHPIGZS8TpiFvbGMkYtmVVWUrurBL+45r2y8WNUPA+kvlkVys
+vf5jqixfT6P+bjm5DzKFD3WzayAH7f3qlTma9CpxOXkIt12c7vjYVKSZgyMdmydwrexqn7+uDfFo
+rGJuyqLJT2YxxDTuVOci1aTRmxu/jbyh3bgGqcaCXWK7NmjwAS+pciFWJi0Q0TTwYYiWLNX5e8eO
+JTZulGao0+5oHGWVJ8nCAmE2Wm7492aqCw7QEyMApIm6KR+V46T4BgJ4MJ9DvChBC6CEt01isbvc
+wcA9XmtERInyRpMufyaJZ4gRFL6bb2lkerNSwOwbNJ1ItYs8mGK14EmLmGqGtLMRAiuu/fLdRYeB
+5rpRb9oob7WvcVLd9fLDR/d7q7z0G+WY/XxMMEQvX+I6eSgk3wJLRLjbAe6OqDd3yvvg/XyAGi5k
++QDD/fyOn5+GtcHGamm11nMeJXRs+808MNYNzQIjVlihfhQDmSWbYrWlIIUIfQwQL1+3vB+dAGjd
+h+UC7g+2n+bIF5Cz1Fb6GC5ww2yWEBK9V2RwQTjnhGg9iYq89mReINlw9pBeOVuJ2vnlphlXpBVa
+DkvNPruop7zJv8XoKiR6HRwjsHXn1YtU1k+vIatD6JPwrgbeGXXYty5R6TEpLrQJXOWa+cZ47ckG
+pni3JHx+p4CAT5ISc+HxfPU6xzKBBsglYFaIL7t5/YRfxIIEJytJ6BwV+2Spql4QtGWn+O2qCvlV
+EfAfa1UJFliEWj3kRjE7mVgmBjjXEnfOFI8bh0pmY3bMW29ihgm56z9FDKpyArTdBOmQJr0bJb5x
+HnlVZDw4knC2znvuXsNirXhwZ5TUjL6MNLG9jm1eKeHVd3ogvQwVf+UZCYgPHmJaM76WTSwRKHTo
+g6Z/2ZyseAHrsZdrSf+/Xt7ikLMmkJuWo9SX6QY5IpBmKKNQvoFUxatONdFK3mmPL9mYnaYxuwVL
+03A981tfOtk1IlvRaJ1guugQvj+K7Zmu/J5rVl2o2NBx0wEzm6SVtNdQA4cDadgdi3sJlDH8J+S1
+9FRJvB4XkpkVNzzgGqacmPw56uq4QcExTLRdqKacm5iVoyKHQFawj7zAHHkCVhCHrQiDNxbKndjX
+dX06a7aiqAhE1/DSQ8Bwxn0kmHT6ExQayRtS2bxb/dLzU6VIXjsRQLgytxgk1QcLkAo4zZXEr/Hg
+fpoyaSjBitbwlLCM4sXNCanJoLqDVMN7gmK0D23xr+ADecNwYiG09lvyX9YyqPlAtJYUUiEiN2x5
+9ccRwICw0AoTQdn70YyFGLRPhIjcjZONzkUdH7gRfuZyW2wk0h2Zs5gMOoV6QhXbxYzBpgxdZtFh
+C7sqSt0OrCJPctq+l6WKK+cEI3S+H1dP7Ev/wpm25odIgzqeI3IeJeZ9O/GGWiOVmF0Nl2gKcn+V
+PlXdh89Y2M4bmkAqMzTBvg6qE1tPOMVHQUrxt7fxh9gjNMGw0iF3bAVdj0V47ka12sd6SKIq/Yoy
+77HPPMuP/Sn2lXLmRKgTwdb6FNCVcYB4xmCgKh+A/HzNVamJmNcEALWuQwqQN9hCbIJYJqOAcEAB
+TuWY3jAEmnGXEdwO8oIT3NWXlZdKgDznBDI6NQfRcgKHQ/SLMdVNEd5VUnbebBaMBLCuthiVzr8k
+qKjqXbkgbKaMeu/ii3Q227ul4N3AH1CqDYYlCUCDgBZv0GF3Ozu13Zy36UAvi6g46tsgWRXVpsnx
+gRUSoudV+BcfVZcgw9V26NIWXUXAIbYu9nndSMqvj2oE2XRdW49lf5Jihfi51oBcAFulATnNEFGl
+Rjigz1KKjGtEcAJXGfVZ47jWaaKnfAdGKpBG2Wl3tfCx2VYeq4et+1hRE3uRBgw70KS5Ae1h3nG5
+RnFManVQvSCffVHBZIHTJYUFlGQ+rXmmY04WZfh7hmANSBn/YXTZNuVUUnU6vkHEPn0ZfV/oEUsz
+zbUCK0ooWlW+CaGr0AWahK0Q+y014kxoPLKbB6U9Xf842XArXWY1261ScutMFTxREtXoO00tjZE0
+0tKjSqsZrhea1MvnQtV2zjzu21xChAF7scatqLyOT+ON6KY/wcXb05rmAgZz/CJXVA==
+	]]>
+	<![CDATA[
+	d6OCI3GvlROJeQw05TlhwLciLosAKawHBsQzUn2m+CoqEqxPi4X42KkD9A7X2ZqTLyJFykTOdPES
+Cpc/MrRsdqG7FWlw7UZBjJoMfie5wHUqIXdZHQZdIuMKKEBNwyuXG8HOZ7Tqs3THYG3nonDfhiZh
+6I7zZZLxkbwRwsKl7RT1SGywr2sJAOe9z8O9YgDH3enEfvHs1B5m8J9FsPmpHYFrlUUx04GjvOYI
+dr5mhZJ2xOskhnCONnI3oV8rR0EB/ot/mHfll8KMcnE4pXTDuiWcOJT8PZTgNQonJkNob4qtqziY
+oNjR8SueERBTsTwqj23WQ5QCAw8v+gXpGn+/poTAqTx5gMvDtphHhJt9dOyo07NIaamcqZDzYTU9
+au7KiPEu/0PxoNJkn3lFGmqwuAb66JUqXRoNOYjQq82j6uhNh4Glqm0Xo1yzF80XJsIa0seLp1X0
+0pfPBQVuSoBR7luLfJrwbo0EHqDnGpCOPsAPwe0CWjwhaoKzj09WZbBOn6D1uYVY78aNArROeOuG
+gXj6D2ljtAnqTDbzpW77hJHahOgSeAhiLOnnUxRVqJtYKgZEi2J0po7/7mrG9ztL1bj5mYNjv19B
+UBMmLDAw/ze/d6lCmawgVrz4B0XTuZNMhtEHSA7BkmYVOVDeo0E8uXrk0kRAl052oImyOCYCaZix
+TNp2mUgy6FeUOMQokyVLNvTPqTdWLRcqPJlsgC/h7uu+4LClbkotG2KHz5j+nwkxlCRA7gyH6nR3
+xJUbojWFrh4CNfYNM2yFWWT0mWIXqWAI2x2Tar3pE57FGNGbPj11CuICyOkAFHUKJrwTeXZ4gQP2
+0miH2ECgNzUkhdHs8chhVTlE35b9HtU1KQK29jP8AWkeZvUPQi2ABCcIpfZDthrKI4p2egAkfnBF
+x71asUi89BQc428Ncdn0VbXNvQoTA2x6KXRiGASkYcl3iUGQkbipiAk4mdn4HjeGx7eri9p0t762
+ppQRTNOgYwl2J2l4mqoe99zoUvZ6L3kUdq/iXuKNbv76ChJEVa06lmQHaSX+7JLuzRfsCyxOsJ2d
+AtA8bCc9eR164kxyPH6d4nONo2o2fEnEIsajmjCKjP4EfBbqaHqK83aqw6Zv6QieQjaOTeh+Nh5C
+FM3d7arc62jh0oqG2Ju3Or5D6UTBWjzhqUnZOlun8G9yFRdr3OzIhblo9K4Vuf14sNn+7pNDJZJv
+OvaxOipXniOsrtDkmw8UZV3kGcqFZDuj6zXeAkUZVDNBQ5FMtolPPyMAq3QWkRUmVvBfPIUWyj67
+XXmlcak7mimcv5aB1G4R8kS5IK986BaQsdDVwzhbgHCv2+wqQpCZHgYnUAca0BMfT/qfO4h7c/hE
+/PD0k0H4hgJ2oAnXHhGaqk9uNpPCof5m5VykQkBHWv4jPxi7/RqK54CZbRDRRP4ttMzYBzYv6ZkT
+O2q/5tvEt1HKyLi1uX6QtzJIU6b9kblsZ9myS7AjB+91mQhFiLApExQnesgFqHj6x/kx1kI+mKAo
+VVyRAnLtsGFM/sXgljktETb4XdPZmEIJK9g3MmNmoIE36M4DgsswtplGTW14bz2YDsGZgR5I9VJ5
+GQqgXvmnDxkRWUMClAZUKU39BU4LBh5jBPZgZaS544CnauBQ59CCtMcbhTrPht7YgPvuRFFZ0gpu
+GQJGUX79ltsQ75LaakLx4qQ2bC0yKeB7zUjgRfxFoyTy3yPhuMjdf2w9QDlOVDgSZTphaNA7fynk
+mOMd6+En1SBI7zSdGYMsS8EvQMALzmNpPJCS5dfLsQs5i0OLr6tdcImG1FgsIYdyHyv4Sb8fqyqI
+Q+pQLtbrcOXhb/G7HRWDn5B3OGyK7z/448TcIM8JPlTxsuQ4dczvKDgTQjg+eB4qtD4InSzUGwxB
+C0e1xc8DbhZoCEI7QPY/KIn4jqlCoxVD++Dc2L1TGKEImwHpdPAJf15/EKeUV1IEzHiTyFrQIYq3
+VoWbJ/xgEZFvEdZBnu+fch+E9lHuRE671EXz/9joD/7qU5qNNR+mWKyXXT95RzzytJnC0Rh5AVaI
+YEDNCTC2VVrMqBLpYiu8JVZ6UIxK+ahlBlij2hbVVEZT1Qsd5hTLMM1o01j924Hs6twsFSf764n8
+tSyotbzOHT8xA6sYHr+FhGm3e5EySrnpqoKVsX1AiazJ9BCahns4BY0BOQ060ClwNtRrjx+97HpG
+6XwxiBd+UszEMxOAEcWdhXR1tm89GRvV2JLD+g5zEmpQ+EGD9fahe+PE1DRabmLygnGhSBRbF0gk
+PweMm4OjMT9D4RU2gmsS8uPY33ZOGXFEOzl0ES0F+ieODxNcL/240ofCJ+Hzp0xBXjTo/Zmv64tD
+5qa1JF9+lsDHYJglizeeGHRUe3hrTHV5ctzq49K0/p/ycBEs6A5CD0fbwefS0qvikhsZw/VUwmTC
+bChRt+CCOZPc1J5szbz8zSaXSoBK7Q7EAhE4FjVg+Yk0H5yS2RjxngGxfsjwipR6Q5/1MiL0w0PJ
+FNUjm+feJU4xMrjCIqmdBC/iSLFzY0MxlgzbjHGdUoWO9iZ49l2iinbAYn8t3V/P1GvWuYqMGMrI
+F6ZPHssbmerZAWBrZl0UTUtjAnGY58Jc45MViUSvZZNYu3d0YDiKO4yoytjeA+gmdtKI6jdhOBr8
+bigEuHeYULJ/n7DFyvj7dv9G5AHa6ABT0v6kfXJ8TRD788AEil4KRZLxoVPbbUpI7GBuIkB4qizP
+vDgEn7ccMg1mFJmfg3MucRpB1GibOCRYYJ9xiZgvysl2ODjF7z/CX3AgHrmXCTwZUWeCdpgeJvAw
+VZpHTZoJNcVoRC7U0HxrM9f8TOIYvVUB8uVPvVfNk3Aga2csbzzyap0BzD/rirKrr8pJpxRIr80l
+aFuo+65KLi2GJWYmh1PWP6Z0ELgZXSTmgLE/rmyIK0v3qg72XlpfR/+we2YsvLVMTXaKWYM8OuMS
+YPm4R7cS+4rcWXE+DGipmGsxuJAuLcyQbseMtWDFXWySq/xQhsw1I6TflSmTmmuJy0I16+FVgi9b
+GKDq55/2eq57Lug6zIuM3yPkDXK0tpvhKiw+5lihidylb+DQSXjwandbO8qbc4OuhPW5gxC1d/xN
+7hNG3qsIANbd3OG0L4P9Ch/Lc3b+o8xXl3rieLQactMkil1Al3yth0moaSQKMsipd2ALEM1mn1Gp
+cfsZnJK8RdVh9DxZxfYiiyl0QllzynVfp+Li5W3hTFS0E5fKxNvddOQaoIVmXL3Ch1fwQoiTkn1v
+KaPM6XeZAzIOxIyeGOLj7RbaamDurtgWofvTVyPPKzvULmrHJp0V/3iLpTuKErmL2XNI3QTRHOPo
+x2fs+DQ8J3Qr25VXIK+p9cKZCU9mTNNMLRNHTYjYt0cddqXt3Rs6HD5YmUZoE+MMdaFFpifnHpgq
+SNjkQngByTuvFCIMeHABwasyMoSeFEdOAX5LtwnXH5Sgcjra8OIQpFgd4uTUFFd6mSBhJwfnvzsS
+/wTU0xWmXy1nHaPRNSRsa/jas/Nc/WD59n0mXURAwFXTE/Z1jpcOn4ozrSZL+T3KuN9IJxTRNiUZ
+EVODMzrE5PJKO10TCGx1RKEzG7Vjh7QPz4UPpB7SZDneunuRujCInXscZeAEswthnn7S/Yn2YgQ7
+LyB0JpvHSZy6MuaoyArdnj10YBctjzxakyFQVIMCHfiGpFglM9+Y6gFjCLMi3Mo2S2vGPRopYqwo
+tDRoPYfqOBWjHVancOaWQErThOqX05HEtBFBUCD4SBIgUwT1lu4G8vxtz9hkLXQTTaolhDzBqnL9
+UfBfogb1QiK2Rpwis0oWMcTDcH81X6sTuv5eKhKtiS89ORpZCT08iMaQi6ASkVA/neQXR92IvB/m
+yhErYNufrGuJszjg43cUqaWGjpJ6aTcztNQMkPYzPaC1ustj5eqKvNxxx61HT6LGn5J2E22nbQBN
+OFoCdJ2e6eL/6kADsjtcvMwqcUfEWuxZhE/o1pYiIfwl0rU0cwOdhut/0k8NHfZCUps5yZj6gXxe
+6J332pQUL/1UmhFfGNYEAgnZBo+6rpf/GglqFlir2A1ngsHx77/Qi1LTrcLZHjAQPD1D2fyLJWmo
+SGPkZTUikZQ+UCj79NDxMMa6qGcPIyDJCB7+TrybbthYaWtLzJZfC4SAIHtilU8U2WWaDcMsS9LY
+JhWin37m1FHBkbg3UL6yy8pWGQ5LJTb2W3eJEuIvkyhBA1P4eB8JBDphUc9iqt0SGtZdwlnJJZKc
+WcB0cz8Nadr7glqqpk9OzfFfnSrRT9SQbZAvWs+G3zKYbUNbsKycqdtGYpGrIPzdhPX5dT/fHglC
+dB9HnainiwdNFYEdp4B+Z5DeIgWqx/QWECxBVWeI5B7DW/3viv0EagqJukpUz2BRRwg52uz17sES
+oAg8Tb5rIvpQMTbwLdBREmwnIy4TVO00btAJKfNaAbmV5RsUTzQKUbbubrWFsmFR91L0yPA567Kc
+rYWDOfBCshymvl1wM+SlvqlTA9ywV2x9YltpLnv0fWxCm4f/XNDJQSibLvTSqgK/1Smt+2UFHCLp
+ZnIge5oQILk9btsY2SCOHTTZXx+1m6tsDMvSfeveJ25/5rzqYgGlch+8L9Fj5rQrYgy+srZKLCyE
+MbigG7VdX9IpcjmWggMmbvOBI4t1WUNPGx203oHppPpRGz4wF1xMoLuKdNMFDARFoq1ED7SVDpf6
+OqnU3jNYLQ50cB4CBiQDDxlbjtvptZHVSrGGzvP74xoZDKG3/sdsc4xda9akrNvTqsGwM0x2+VWo
+3f2i0pa6F2uFAoTt4nuTqkcrPg6OSJo2HKMI1Zp88FVyd430gYO0BiqPFqDi+a231p0TyL0Wrw+H
+zsmV8NP9UZ1aQ7lC+1J4xJ4JaqWyUWX/JzOE5iNGCp/MpC2/27+gku4dfLk8DHz/UYjKzS01wh08
+lEVYcjt3bjXZA/NSRA2mVRQmR58F6gf0XX05uuJ6Sk06ubgc6H78X7o8K6mKwl01Z6idGjvTkDHd
+i7ejQ0SQHcddNbapviVaivXfUjSzjGJlDHuLiumLtJMjA9AfqNlasA5F3vl2OD1h2zOtsYVsqCo6
+zbxQ2E2SODD2X6rakZbzuH1+EJq353qQ2EdtcW3ZJtyaNwa0SLKcU4Mo9faf3UYPdazS7r3Jpd20
+LoDq6/lQaLg3qOXuYfmwOSqZBy5gsl+lPopewFX471Un/Zf2ALmwd3fQAYkV6ngP44m+RdCQnNkC
+et7wLRug2mtyHmgwJaUrwMKBO+4QZZUECsFtcJ4TOYP+gs06CI++xieNipkbzcExjrPlD1t/Ffnx
+ep1tB2Uj1cyfJIsujXG6+d8SyMajSjJMRD4ne/q7367rM9D7AVQa7ztoDa5flEVqpOdCf6GPopys
+TahcXhxhxVEVQqppBg5lfyGwc9XAYqe/egqw4+QB8DXSrEHdlDpnr119AT/osbtqpg==
+	]]>
+	<![CDATA[
+	LvBZ4C11z8Z0s0QMsu5/wdC803klzEVR/b0YO5+ZtGye8Y6A43S19xrqeXo6lXH7oCtJ97SJHs0l
+zB9sImofoDw3OiN6K2Aj+i2qwfX5SyJc38jxquYdem+fm6hDdStfSoJMSyOwL3JWAHehIXmNKnnG
+UcuBRIgERA59W5fjLp3LZ78NY+lpGBGMvIpfiXbwxfFfQUGEeCIEpzY3gKu/3F/dXCs/snDwKCS1
+FGSNqWfne25gw+qxkZlkuf6VSJ1/+tbEt+H1l6WbHvjIMuQCy7ehCGLsz7n5aXa/gpIdVCAmS0J5
+tmovvEwqzxYHMYK0D8tPVupwajR6jEJTblDHAfz63IXYMXBY8YaGxWbscjSTxbXrhYRfejzeqfgm
+rJBUeoyG4hzMxCi1aBLE0ITvkw5kCMvf1uOFxKMQWN6VGqd30LkCoO5uykEOCI2ESvhs/tvnyhOm
+EwLK0k/0KEslE6kIhzfY92vSoUj5KmJAgCl3qHgz6Sip1Vce9nABBPzESAmcPCxr1BUbBhOvyhqS
+3BJOKTcUtUGL5XNoRZbTYjVv04uUiK5UhuL5tqT6odVjpZuQqOemik6IvwKj9VTjVM59x0NpDoXE
+ex89umbqjMilQ56OtKv7lD6tXJJZxGxKVT8zxIZdHQZDJMwyx7MAElCx9Sco8ISsmugPxfLltUo6
+upQS/YOfb0nfSET28u31hFs8wfcm4qGpQty6F4kW5LobAZX/Tt8bAZeViKB4h34RKia8WACtRlUt
+F6Tag4vUenU2gNp84E1N4MG5fHoTRt+oYoixKjh5xfoLK/IrIcxvKTjrc50mDT2XtNfMY6tZPXQH
+4a+e0P4hv8k+0xnI1gna6zZeh6ZPw2b2xFZC7gqKK9QeaYl2rNfZLXAey9n6MPa5UILxQSNCygXM
+ZGdoGkXoAEJYOFcmMFpIcHR+zzsaUlgXFwx8uRWQD7wrVeOsZco4Bu60BYzOTMIPq+gFpuisrCbB
+T96SZrDPnAPBwnWCf91s60oqaVoAbgT8xfx9cS8xyNV+DUHZj2MZOL3WmXKdcFYW4SgbBIo4gFi/
+tWaQvZLeUrk5Jtfak1jMa0FZrLq/GbTen9DMEmKs5yS33iSthJvE3uDKb5UtPWx/U81NUgmsD7mp
+2tXxGa6oHfGGadRc6HpLMqpjK4WSp/EyJF+H7pshIQBg7yrPOLC3ASZB/5TIkxRhtRIUX0jgu54x
+rkGP5KzxefQD1nz6D0YR+w4AW6baEbBoZrngqxhRVAXprOTPX5FSJpvEg9mYl9v845XKKOz1pYOp
+ncipOS8pSkLC+O9HK6UppSkwdelAdVrV3A0eM0JYykGojlSKmcXVo4qHZvs2vmV+Pl2GppY5Z7TP
+MnvWKViif1t35NkkHTWYr7hQM9VMl/2X9ryG8JUCAfTjCGZX81jxQV4RT2mrkVxheKBV+YZzR6J/
+vlcDLx1O9BX9MSzi07fzXniLMk/X6qjipcRO3V735dmVEQ+xJmaTbphyd+g8UeYLa2L86dY8Ezrw
+bNE2fK5bFpb9mkjEO20k1QkOvEzqnHvimOFFQWF3JZ2zTwGkpjfu869qNDY+6IG4Du3R5XiWzkqD
+fbPjAaTE6pReRzcmemyU0huwPfWB+PSnR3+C17k0w6iCWjIaM5xW5GS/jNGfGCqp4EzLHT1JT+tq
+99XQ9N7gMpmh8O4if9qlbycIxFZHTuJ30jpKuUN1sgjjNew0pEcfpyvBFFCvWr5fx5iUzfjIroJ+
+rJftZcvxXiiAQ007Mp2azlFvbq0y3//QrkwFtUFhFINnPIiw+Iy1+ekxaWJHdAFJM0GZL74QBeIc
+RffCYnexBb4IQYwgpa0+J+ZAs6dPeeOJNVvAHKZOoQoToe+N67F2GqyPcmtBn18D1zgLPSfOjb7c
+g3kV00M2d561roHl0+wm/tOaNsC7gV7kmTX6r6OtVy+euAErzWr7IfNJ7lszcvVX8y1zEZufK7n9
++ZvncsVrnZ+kf/fBFy25J+ZxNujrXCt4tawAdwpfbkALfX2Vq/WBujhKt4iwxO88V4kVDLH8+sXy
+cHuEsMqTncnL05b0shLQmDzWXYGocNxAri5f89LHSFcY8zsqcesFmx/RmK5es5/4j61lWT97hA4S
+K6Z/Y4DKyyeZHy9yN0Jtgl+YevmZRDheyYncCHUcl99pwNICmGLONaD2sv6sBmQ3Sv1G1qMNSRUj
+Y/2m1PNhCBL3jqSwnsMTx46SdF7Guu6nWlrRb6qd85ZN4PQPpNNU0ftMynqPPILkdR7D/Cj4GX39
+KTMMURK6vH8nGhoeoIDTa7431SaR/jqJ2Cdhx5z/yf6itujO40TmOcJ9iX1zuG1H6+8P1k24v4LS
+VU6ZPGM5hIyOG6g3dvklaRLeyoX+PAI+/AFtBQ4NNAh1AwkWgH26N2HfitKuZ0cNFJD15k814WRg
+p8HVKZg74z+lE8vIR/dUnzIUg7T2UDIEqBvtkUJhZYSrlt4WrUq7dQa1X2LEPVQIFStq8HmKrxuv
+7xlRjegG5XLyz8/E0w4KpKtfB7m9H4B3I4E3FZo/lhxJsuTXzbCVmWqi0S6Dkc91oykZ6bC+5eqv
+H1EyWwwkj3riZQ2Dp0/Fu4l/GtjJbbUffp4KdkbWwTM0PYtbUX1XkmTg5epY7ivrZ/5GC+yLHYqY
+wwNAX1lNonAxVnDBTOF/AR154roCYzPQ09kLP1yNkSP67ewpmrddkuhQzQHSAoMtCQabZ6nAQuBA
+MDk2pPHmmA3hkkGZEIzhua7FD91diWNmxrHrbDQyysPNuYLWAujqrmxminl3msuRHVfeXUcV8uXm
+x7UW/VB3t+oZs+rIYXyB8yb7uIUq+MlQpy2KlvFXbb6ohDK6bnvQ9gyllsWALc0PJUls/OrDZOcL
+25wcnkGQFbNOI+nHQbB2L3wv3Q009CRcMaPlQNAiuv76hBOe21W9A7H/WOQK+TIroT5YMUrjsXUd
+OSU+0+7VGubBxPuy/gtjtvpt7rRrI+satqxYHuF5bDxGVcaA0uETTplWLiHh0LAvODOQNzPSLSNA
+mlp5LusEQoaeHO7wUUQcSGxfnansEVfz6L1Y/TvdLgnfeRUSwmETTUtI6uPPv9EIqhLlJ4ONidqR
+biNbp8kn917/IvuCtMTcU3gB2Nn8ghFaf89n3bUDt0nZRbDNqULCzFvuEIqyhKgW/iXzkAUkv0th
+dTaBLlWfWXxcXTXsj/zb3PYo3p/nPU5XtL3R9YZFR1cfzEz/i4lFCrG9crIIP1rewEIGjBAT3T3Q
+Rd5S4NMZrNlJknfMniaNWATMNqDzofRjLDpBpth9D4A7b+DYGFKqhAkM9MNrZz2fEwxVwwpBN7TY
+ztIQAQ9ydGviQ9M9yQEdpWTDFH/v+rjHwzZUaRoY3S29vKWrEixvWrVMmvwfTvAmNQqsKl6mAYTJ
+Q8Sv5AVG77PY63YMBcxN2U+ZdlZrwAR32V1yKIWyUZK7JXHAe8jV0SF9cb9QKPocYCd7FhPTfUTr
+I4xWEQYooLYLXOm615QbLeq9pTQOriItGGtGU/wecAXPCiTiNX8URBNy6wlZi3roH4VxN8VbxBFu
+HaDv5bppSHQEuf+UVF6iRiVFCK+X3UauXFkrSL+a/vWgv17echdgDFfF2Q0TVXSxzAnUicbwjqRp
+SlgoN4/9NYGr92zc+RE7WIuIr5P5KZfEWqEmZpP/xxB/Aty8yc2g4mi7PfI9M2B/+aLfj1VRlFvk
+aqXtiRJh6YV0oLOVqZCOnDOeKGSydM4ibhvL9m98qAx9+ryMz3H8QVEvW2w7Ols4o4WYtCTimaF8
+/Bv45ZZfHRVdkKi1cbpLUAiyaQ8UDkxc2CXdmpyKMb4c1gwsrU6/semMpK2oF2nS77vGE91pZCjc
+WWVWQKq5LvK8rsCfo2kzUTbvAnTOrg6MiRJISOTguSwmA97F9LWht/GEtQsOS9RhjjFW0ZiVDhjt
+kkU3t7nEY0CpAprQJ9lZGAYuiLr5uA8fO7AcPAJovheoit5kFPfWHtgu+8b3FkUiCYfhpintBKWw
+RXCoY4uDapURD9MdpXfUfo1BZOrxkYPyVXLIJGB1YMBH+/GJ7tZrkhTARGZcHLz6j0VEVBOprKMv
+0DBmFlkmzG1PDVWBkR46IW+LDEszwgoFPh0Ir1Bjp0wGMplgIg6kC/MlERf+Wwh6mj27dTlahVCE
+JrK2+gkuRYwNFxdgCXNqN9sC6Yl/pUyVzDjBBs76jYb5gK6VacoGQaLCd64frsPqfxfwHpcaaxiO
+NIkW2r6KEsJN8VHB4+FzTbQUsigAO9xHOvMCTRuOYlEh2umBvoYxdUG2BEQxSQqA/8NIWGd5j98G
+x7E2ZwBK0A387NCESgdfhxd+zv5kNDKu2z3rho0nxDXbxjzmWS9LdZZ0laIIiyMJszH1Kt+BfWVb
+XZOp39kWBkqr53q3lBLf653wLR+RqecIC+lTAuGoaeA1MO1StEV/XXQCHE2wGHY/KAhPJjVTg0OK
+G/ZmtSCC1mMmWQh2tydmT7VxdQzjKPMdIHDevJBtPP2fz3wQeZ4KHVmwF/0XqO9sQI0PlO5EN94M
+R8W22lfxVLsI/l5BmR7gy+SfAlhmIuHYzAqvctWih0Sm3yp/C9JI1AjWOJTGVmCtCk5MLqRGm6eB
++7TdFG+4m4rfBdhQ0tRv9eBYTdyaVDoIIWeTST+Ep50XaAAhVxwnfPIIShBkJpa7Cqsi0PrxnRJe
+lbQtLIbQwboFhYNoAAUF3VrG5iODXH4PK6gkQ82tVgYP/dLBhDzgUOogHDKEWIFglGObmYRj1Y7S
+21Q+K7hQIMwZeECMIc/ktMtVsx16Du9OtkiQSSA13T6vpx6yAxQblHCQ7MkzYStEpneWALdLbpjt
+NVEgEn6kYlK1geBuwFFJTMDSZAS0kZwQQxab6jciF8EgSFuAnIf8EqGm3btBYFDwyhFDjZC6XTh7
+ud3Ahi7IwzY5FmVS4KzIPJXi3hFegq6H2WzRx0U/5s49JHVPNRZF7G3LZBEwpdeaxGL4/C06HcnM
+vYX3DpAI7hEdQLwM7lU8ZjYvQExc3C+lV+SvTWJPNZPptR3PhgAf6CLgzE3tfY57mS6Y5brRvOHM
+Rq4xj0EiKPJLrXC6ufo5RIYFVFH6grd9TbbfcVe7/8EVZ9zMg4Iw9pvljyb3zTSlpRL+41lNOIsC
+I7d31onxxZAcUDRguMZGUm1R/wIpweKWgkw14TyGY6r6I7hm1Grv1YTZSxZnlLV18xq1DwfOf0e4
+3EyHb3O4RlCTFGOhCxMAiEeldj8MAhezGYUeIzfaNSKefw27QilmDulpzTCDFny2rrXWTAxaoQ6K
+i3hCgZj8rEa2APfW9RQWiSehukKQcTR9T96UXA5I2rM8RydxiWWx8R8u1ugMkrXytHaIRybMhyOt
+7CkkRPq7eEIZ5Y0OA71fIDiEtIFW6inem0cFC1KnZD/+LOtqHvypsdWyDp1Dhlautg==
+	]]>
+	<![CDATA[
+	khDf5gGTt593w/Eerh8WVmVOHlWL18Tb1pq4LdDg6c8CgG6VYRQxl7+0I7s3ykJemtQCN3y4oWon
+GboI+W+DzVyAC/b79eE7bt29FMko+vARQ/ybEgBOAq1QSrM6XcnnuDLtuiTvF3useKxvSoesG/xo
+PnHHNog4xNCOOuqGtJY79X9Yi4fo3Gqc/RrJvXKiZ5TO+JmqLN2i629qN3BCL3boyzrPL7AZWnhc
+nr6CL42vjr8v7uJdGs773vEjGOgxaWioVPlHlQ6zBVwc5AjlqiQF0yFOfJYIEqW3b2FDfSn8fSdO
+TAeyzCM1TEJRsOh5lJ/Vz0vPlqaVcwEEN8Z4kuopQqMhUKd3TLYLcRQDcPNHg2OT/V4sAFXq45R6
+hIu0R/boIjtFcIteoBb+oADHe3G7TX1Gm2YQzeB35uXa/+M/rYbZoy1/jPYjxrkDjAq/FwwmqMov
+ouv6FL+fDudJzCkfePmBMFmFicbCtRYnLzeWy4H39ihMNjPpwK81YxnrgSl0LP3Qh4JuDbgp7nmf
+mRyK37n27UgNuBml+rhyAslh0s+jiKTnmZ++buAJHcug8yMZoKANDs0ynXvBu3dD9Rihe4AIJClS
+ZxO7JDRajJACmjhFKCcwa5KkDaeZXvNhBFLrPyAKwkwg6CkqMGt3d++UKSPPG65gUJReBQN4AmIC
+cwKF4miUoR+UQ78BD0OVbw8WwGcvk6aONUM5hW5RlZWpdmUdpGtvY0PuhumSIuOdloNmQnLsoU9k
+LjFlJRXatKRVOHUkk/hoRDuYNukClZ0kQyzzkWnmPWVp9n2aSR6iUsPZ+u61dyM4gz9bkpwey3fD
+CQVDVV2kHonUOotXHKGwYIbGudThKd49jOlkXLeije5s7Hp2NOWTc066yJwlqcqhIh27IkUMmjuZ
+BJVGglgu3ig8O2JcuSY3UVlUiZlXzgoadxEKxaizFCUUinFlEVuavyaIlIdmpcJOtojc4b0O8dLF
+srO7fWitmzHPtXgyFpmSqK7bO/bJJITtnEo5k3VDTAyre+XH9DHpkchkmlZS3eg8gliqXZ8fclj2
+HcmjjVcdOemWBO9OuIrczIiRdk1iwxMWq+V/CI3cuuuH6Igx9zfrRJIY57INkaIsXQ0HEfPSCk1K
+jABgKR2uZfjCuSwPVtKpZPJNI3NmZHlTOFaDHVMVqSXw1dzjbemmo7lLjphs7ZoRo+go08bH+fQ1
+IiRWtIFUZCSYdaJ1s/nXneQ7I2jDY4aYR1VVSKyjXFk9FXUg3b33kqhJjqDmjNGR6Oic/nhyc6rw
+zkp53S2ycoftioAHGB5QOWAwugETB+kAEnNQIhBdxEGDOwMDrTteLlMKF1lgKW7TMvmKFZsGvb+t
+LcUVq1uMpiguztBYitNAxGeWye7lcZm2EjFaBH9P4khRembK5IiRgGqMENNuIL55Z/2JkR0x0Mxk
+apQYLROGN6S1osn6rotTKbA2WpqkwUIoFB+2Y0fasCIjYLDIyhonFAzl07mqWJFhMUKhsCt3KKOC
+aAqJUDAgXtf5lcJneT+NxlEAXehIiEiTRElJM4PTdmbGvm8qSnJlrFWOZCIsVXVTBQTQ6Wt2bXbs
++uVzekwvwz9fIpvKCCmprSIUDlXF6lgJhQOZnaU17a6/2rVqwkOckmV2/KnxGGfqtq6+mlA4dOz6
+JrOd8/rxJhQO+ZKJiJBeVlZVzrG5zAytZ7q7G7RDoxM9LsM0ZrpENTYEJ+eu1qbyf7L/VIZErQlJ
+1VUdmTGzGyG7GUlL85288PCuRkxopA4PEcdI8/nnyazI5fOZLzI+kZqymSI5bYkJUa9EsEOkPxGy
+zSdz38T/Sb1+PMnXREVHY/JbmVxV1lSJXSVmaGmkPR8dqbujIzM05EhGGkJFDhFxMEk75JQ0xJIO
+mTRJ+iRkSW5ITs6YnGCRZGtT+exB0pPZHbnXkXx+aLB8ONdgKWzmtLdCp3rB4mrlUP4yr1isvMuf
+kRzf/I5PVHyTp1xeAblta9s2Yk04PZq2bdscRDybfIg4edv//x8MVMOBbAanPZyBshhVZIY2h1ic
+3suwNExt+imv1VB3ZJsWP9NNW8iH59QF0czsbHqyKdm469mUAl80lMMpTnPkNBPHUMpw05vetFkK
+OsNN627qeaBQR8HdWz+T+m9DNCtyxRuWRa/ZEYgfMr/KOnlU/o0nHZOE1aSTTPZSz0Pta3mi1rj+
+Q3Iecd0MIWOpdYNk6ExUtaCqVcXN0SiW4samqkUnkSRtay5S6EF6T3NmSW7t0NGMnRWx2RVeliAO
+zV13d0JVRwxPtjlZWZTEzu7IR0TEPHz02BDty55+nSFFuY9SIRSKVlkd3FJwPyG+cV+FhXc0hnhp
+Mkw6UW29qiopMUwv1jl4nKIaxJskJWbKqFYzNTPeJSJSTSfNjMx56XP5pnfNa4mqrDZVO/sR3nk1
+dL3DHjHKXPRXFodecr2uOTpy1ZFlhEiEg2Vi2GU/lWNSNbnE5nAU5+WbufXuBKmQGK88q19dtZr9
+5CBmYgtzoH9NTKeVuMQ43u/fJm8I8Vj48hXZ1U86SCHRqjLd1WTRZY5RkVISCoZBOEYlJ3JFSZQv
+JOXDF8ocRWl3STqmLI8Rqjsp0ZoY9VbTEKQjaXqSjCFx0Vfp2hUxHw7Z+zNSV0iMco2JvCpdomOD
+vjkrzPoMkepSKWyeSSgU+XwSCobMUlQOosrmTYM5MZBjBgwEA9QAAwTaASJuqBKHvyGzARbOkI6j
+QRwkL1pr1HxHkXgas8dt1ZpVY6gzNFQ7XDHc0o1RsWIrrFbOwuClsFRdlqmorOEqKusYjDIbK2NE
+Z6axstKPtTLLqFa9va4Q55KUMzv0XyZNEk6COyRq8yK+cdAUuTbRxRc5qzXV0KSno94qxegga3XM
+qvYeDuQp5XC++hjOlD6+Mcu6WxqZKYdhbltFNs/YrGyX18IfzngK6Wc2dZ8r7KWY+WCBGb8S52Sv
+09k9dlnFnDp70tIqk2x0afwlmg5z6jMnu0tAmTY6k6xZO2kdDw+8aZllkQaLhs5nn+dMtgmF4nZS
+ulzbaPdwztIxmKFSdcEZKj2MoXIDHotyLeiXAj/SCh5+BdEzxfmk8ufvcqXsqhj+C/0KocDAtaE8
+vuTLgjy5FE3ny4jTowiJiKHtQkwTu0xKkElISHPEyJmyudZwNH9FhMx3ZlIv8SyZRzLLOUecI7bR
+6LQLNBrttD1PP33F6bTTmPaobWdJp9OtzZ7P//nn7+sqAV3zCCvqFRE7p1ld2Y6mLpftF78VOIDg
+QAEEDhIAQQQNFjDIByjAGVkDB63hEokGYwYIw0ESgXNwxBswkI3hACgABBE0WEACwxFwQAMgUEAC
+o0coDGBE0KCBBw7Q4HAwgNGABh5QoEEDBxgggTGEAgHGAzInsXeTk5mTOZmIOZMziZiYiITCYTIz
+J3MUofEXhEIhFApCoRAKxThiIiZmZjMNZM08Ozy6u7q7q6Ozuqsz3OFGERovxunoCIXi6OzubnfF
+FXZWq2td3ZW71xEKhQ3DpyMUFlxdXTlC4XB1PJa0h0nGYA/72ZMTCoYbRN+gkaMBzQWiGc3QzCgt
+z6xn1LMz11wKK6iGUw9FG/8V+Cz2r6AzqykYRaINQzQrNaKzq5VaMQwXIxQWGKFQoI2qoqWh+YyX
+R5lkhu7kuZJNgV9WL4bURyJyK9UlQeN/edv1vyctsb/fK7Dj3Fkh5a3l++bTb//p91++fcP////7
+v+sf/+X9S9///cv2OrpbVHKJXHsWqSfaHVfrM4hUlXkkdjJOUWvI1PmlJFhtuvS8TWHxrKxHpRfW
+VcSWU6KarJ8t70gNcdzzqM7yOYVlc5d2pONNxdpQZ+xbUm/GBrN6SIX1G0r7p3rrP/8pD49Y2pKw
+jPYSyfT99Rgp8XMREn9wDC3RtTspItaxygzNFiCb4Pyu9LWoTdteqql6PXZJfz5PozGvmDS89USZ
+LlIm+gkRI0FaHY5VTVhSLIFlQSmft1KuTJl1IBQYQJlHRGnznOeT+jzrsKGcQ7Ngqa7Pa/YvJWXz
+QHmluHLj08uNQZ+lTywXBnlIX+fur0ZmDZ4nqBR3mi1DNCAAAAAAAOMSAAAwZCCYymJZlCZpJtsD
+FIAGQCgWMBwaGBw2PFhiYqGNxBQyBilHiDEIyQgAEI0NqUgZicUFSHNpHSpS7XcfD/EkvYEfNdJ2
+HQA3+6ja+1+FG0DLOwifIJF4IfpdJE/wmYUZQZHMtXFLAH1KSyqzboKmTiok8RVhqVqpS6esLO00
+SoFtNTvicwhJuIz/sq/0gkN6xY0bnecBDqvQvOu+9snBIhidA4fUY6QLkwjMDYeECdZQfDS/ewFB
+VXDH7FaBUdFCqjcPWFwIJNZkzTHCodBIRUjJ2SbIEp7kxmB7VIY6V5DsljoC6XX564SLEuzA/gjg
+V8GnviBMV9RdvetVC0DcqUV8DJCMuiB5HyXsBLeQteaR+rOe5nFodTXslBFsaMbaMCs6wk27n1np
+Dm+yuQsFQhsIEnuWD8DfrToCbUDDlYwLD8T39RBeCbB00kzmOxjrqkDKBPRRTT2n+fdQhKAs/oHS
+DhL+h5gQyiEs7Yg77PRkqBwCk03uyqhVaBD+fxCq8trcx6P3fvuHK0sfVD91S7N/MA63B8lDFAbq
+M06c1ZA6cWCPOGZ1cb0jAKXMAgJzWHkThYQTRIHS2XKkf7UjpPPUknhBIbHEmOZK001Rd7g8rahH
+OsRib6A9YSmCQnJPyGFBGfHZx5HJLeTJHhLwg7zXjby1YgoribkshqB4MlFFVK7mSOM66iAZZJeU
+wgbDfVGhkLtCBXsHyYOArYiSlOwLJ0Olo/U2KOJyVXArdZDkvQpE1lA/5CM7X7IyConlcHB/Kcij
+gx0wgvS6J0UDUm9iSmFZcmSYRt8yIKVJd4g7UG1AsuantRde+LP+GAMLKEdjNzcmSH2DAqKAThRb
+fE9HGZ0/4IoBQbxXMYVU6JWG1L0qwPVUq+qfmBQcIqV/SFsJ+uTbk8SE9ogBZH1eYjWS1RYhJtJA
+X5HWtpKpE8N1zYBUUFy7uEhd2XPcGrg8wTygQpJZ20xAItvQjzsjhK5zVdykE0GySJUwI+W2IPUs
+PI4kNyxO4BDpfsR1u9lb/ymzQodSHY2DBRxppPuqw2jUdsLR1UayDEunSWMgIQsbyfBH/FFHYpOy
+nv6hOlNE2RmB6u9ajAghsCeqKJeFjurHJoWIK36NhLXCuoLf0bmUW9rhnXJzqvFtiq3QAj7Dylog
+A4mJi3KT7OfyqDS09989ruqjDhVgsRzVmJkopQrS09c94MYqL2jgdXHNfI7jCgnoRJ9vI0imkV6V
+ppDMURjSj4bUuoV9QmqIlCFfYK+ZcjWWv1O5BlIz3uzDApCqJNflZcyPun96ufJH2W55NXSc2rsg
+qP4PbtCrV2HrPCIzzIu/oKt9w+tNp/+XEtovsxTTW+sXDEfuInLJ4+2ihfPdRvq6sg==
+	]]>
+	<![CDATA[
+	y45VpY3aaeHwq9DbnrQeEaqphAFk+1Ooj4/Ih9rBItE/PIRgxyMNRREJR/2AwlpFKydvOs6n5HIM
+3h5YrzZo5K+VmUyk30BCUxH7E4BxRbbRSnDf0MqOMD2m+GOxF+Y5h+aYLSgur7J7Trg8XHQLvgow
+glGIKqwHCq4WTThqbmMwitqBUIupeTzUinMcaWijFlua9rCRyZsfYiYDKhahg94CdlAHgLJhcVRZ
+W1jrrnCmC4Dz8jhIEHIb7d427/b2QP6SlMr240xSTFLqiqgJoVREXkQzzhq6HhYjx8yhIrAlPgCB
+Vhnd9IIOFwM83hRnzuy/spRVUQ4e+IWAxtRRetRk/6S4Z0mqIcaYZLGHSVo9NZuKMERKifJqHCpe
+kThmr6hDf3kc73PhJ9fQQf+fa0kB98MmCAG54VgNcTDwJ/oZpjE4VPTj6SChHFsSb9+7hBeQWwET
+H6u1fxJxOcpBFsLQL+EXinnqZGPnu7d8TWETj5GmvqGdrm5KiIkkLFZMCs0pz7UZnkPsra2MPfZI
+YYynejaWLxDRweL+BiGqxRsWvIjtLy+cgqBMXBIHqM2jvrJQX0c05LbJkYP54S+XS9dmKb587I0w
+VgYkbYUqvzv+cuQfHH2T9CVWYCUx6BFVb6nQt6TElbvEUkkQY8Lj8lPYenBGPA1iTt9cZdN281Qp
+qNzYU/ZPv7rHe8X7gLfQRHipq7YXFMCbUmaacRkut10egTPaE71ytO2UsDwybEMIZRTrVAdyumsf
+cxc/FdwjrBKpEHmUPqLi3VpMr4jRfxa1iBuqClBjgawq//kXWVbB5dPZXYqDTycWzLlcPYBCXJ6n
+Zpp2hbJJ2ylKVrLl1PsZi005d9DLpZEoaeGqpec4p5U300X4J8eqJKGl/Kg89XstbKZ7gxgYPmDP
+4ffeLZNMvlVqeVrRn03Kljl/e2Wh5SRuy6pGb/i9k2GrvAjVw+Rw/YW0Eaq1bgeE1ABVu1qLeTgq
+RKiAsxJiiKlMJ8N3QZHSYp1ioy1KcsWkh6mx+duE6+BLIil2MFP2r/UeirrQTtdMEBz6INKSKJBY
+Mw3nZE0LMK755mVfY+1UUZpz7qhgtoRztjSX+QS1UMT3/++4AdnTvLw9V3girH193/pK5WqWbApL
+0CQ24ek5houcplTTiOHUS1Hkk9Sz1Q0osxYx06FwCSR1OzdEDFrLMnD8IfJYbY11I0a4l2GOZlq1
+9+pi6GAFI2VF8a1T5nil4Nkqk0qri9CtShjRTwUSGQhnbkJzNgVcvXkcwxTKrBe2WTPoeqJc4sjA
+avDmEAXIK1ueIPpgoJS9A3xxNEvGqIqtHKuR4UG7ezrV55BzuCIuVdridFxk/BKS5hRnx4WU6fF9
+Rhit0goAHWx9SQrw0sjSf/xQECv5w+xYImKR+iyG/Kv0ETAenFWwlLcPFJSxyiShk6jE8cso1GfR
+dBWjME/nMGvFWEynjKwucB9TBfOzoTfqgpNjuFW9gBo9doWgx7rIXd9h2/FTMNzgxYbwXKAEX9ar
+B1aUS9C+sszfq5OfTX2Qy2NzqQWOyC7Sp3ziAYAZaAI2oBhoJp9bxZfiIp6CkscUUsPu+ehqVyYg
+G8/sakbxupxCifCiFbyUmoSZ2jnl+F8b9cXl1TfzC4WdUCeIPi1AzpTmblXNKf99NhGzEtgnzuKN
+mtmssalVdnhv1trFgBtBS2Tj40WFVOGdvnNU46AmUY8FQsJ7aIHhEjWOU29qZcn2eABjIVSxp+JX
+WFADfVU6DR8ulPq1a3N/xpklEitJ4O5TqjnilLXbLZuvRMs4oZXxqEoZI9HIqB5Kt3wdqmJygmIm
+xUZVQvpxDaIctl1VGWLRM0mFV1Kvx456qQ+4VySKnEX62PG9tv99F/FscXkSsdoDpVj3l2OhgphD
+vrRP4oq7QGL+jboaZ6aMlyJPM2gpXJMCl68XMr1qkoewQHos5E7LW+JpmQ9abNKhgQuIu3/iyt9/
+GwT3WiFqxygo4ZO8ugqGNuYkIp2Si2ZDRHOr0mxV2tIsOyvHcURTJ1sPNopEkVDoTfEGLHZD2N9w
+l+AtjucbNsSBQMBDydZfavNVYqKykZJP9VaxuJt8C+igR0d074ix/BgDQiHrvxinuJfdSuFpu0Mj
+AM8IKEoKUUxC7GJj/oKrC7nJKe0Ohcx+IZo+wRpbx5G7bCKW7awiEb2JhuUKvbOorheDDf2Qw2iY
+5jY6AUVgnErSowDft7ASb9QJ/xsTFjkyD9f94E7I+gdsz4uhwuUZqbjkUT7OTdjn8FOkIKKMT4pC
+A88QMwb0Cb/dPuONMWgDNKXR7ns5ILwuN8F/KQ6PwCsUhEIgNESTOHBNH2Qzy+JZifcGAkfxJbb0
+DKKCRVPLvQG193VWJfdd6qFK/vPDAVe1T8aqPv7kmGbsnOq8vsqhhLTEBG4q6ZyniuhO0N2VM3go
+rTo8/9ibp3GS31gfawpWpB2CFGwKArJS9Q+iZlcaYwop5OXQwrEZ0k7F+A9xlmaIqWmpoZfyzRSn
+ddWBM6g6AORnSbUFCLxx+D6t+yCfpikRzukFmgEja2oePs3JSnI60+yymt53UKW3K3fT2zpr2Owd
+a4wWnA/cjr+ycTbYTvS7MKVy+c06Gay1uP2UrEXnmIZhZp2CMmKT7R5waCVp/rcCi1syS4RwlLib
+KH5MOgplozB+Jk9spuF50hFcZRHBM+OVYp5jXacy4ZR84JeEvAOgE2kdjKOg+iVB1H97hYguE+gz
+y2XVxYpFn1su2ut1YLf4DS5ItwbyBlcDxwKfWXJxL89Ff3CNrAntuARjCB84kuCnygk4ZAbJf/rh
+uWrACkMmWX9MUsX0dR+exN0d+2CmiHJrAlbtuag6MwyzNul6oRL5q30WCDk6YI+CfH6ShkxaQDVp
+txW3pjt4TTDFq55+j0DYODM0cccyYb7s6TW1nXbXHQgTdK7Gwest7CEaUyirDiNwxDCJGxknFrXE
+4rrCbx52aBjjZH9WfbE5CzOmghjP0Kh3RtWKtZcKzE4Q231jzAjcCy5/LHIpr6DnQ+8HwsAxtvJV
+qgdJkl1DBone9/tY99IxFuOE+CvZDMAWE6qBpGN429Pv+E36Oz5yuiIsk4NWUx+zRdRlJuQrUnT7
+WG7XQAaCkNv9QNrJfewjmBUbo7iHi45yPc92QkLrv4IPTCed+hjZfmSRQ4sMIEJA/GJgYGS65OoO
+s6gwEN7aQJwlJlgAohdOFmV2SLG0L96TDEBqSKk02S459pDEw7wmgmon2dqZhCPjLfjX6p6UbgfB
+chZLIyiD8o3Z9cYaDF4CIQsUV85GmE4yslGYmVHRb5JVgb3JhMF6dnV+tDmB+1htL0p2t+sTSbFw
+bTKKE5eSTy0QsQJ0jFzZQZIfgRExAdKzI7Lo64DMm1pCy/a3h6pAdYT6MGjkFXeN1TvTjUimWYXk
+tMXZZAS1ZBCMBQIhphhEe96+zVY9i38zqbrtHccjF0CMsIz60qSbi4xLUCQuXD2MGh5+MeG67QqH
+oKYT6p2G4tadvWK/5YO6jXn2sllesSsTiVkMSXAz46QI4yCHR1e4893N+id0JpOIBL2sMxAWmZcp
+G5PS/vv9l0ejx/f+V79EWKbnMDbqMuHV4s+RiJxl6pBPbZkB0YOf8lfQLtOXmi58JVggE4KogOAD
+ZZt84HMvpsvsuqUxLu8wCcSWbKEjhsrI1L0KDvlVl7XiFkfjTuRAFAyoiIAXI7u6rI2GHNL2wAqs
+y8zAyyCmG4US/iMoxDa3eDT50mUTfHCpUtIv3GV8TAZHKmRNsGhAwHyzHAO/1e3RMRYgUUhRylvO
+eMcY9UQj7xJczp+zXQbnFGOGDSLc1c1bGHXMNgRb2uwyIf6bY7egsLNwE7uUNRI6/RsOZtESix/a
+iCIziVhcNVjGdwPGkb5w7p7XycJhVh7KpYwlX3YE27cVtR6ACT3aQ2h8IL/0VnJcY0XIyxZ6ysjH
+j1RLGMf1gcTuFqcYNPKS8cucsNm9YbnWy6WETywVfQG2kSgOlEBdJJGW3qRX5jEGK+G+eu1HP/ca
+AiqzEjY/+yTE5KPhgv5xcVL072K9dbl3+9GbP1wc/F96DCiEdzrPJNR8JKylDCmLRBwj127c/DLP
+38vx95BuuwkEJORd5oEnoPATp8guWHGUCLDFCpWMW7v8En/aTFhie1MP04IylerMLVi0n14Y9Lat
+txyawla02zczFhstupJpgqkWNSKDj3OEERi5wWtXYY7SSF8HdKJ6tJpP8E87RoDv+/csUOVm/lK3
+1LOOWCOSf1h5q4CTooOwLxoF9KP6AWqtL5nh49LP5Q88M7ShE8RX9wPnpDAIbyED8fpQyPBrL/id
+XVpHNrIy76PEyF5gEW0W2VTXqJ2QGUsGDC4RmFtvj6+6Yl/uDxeBcqB2DykMdY+15DHIFfGit4ne
+xdGZmJ411Qt9ywTjVkxRTGAU5958Pwjv/WB3KO8t5N1CmTChGAhpaWri72ZLGxL/jpuMwAiMXTOv
+iurXZWi+i+Q0s2DkoXtO3MNzdruDIEJ2CjZBeTjzq6uhsNyIJRAQYXbX6woo4FGO1eyZbllRQPtE
+j5N12GUHVyq5sbO/XzzI/ztCww/woEBX6Fs3J+69jTpjUbQXI9n/9HMrcLskd+wwddCld6I34kUX
+BoOk1k09Sa1JkS70ALc9Ga9FGWnmtIWFyjtetJA22ur5+g9Qu+vI3ibk9HqLIZLMfdu/fut9BghF
+/j0ylYhpr9NA7NZ62i+sJnnHBIyYyKemNKI/L36As5Q8Z9GUfaAwtbCT8lgcgxL38UKKqXsv4/z4
+7vuQhSCvxzYNIrLNdQcoKpl45V/ImTkEi6n+SIVwuJRZUNtU42koDgPl1AWMEWFoByqQVur/9E3E
+shsydAXu3Q+A+YIC+vS+pSc33K3nxOU8o9g/7nVTWloFBdeBRBNtM1Yz9EXxH1g16gwCjAcBhfTl
+WiWpPUvA27nBN3Qc7x3EyoQPDwsxVh4rWqyMi9BxbY3zxAX0I7QZwhGNHqp7xLIK9FteL7sSOXcj
+6IpAFKLgOR9j31UIjSegVKWy69j+K4aS2tAQLtOa0aIbY4yySgNLuh3adBhfsRhxXDsdBNkVjSat
+PmwmLRoDbIPpkAmEj76psCPr6XET8uv197Qe3Q/BydAYAUnlvIKvO0WWPC8zWQFNNiY/JGad/TBh
+6mJPl25wyZr39zL8NCPOeZc5CJiz1eLmuKzhNFzKLpTiCNrFCsCFEXOKH3CtBHW51ZySYaO3rIUr
+i99wlDrMdew0w44X2+uWBocoB85mV4iWVO2uTAEFuEhqhLjyc+GLfBdKNcpVlLFC5FsPHDpkkuha
+tYM8cYGct2wDoiSKhrewEV4PlqAYDV2fpu0SptE4aKaFZyyhdNEibHpmOZjg2DInUTHysOWcWRDm
+lRfsE98isMQ6RxixwJCN0tBVtnuG2Vmw+aVVInlutsvvl3AMApydDhpV6d/rOssS9w==
+	]]>
+	<![CDATA[
+	zbE4lBNuzbCnlGZECfRtbfVsoKxE8UweP6y4pQXN5q96UL2CM1OlmLKgN2cAoNS76nYzdSoqYEhK
+YDCF5N5ALbdv4VeptR1SE3RnYQQUjNZArsj+f3ieuqjzqCNA/KNwilC8DFvEjlyNSvVE4IQBOr/x
+yZ3gq7BA24cenkeSv7ih4bgQLV9lQq8zrlLxQa9zL1YCxASH/10DLu4SWnvNChia94x4/fNi4eL9
+YfL1zhvwlxIjGAN7wnap9sGms9RGZJjdoRoDuDKYQh0x5S/Xik3kuFPV/7Jh1v/k/eEf5y8IgKPJ
+Vj/fRvHTBN7OyPav3EAo6M/Td//t//DBX/dyZGwgakRknM2RCeZz6tZiL6MH6NEpwsayiKDRxbCd
+362C2jgQMLZiQpQZZoLk0njbsqAcjZjr0QvlIOSfs+tT/psbZB17WgOxtuR7QUNKJwgTezM6HBtJ
+jLEYwiWTVvnw/1n9QWY5u97QlNgqCsbqcOcYoVXVoELhIMp5V5v6DCe4ekjcEr4KpiHAtWOxtKcR
++JDl/8xUym1ylxDNreIYWkaal4ngsuCdP+4OmSA2rNsxgpIOBexgo692Df80CQZuXKKIW46Bj07j
+tS20+PQR7pu5PptMkAVRyaRZAL+9hkDcq9V71XZKLxOEz5tafetqWwYd+l50j+1WuLJS3wb0Pcy/
+Hj+NVaaIPA0y00Y9cuB9gOvST+qGFF9xm3xkFJnUWX3npVepyFcrA+RqcUEvO5r3FAVmmdKmL3EQ
+2cdUZM4Lkgbn+4cDtJJ40bk7rZfNloFnZAj7qum5EMXfTUu6c+yOjcp4cfNFVWJIvvsSzYgQGRfK
+vP95KlYBnG5HTAwxDlCUXGar1GyezfaHdjtEgSPeWAgwhMmSV8KoVA7bxQcDOGDKPygVaxErZYKZ
+vbC/VxRc1FVKT5LTXiUBxGePuQHJS8ePWir2K3KP6E8b9cylaOTPOa4LJkJRhQUD7hriEQoFcReo
+tgRpcaKFq6pwOI3yyEpIPvJfHppcKZpovjmGsYv3HDviCCeIRElSrIPj5aXwDfqTXi8QeMLvegMW
+Esd4DQEI92jxCxVfl+qSYK5YeM+VjKaqulMG8c6iez6SCcfRAvu/Y2cieao5aS8DqFuWAGV18vSZ
+uSowQ0QofA0npC9DEYlTPareuh6EM1tHxATU2xZlzDScpEToEIdvF12LfhcDCvvYWOagVk3qOk1y
+mzIftN9ft6U6AnktSHDV6O3w/xDYzcFy7yp7IuntbAQfRSErTMORHNL+edAzY0wi0rYsCArhO9gU
+IdYyeCvuseO1xyf75SF1e2Wk8X3363MRx2MqWzPfagoousKgoKTzEyD1L9KB7Mp2jEfHruHKjIRZ
+h2d6bZxRVXbcTZLle/3VoGJewssbh+lit0P9ZG17Z9poIANleOoh5I3qG0Q2XD9nRWysvS7sRM1B
+8QZ5EgMcar2SpNQTP93mY1BaDSUc6dD9ta0Q+f9P5QhQzEaV56Jb8Dytc6IsMEPYA9tmkN9IwgGO
+C7Y5EYqn1mcEaUL7mmz3m9wUhyxX1I2KDtAkwXA587UqgZdhDAp29xRyZcDOY1gY8t5V9newkhEE
+GKpyGkUSlDLZx928NJGFANfMxsFsxY4qOT1BVQ6Mqv+WpgSY0q9E0+Y7dAX+O681EEnGBIK/RCzY
+tT8BUgehqMezNSUxo3GZ0uSTajBZOGvfiZeDL6Ignr3yDRbFKfDthoLFGaNwlpzZQ4uEfyPDed/W
+Q2nbrPOuJG9u6lmqATVt30Zlm6+8hYq1lYTdMjURi92D2YbaekN3o2apYA98htlBYtKsc8XQeFHL
+8Lt2WHCw3Rj2/VH8Re0KuG0plPU1Y47SAmk45a6ahWoSCR5eM18oJ8JKKSnOK1pxCAvY6/0OiI06
+PBfdLPgGIX9za2TiZWbjBzi4s6Lyi8qg7gcFC3Jk3jyVFyUy7ahcMx3ejFUXsGVURikpdGr1A0a2
+iHt69s6/pbCQ01DEzQ6V+jA313qIDHg0IEcxS44JnuJY+fDXaKbsdM7Ou0I/jwpLlLWjBsQkR0Ug
+mXvFWoqQF5HAK8Su8d0nNGUKxazR2XsNbtvy3fOGefFBhkAGc7leCKt94VUZV9y7lhiSNRkKrlY7
+HT5NhaAh40omxwrBjDJb5Zc/eu2HaahqiQM/Xow7mudv7bkYFzr5c5A9iHt20Rlify+T6nCNvY8p
+4Ye+8iQbYvsM96qymQm1GMvTC5leqMk2gnKuf+CjSb+WDN+PUzSbsTZJRcim5J05Jj8xX1x8Qccc
+uY0KKD/4+2jCHMDJGeot+Q2/qFBu7ChcEoqEhIboW67vC7B0rgTnKdyDpIZWBb2neJpSIpH1vT3j
+7shlUwUYMQ1bf3faGQjrfndrfsF0KntsDEsw2/ScX0nbvdg38lBxXV07uwRPZBE+QhSunOlpzuiR
+7wuSnZKUQKn8zBwwrt07tEn7tpSbpnWG9kczd0I/PPAZs0Elk8unwW278629OeFMw1p+tjQfUWbk
+kSmwdfu0NYPZQlSHqOE+awPd5ACL3HLGteqwVt5ygPc0ArjNXgBzlyNPhI3eKaZCpeiNzr8jWuwf
+AGZQN2+oVr7NSE8oFNMyZIZulw8UO6Ln/v6FXALpYV+KhXBwUS0p3RN7njhmYfF0ZPD/VZEuEoeA
+e6tntj7WTh6bK5ZaJbbtIuYmMpEb9FmK3KC1BiNBBqUnDYAyLP2hwyiaOPHQy0fySl7pFabiQe4c
+yhOsSc8K7oZRp0soni/SgiyPcFxcDfakDeiGA1zkBph91NgZY91o+4n3dyM9gNE/D0orB+4EJIqE
+4gblb0fb1G9ssLJMq0h93BoMt4oUcoQSz88Ava/Bn7JWLhP/FfYbDka2NOhE6tAQcVshhIU+fTdV
+wxJicfCzHE4A0FcgxI/W1+5LfnoiridAPvamjYvsELm1VW74ioT0nzkBq3CYlQmu9GmEmxDCPfKP
+bSzWIJ/I18711maAnogQcisrW/qM0mJERCqbohuX5MfRWiwh+kaubcJC9cgVdBdQd6IKcfQsCaB4
+7UJlXlha0NTaNuiWSTnhCAEEV1EjPLxCegXNdCpnWrX8pBAtRnbW4JhRxYngsWh3/B+719p/D6vZ
+v80o4PtIhJJcnw2ulZ5Cj64dhp/ClyP/efQHG+4N7VLipxt6b+5VR0f+ySAr5je5Gg38/xq/nNhm
+r/oLK1t9B+Ck11ukI+jRUmbbZl2Bw+GMh5vokBLH0mEH4b0+ml1Mu+EwsL7ojVkXIPX5alZfJmt2
+BPC0mifsZXySNXVac4r8xT7X5GSVhKo2qAPOuREERVFuFlA2D4G8iOfTrmM6ETy4ywwyRBI31sOz
+jLut3eZgQ97Hk53K5DUZXA82a8ypvmFmmKr3QxAdGG8VphjMpuRfzOww9rahBlg9YbMgQDdVqVn0
+lYWWrI7hcTo43jnwzbBpqeX4Il3w2PdKVu5UYYerkCski4GpFDmbcgvtYnBLF3jcL4WcE8Uy14Uc
+QCTlwJdX7unq3YHj7l6rUPr2wYJZ7i1QTAhnlz3ur/bofNTKeEaYLs/IF92iIEPT6bhekv/uRc1I
+ujaqwXth0dn28u7fQo+H2i4cha8QKDlTuEoxJmBDkxGpLPGtzbdLoESLGmxNCLSHtEooszxaaiSE
+wDdGB8QARwDWUFZPz5EpiGCTXbd39k8tYrGdqlIG/GPamqazS6DX7bX1inFbaI59KpPMqURr7Vl2
+FSH3oixXm0CpJmxP3CrkSRH+Eg/ysEfcCotf6oYAyZe+ogOitD4kIlKzC5ottVUkIYlApEEhAs9i
+MhU3IB2FxvwR40XrHVQdBo/K2uKSmwBCqCEyhXhEUO4cqhKACNoZWhc4rDSSUlwWEzG1VERbOy9Q
+hEYjOwP4u1WK1crdCzSWOtJRWQnPaGPEDLlgXyU593ZxqtHlkuFJVKowV2+mhJJAB50FE4R/SXwW
+Eza9oNEXVD3lVe5t5TdVo3RrVCI+RJp7Qpj7tjYgiNlTmwVowJUMVtUxA8aevwsRYcbFkYRy2lIg
+zqKlijEuB2rgeZfM7n8zNUNHN07dLnq1qwsZ42PP8DxtLJcuO8M/lUoZybYzLwDTccmqTMaLjHNs
+AJydYLjuzltD5+mQ6XHOLEOh64ViTueLYW0NbCPOrLL7Lgic59gwyb19U1flf6quzOA3nK+KbhjW
+iQozNK8bj/g2vFJhgtDfi3qUlZ9FOBXpnQcXKh7UE1LC4JbIBL7q/bOjCSA/stjPUp2vZRedTzcQ
+7/zESyamjTtHy+xW0i7Y6QZzUv2WP2Lpvnl87q9hAHeoNq5tGdIj+ugGuV+UhveIDIytWzADNlBa
+2e35ELr67TtYWRQYbEVdIpk7r7NKvfSgSsmWQGah8uzTepUafiAIDFofTubIn/C3DIRGEjfmMCU5
+kPLQwEOlCb+C1baRofyWvKA4HHWrFMq5N7IeATMfRntthAvzvJqEYQ8G1pqWGolOxXaAZU/KX3yO
+x0hYRgFiybF05z2ZlXk8HETnAXFO3Q3FCxX0oqSAxF1olIggw9gOlRVAiAxNQeoKNw6S8E3UPbAV
+iZgJAmhZBLoMXMX2oR8T9ebao+Cgxxt9nPrk/VEHx+2TFr4UcoQ4BbHpRhmBY70fedjsb3RtoUsy
+ytN8IhKd12Ep9RS0lj3r2iuLKnJvG7ORONLeuwltkwaN7GupxiKLhEy16rmXXpGFpGbD9LNHRei1
+0vDAFrKSDeeLXufTdWV7nOLU83YPl3ryLigjoFxRHRWP+uEm3vkTpmMhyaVlLmQHJfRnuQwIqSmf
+RALpOkHhVILNAqldyZy2yR+DMSeEH21L98noANgOxLUyETQZ/9C2HN6xfikcRDXghb+lV28M/BfX
+Y1Q/U2DKQa+y5IR107s91nWqUYFNZdqSOeLpBVOfcCzx8d20oGLSxTcWCiA32QoEpq+bWdApYeCh
+6Vau4UmDiaNG5TmEsGWLbsgLGS5Dp1k/MhsWyitqN/fTa9GkRqmSI/yB51+MkXc7uXSC9gW2HkrN
+lMrVHy3GNm7+ikaP/uHv5scsrN/4AS5b/cR7VuYCEegLlXiAPB43CF6ZCM0iSJjwxpxkwMn4kXyV
+aUpkm72f9p5PXtimNSJEr70rnPNc9RXGJREzK0gkYcc69STzRH8jvmVzyZHvouWpPFK/IHEtcTSP
+ITe5DToQn+YBxkU8GWa0r45uX5AhVWOqxmUj1ZCzPOIedTJxS5uXubq3J9cO0oNjFkmOQ8gTQtix
+rq7LiCbKRGNldjhy/MINFxWNvWJ2VSggRZr/Je0fMI1cdWhcyTljUpuBrzn0hV0e56JbxIiWcVYS
+/Io5O8XkAzPBnllUKaLWaggO++Lw/N0sp0GdkqSDrDYtdWAgYmw985kRfEAouJhDb0vmiJW29Sv3
+itMPQKKGJVlYloPvqC49TnLBwrgYf324lMzm5HYp1/DJgqU8sWFDDKy7rwf5SO/rZQ==
+	]]>
+	<![CDATA[
+	SMREOmQmr9kYm0Rtmw/lvjjkpSY1UYPie2lHJdQRGLKF4EkzODGVdgsCDaliccJgK/y5xzhRd7gn
+XGWx4OqS4ajJJHGQT8S5FE4vExsiiiyvzbPA7YUA29oS9hVRKK9765MtBCeV1ELylZyKD9KHrj6i
+9xohkmjYdhI4LMHZCDPsmvJ28FQfbNOq2qh3IKXRzpAxykQIC7RgEdyy0Az+JDAyJC6VgXxK/Xsd
+KKIAH9+r2kUOEyXD18CqCjN2V9kgKKtTmeeqLd/4r8Z9vUxhyheQAPOgeCarKzOWKP/en9eZgwxB
+PuZDCjyKMyiaqw+HkM6rv6A0xRpWaMJdEYJZVL64s1BtCs/aX31boQIQyjW+Uw9eTUWEtwFQ433F
+Ahv4EOxjQtSiCiUWIB9szdt9eIIaLxEhjHygOitNlaS1eNPg3GTk9NXEYKg8zihSp2+qMPexKMNU
+TgQ/fv/Wh+xbRUS8oZUaarVBblGW9qAif4m1Ba3nM/omNx2oXuuLcsvJQZ5D50CFKS0kWVslQ5wk
+11gDiCSrmuHkbLWQD5X0imISo0spFrLrlskhCQoTgceJuWseWCa6Trl7lLcKCwtQPLXm5Ap0Kznk
+5Nj5S5JosKUsMSwqXCh57dTVBr+5s7HStGLu/n7UvftHQYjKFyypMZFRxcfmKjMIZPX/zFi1Ejmc
+0plvuGwOlbBDRL1MjLvPUZnuOs4tKj2DqMLchXlOYRg3EMzcxBD7g/66TKo02LDgRQdOcB4iYpEg
+WdU2KooAvu0pALfn6Mg3ymCcTLl4DSqCYATy8u+REKgCskX598FWhdeU6F6lP3iTq2xilYJt/6fy
+bh62QkdkLlmkO7gUNxe/TVqz/8AtYHfqC+Vw+qmtoKXofcqrFFmGUn7b3siSP2upogWQnDA8e9PE
+ac09Aey2BWcsTuD0Hp5sLtqEDCv5XHDcizhOXLLVJsQV1VAlFcjKC+WivKvaD2+oEu0Ofh4TTp4T
+VImkJa8cSR5SaBQdX5shDI+myZZFCeaNdO8N7KIzRkLshHZgcgwFWiQNsNoCwtRqno2ty6WdxvZl
+CIQiWHenVcgBGXdYIquulmFszpCvlOQ38WZ27SlCZogooSNsyDYofyKKIHlmg+I1WaLGtPEM8IFl
+nKiIXsrKTTZN7s0KRv+xHHe0Uq1Jv2ndIEoQjBx1HKgBhHnix8WYoGQphbLG67F4TjLFF6iewU1R
+e0pVCVjZZTk0Tq+AAEt79h2gEDGfTr/+KEqqQSLcK82+/niVVBSBtgNUEbU4BaZQw5pcOrZInuqo
+cO6kQFRSbF9evGlUsIB6/p0pULIhWmGxGz3vj0kGqXi8L+oCdxx8LgEoe4Md6Zs4CWhRVGpjsIoA
+3KK2rhzMWmK1N6i4+pHE6DBjM54eZa1dfz9K5k4xu85dyP0AVK8hqhILddau6vvUOIogNBYhqEQS
+H3rR28UmuzRemzvLxUaFwIREiAGKQOO2FWVz/iIip6iYf4TZ75IoynV7Mn/yd5vil0KWtTyeUx9P
+4Xs7S8EJ4ilKtzRYasGh0b9mE7yrgomEjGAo2h02XJS2mbOrA2OjW+4qWElAhS8bOp6FdGDrrTO3
+VntUy/twf2KvIrwnck6XKQgt36lnZ2ekaDgmvoQNsNG+CuBYWaUAEayO+oVXt141imQ10+KX/hVd
+xREZpOHvbER5hVukRuynQE/8SI2FmxhQldOAK2DtBxLjwsNgRWzbYa3tnS0H3BaWE88qURMKkVvt
+uNGrDoSnaNKKF1TdhJ0i6mmi4thyUjmre5d1hRh1srxTlRr26hQssqJ/AmsLZ1Gc6DSLJnXOCIUb
+rVBkL5XkQ576UrOZWot0gEh+q+CaBi3Wc/IkbJ4eeE+aP0bolkGCaLFYSjJzGLeFlZWSlaGqVwdP
+1umqUpOiFJcXAgVApY3Hep/Hn0rkCiwez/H9eUOVH0QDC+ltUpSdsBCP1E1+Tpede4kxGwJJqdyP
+UBm05VI9G8w0XvBQDL0oFSpsSaxs5j2PxvRaQYwFKTGiSQ7pAkB78udbIJmr5u0VJVAyCPdE4fIx
+OTHt2JSfZMenaHGgCwtpVPKxW8UED6zT7157pYao80JyAZNo8+0qb/GKtK0c5OLJ8TXcO9vSiyKv
+ILTcJDUq9egV9wO1ARwksjl1VIIsOyn3ay9EKx6SxSL81pW8s86hb8WbNglK792fU5q4io7Ah3kl
+dzTdP+0UqSraMJnKtA6q+JyqexCsCECZFaqpLIDR9GxnsTL/FaJv4s38aoNTnyAUjjRdmizWXbGB
+Iu2fwYk1O6Grw0cFZ6ea+3RB0QTxl8EotFuFzHDkCD70tlhI9fxa1TGcoBl+5ZqqNuFJUXs6UUFa
+FlXe2B5b9UG5V0TVHrwrCii4XtYmFkS3iaJMAxUyn/qRx6fzzlticRQP7kniQtuK1aOC7ED5eqMQ
+joLqPatImAUn+Ntf0FQpYgVQqHUTWRZk+PXgrM65XgZMl88UuzyMMHKbpUQllQjulCKsfRQAFYWp
+JAfHigaYiuWSXXXVBLfTRIdjwZ2TmSmZ7J5id4/A2RVKZdpGROnYFD8ytQkmisZTfh8XTrZ4j7K8
+Q6um+hR3tIqJmXUybK6i3ppCARycdXJvdt21qXN8n95yPVIDbn1fxVs3G9V3S+sprEhuC3cxR3zP
+dsvStl9dGPlQjVZLQo4i+TRLqbKsSA5u+6sHuHpNetr7naAwxU33S13c7Y6j8C3Np7kOh8IzE6EV
+Nbxc/9ON8fFX0YabNzRZx1cVmuClgnhPFF2jhaTSCrbvMoPWg0IBAPKDbUUGhr/JDstqZzsoqldq
+CkFwk7azW0eQECbcmcw2GwulYTwKSaFnwf4o9KhUHlTVc7IpZrKNgIgUIoWb1vSI8hpY4oS4ogJT
+qBwg+6r97dR92BvrSBhf9hAsRdjO4K+gaUBoys3alZuagzRQbY/2ihEMY4EoS2llaG9PUTXhqtOQ
+0kOKJ/ZdNmF2rpJdbo9RdQvWqZkUFAUURy+KCjMQ8Smv3OKdP1Eq47pkcaKJDlFQDgSYRX/hmVf7
+7nD/Y51+h99361Fo22yPcIMbQjHWWNhZDwrr6nmHHCTqhjOg9BTo3tOlaCtjaAqIL3JBdnUrwpxs
+Yu5/Ceu+c5opFCjF0eI9PpCZGLqwKfyzdKsM/fZUqhRmtwd5HxloIYQVNVBHFUzLcXrdS1Q3b/sB
+Iz1IJ6KdSt3nyvj6XGr1mkva5G38ULUe3IoWqMsK6Mnlyisd78Gdnfl2dKYbladFgqCFontLn6fI
+mDY2jlBczH/VAfrya2K7HkbHtJllfARbKon81SdpWSqZXMWD36o73LGoYglnUT2DPgxf2TcdMikY
+vKuKtLdUZMr7gRV8GT5QqIhaSIhsdcf8fA2rot0o6uRGRUIqg2xPMbq/0hHtclON4AY715hsVOna
+8/ZThx9A8CnGX3S02vlu7y24Kty49MzV3wv6yTPrJeyvqNb77o6/0W3UhuUORS+a4oXDMxkcL6cT
+nAPFKLHJ1On6ly8RCSK9QhOIKB3C3t1MhfQerSHV0QFkXOLYD6UokCcURyTvXfPwOyYf77lIjKyN
+KEFcnMe2VMV5NDowmnh30bxzi5nu+DuOMWL1CETJtooY/KoObm+dCq6B6jchj3LGT2GK6u1BHRQU
+5S5RypfatUWs1rpynKWf3274NNFuJQmReFwrO+EQZk33NxfaXOV2oIKEIBBaD42XcF65paRp701s
+Bpn/9DGy6RmFSCkCBcTDnuizny4lMH3b+qk+j+Afi4vwVkRA7fgIOvBZVQH/RMF3TTbnKDltGQeK
+RSh7fm1cSXl5ZSpaqXEsAYM2SQUOIuDgWL0ATAl7Iv5pjyKm7Ivc9Xkt1Lp//4ags98OAAgfnmVB
+3VOjxtkBi4ZHdUBJtH+7e5zQfXchOQXy/a3oZWFokrLNLMpvO9xWV+398Qg3xeHFQ4HQ8nr6oPVT
+33OaFtMonzFqJ0YuDHuOU7S1ycrh1dnygGcWfAh6fGfLXxAgo1VU4SF1rXXRiIGtX37Cra4BxpCD
+4PsyDUIsPjFU99C9YadG95HzI6gEREE0MMuIJgpEzTtI5hS4u+/Sslrae1adx9WQnEtdhCOi5eC3
+0iUW3JAS2h/11dQ1apb0br8hLQJzPf9ZhkhqPZkS96KFsurScQjYpO0Mp7eAV5xBMevfxhmwVL72
+I9MqANw1/BpCGyLyNMVELzLWIJy53vvYTDe+di+DK7HGwNvCfM1MwzjYIhybgfRJuRgg3y/oaSmj
+NQHvdc9pqEZoCDuLMkjrZzO5DNXENHEwN4qPQarN5L+9eYIsnUv+ZS9DNURl9yy2SB3bEDsQEus5
+3fwKUpRZ+Acue5aSEhgeLWjWvAsu5QiOKuTQaFVy7zfxskFfyKdRXMIpR72Bj6OZk5l3P7Xtush8
+naN9xIImkMB+CcAQEQIbT0jrr1DZFq85d+8fpgARR7O9MOKmHPKaZ+bC2uVqNAIISF4CBUvvlEgZ
+sbWdSUhbjme6sdhx0wCiiMrXLAFQ7Q+fSoEX+yGtJsIy41gLMwIEMvQND7oZcVnyjHiLvMPN0nZ1
+Eqk08dmVCdbovmgqVmykmQESGfaGBd2UuCw4mw/bkuQGaOEyIcaeILDf9iAms9g6CjkkB2JNE7/w
+IRJawJdswWArloyS24RnS2YUzU0uqoJGqWSlAPdGoLbm6lXzL8gjHeYkVIWJBWi5Gdf5LcIlgYNh
+U62z7ugADl+IoMaTozdb9y7tB4kaLyrB59WDfWMbRO0iEBL6MynEyGxtQcOnJygVnYTV7aDMkupq
+LzKGwYGB3wxE3bBzQfJ4qPnImFiQmdSi50KBWLc9/ue8ZLoJB26M38gksl1pzTiMsrVBkjXhSlAR
+C7ch0KNv4jeFZgRcHoxpErUpgcxKAIEYyQG4jrH4nTfjT31WtBhXYm8zcvKgZKpkBqLwgKR55REj
+cA/a+RKxFlr2TcuLYPGpkzaGnI+UwiJY1j8nRdHFJY4SPBUUuSa2WOHoOS/JHalGwURRp5YZNaWa
+fXvGhhWTqvwVEvbtRiAAQ7w8+yTAriIsHjL2l+XEgZH2PFXqgngVQtR6RVC8ZPQRW27QkF/nHHK4
+P4f7ndmo4lk/Oy56ATRHCTgMIKlsDnoYUhAUcYLj0QJCuQSqlm05VcILIjpgszO2LP5eOd2K4UBl
+CDN/s6wxlZ12Nr1TkboVgUCKJCvHHfi/AjFRIwVhRaeqAIrQyePJKflkVyYiQXG7EshKMdalL9jg
+SxcqoMP23CzIipmTUGjxBVn1/ydctp8a/sWeA7UO2VLKDewnVzgaBwMlgQ6XlTjJS6fbYCSW1iOQ
+lkEBVqxBeTCPtkI0mj3sWQ/6wK9TWu2NNrijkteXLadgqA9B5JAuwGevvPwpm/OEMrz+XZ9v5ESw
+xLz+zpZ+hBP2ojyAuMrQTrIU1RBktOQiZnoDONWV3gUhQAekF47VdEhUc8QMx9LwuQ==
+	]]>
+	<![CDATA[
+	DyqS3rIrLw5arLAMnmFSvKuAIfaVwV8hQBQ6Gi96DQrDAoJ/mgo72gfQ5vTgg+iXXbGMmB6u5E2u
+vU1IdiAEGuo3CYBpZMEGiHH9ESN+LDJzspkpeU3XHMUFqyZg+uzOZGdSgVEY4QyGNoluBwyL8iHc
+J4F8PuZdybg2wVl9FpM2k/9iVkklPCDJ/eXE7yT9xAGf+cInfOppEl5thfrGLr2B6ZVCKD6NRse0
+21aqUtDSQf3yhp4lSIMhiq9S9yVR0RhQB7Tl72uDG9SSKxvCW6m11wujH/o6EKExrs5aNCiZ2gj1
+1pJKWkd8v4ncFnJUNMaPFygPXHZUTKh863e2A1l9ZyJ0v7Ao6Y62UgbOkxXcbF+gv797nz2BDg/q
+tIJ90kcJ96YYlJJStEX4Lh8MNYZP8ssvofae4TpRI3UKNGPi8KUyMeOMQAzbnNDCGfMPxOCkCCo7
+gHyFsnkySaXW1RHgyCqxtdDa73J5dLJYESis/4etoi38KEtNRhmESNR38FXfzLHs4I+QFbiI2aNQ
+KiKAfGuIFSEKpF5fmwKktxR/P8dWIpmokGwEVuR5RfCUPuoa8RyyGHHlk6HB6t5ofGMwCBoWqIi3
+dlgjAEia0+LAQY4PxMn8OrXkH5OZR5nL3PLKCsjwRw25ITUTu2HofW5kh19KbGkYyM6y0vgebc62
+TdNKM9qbHe9OZ77Sd0bGiJ8fffJPlTcoPQKXN1pQFK4hPB332JehhzWpfH7VOd485RJDlqrIv2ik
+7cYBByD7kSjDgI+GHmQ7fICb+8L+PikLj0SnkSKt1OFRYVGp4RTPNQvWeW6VRGyt31IbjAJ/27RJ
+TRN0R6JXMZWE+oiwVD9TcVdHXLL/mnyowzEWwbHBMqo9uXYzACMDOpkuVhvqX8AX0jVmITm9hFRW
+cD1vuoiiQwKFGG9jQmP+J/8sNWIJTb3qKRwRycazmwjXRBwzCNl+dSPrU1VfJJEfCSuCtURciqSv
+72S6KOVtbO+IZ1rlc7cY22/typYwiETR7ZvbRlihsaUNwfDXx2uRTLMlHwtEpLBdwp7FSM4scb7Y
+nSYuSVK1LFwqOVfpI8C3MIGIAx7S3XcbTJKC8L6s/z9ZIbAlYawHs1l+fbazmJ3CV7gxF6hSoPR3
++xKIRk1VqQoCvJ4dBL47ocMANuSpAV4mGrEaMfXUvS4jd8Zh/HTfy77/6S4I2lJoH64CtiWE1/NY
+8n/+lMqQKQ1hYxAHttRfJo56dN1Y6j7MVVwIusfiyFR2i1qecyYqs4KJ/InQkaeCCEeXdcwGzLic
+dXIeOYDAItsQqurwZWY5nrSbCbtQxpA3VjUnCmnZNw9sKrtI5eB4nufj7bRDG4y+Wl6OqB3j2aQy
+9kszXY3IX2/PRvaexLZnuw/SGDFZjNqbSAFBHZh7rGsQDoDZ2ntiDsiPetVLBdvRt94vbE+l1cTO
+HzDFyJjM8wajsYrhZNrI+mkInvG6ZWO5Tt5KIRRUDk310mDEwl9Q7PWfWLM2zViLCHbCX75jhtaJ
+TdUrcZqxFXlpK4N+F4wtr2pDoIFK0u391+9B1ut0Fc0Ymp7yCFsXCz1MdlBCEj3t3mjh/KwRjLgA
+zjp7+GB4/BBCz9bPzIPA3HDRCECaMAZIXw5QInuR6n3dfSIayYjf05WSdpZzC2VG38NK6sS7zxct
+m2CP5PgnTvWPPG9AjOJZhRGqfKlCIzodj2a5xDNQHhMNyguujPwCATFJrhPv7IZx0XoThYzRYsYN
+G9YJ8iCrMz1JQnNjn5mVQoRWHRtSFdTrGY3ppXIqQ6xxIpwO2RvvCWq1KqjRzLp41NJ8AfE9DpUw
+27UzcPR7CJuBQDjsligYpc44TctOXt9QYI3lQ0cQjSjCP42RZTbiC0dQBxGLggSxcPgI0u0wBBO6
+eo0RZEtI9rggCmA5MiLM9zXZ2wtvq+ghkXmjVl88o8iqE0x7fjfMInXKhFeoyUHL0j3MuRWQunIR
+XUe/0Qr+g5ENDCVfR69iMyeRLx4evy8JLZbxdW92ducYgm3WPozNBevJ/D6aIG3z9eyUpljFLtq0
+eVASOFI4U7eqS3DKZxQrx+lguZLXq+4BWD5QvxgaMHLAwlGJWC1bgA2MRMHSlCKSfxdZEiFbcHLJ
+kVqQzwjYK0Op9H/Zy0leEaCEmyzWCuVe/Cxx1uJ/XiGsc8tN0LmX2JbT2o7fMo7YfZdjYRKNlz0O
+0AeW3ytfc9t8/UAU223kRz7jBwhe+tRhidp3EdnSWwieNq4iLixdMo65/wrGo0K0wnCKAwMp7+Eb
+Jwr0lpjs5qHwKMdQtLaC2d0N4uBswR2Q2j82Lzj78JKPzT2u8HmKWaS+Z2XrghqbY626VSxkgtgs
+2VshMYjp+lHIbS6DGrlHa4sL60AvN27k0QDLYcdDxveGQg6jHOJbxMWPkGH6i25M18FMFfSkKCD4
+VbDQaSUTp/UXIj8hWiQv2Cnb92X14sgcwzMmMTpsQTH/B4ElV1uF0tGeOgVVMoqQurgzgqQodcva
+fcoMHODyeZLUgx5OFbD8W0r8A9eJQiKPAl/tRSUI0ljWoPZomloEJAdvwKZ4eLrLjwkhlqIXkjsK
+E0gO14kqlWD0K/A988r5G0KoKUXg0GZRsrTyYR/wKL+lY0uDpasgVukIrCXwzTiPzoz7hx5mu5Ja
+iiumOS27AiuLzgsgHNzKOTB4Y1Lj8J2+9iIGaFqr6luO7XBTJr0+bURGXQtQIb3+CeXRHzz3niPk
++RozEifbMBqryXJtIcXralLEMHSKXsaEcuBVx3pas+cvIRQteZKt49hxSO6vS3wf1MgvpMBl5iOv
+JjA87OaRA1V4QBGnSFPpOYokfHcNymoWNVZdU/DAE/mqv11qekowHCyEcQRVF23/zKgkpNm9D2Ju
+QqjW0eAUs4tFAVDl4TIByi/itQfVoU6oQ7mKVrkrm1AY1N4wKPI5T50TkumbA0DIGdQNdA6iLcA7
+J3wIBx/C2wueU+y6r08PZzVILLL3uRUl7WZ+B8bw9c2nS2JOEl+kmv2wu7bAPSIqza3VPXk+OxCz
+pZNy4oAvMM1qzRKfsX3cE8BQLmIOOHeB2jmUEUgSI1PR41A/6SpSi9+a9Fh376lfYFTkEyuMnpRw
+irFSkAm9z2FAYSpliOIMEAZeHcUm0nYjVtkfT9AoHhNRL/SeMvhd9GfGYIsuLS2vOYRBA5GV7GMS
+jHGcWti1zAMayhu2kM4TF0OWAqsHe6jM4QgLd+QJQHmhGf951xoK54SAfJVQKrq3DbGLeFLuxmEc
+sdvbF9IeA2UFlWASe2DFZ4u0yb5EUpQt+Jh/wES9ZutqAHedg6G+4oHaB3LbUZ2sWXKryS9eh9vG
+Hk2ghhZCg8w9x2ZE6tdFR2bDAJbqKQ2dvGZDOkdHeqCBJgv5G4IpDQ/XO/2EZ0trsdpyYNBxMltn
+ntzZ+d2GuWxd0xgt4O7S8zrkIvtm9zWNUOk1ZYCI8XT2EUZOLkUptqu+E721WKSswIbgDXcHBPrl
+wQ6EFTrGXgq7jg3SQ6WRfGSWa7JdodLRoYHiEuYCok6EFg0aMHzQPWc6nh5LBxdYHR+F310pFMOx
+UfBz9mzBoEIsuTTFZWmrndOsz0oj21E8WdK39zZExQ4O7ECTcl83O5jTMuw9A/UaGYSy21UlSKh0
+mlP5B8Q0U9YqRbowUchRtoMh7F9asVQmf7gzDUSXRK99CtKcxFiGQDZGabxtWAecf2BI8H5Vbnmp
+np7VjoUJExYZEoaeLlh1YOVB6/cnwO31Spi4AsMIJdaapbUzwTx6x9rB8PwCjGjaDgT5g4pimBI/
+X9TWgpDN+cK8Z2AcB9ZsD6g4s7P9W2+JOTt3WcLroOGLyUixOBBZTfyscszWz39bhSNqiJg0Y1Sh
+CqiwDSmjhXa2Z4oO2phR7LqaMRVAvDqerrVAh52BrbkAuz/ECNViwjM/EQPpWmxbcFIgpcLIgl7Z
+AMSgbAR9IitO2PpgM4sS2m4WNdz6R1bdh2qSnzF+3B9z71safK7DNoYOMQz0Mp33PXeMEM7B5Fmy
+QeWVDCGSk7oUOcpfO9eD1xxA0nstZMRj/9vvIgnmeFYk9lRi9EuS/fenfAsngBCxcPMp4ks00rm2
+2TjEHjf2SWw4KcTFESQyInQ6W+2/OjCS/vmFYvU4Ya2KQyMqICLp+gFLxXiFati/UiswC866BsfD
+GttLdsfTZHX81VcWxUEqjhsQzyfcmp4/GbYMf2x3yiPDiPSJBNpoLCnXngQj7sOIG1tfrxhlmtE9
+/hIg5e8OTiSvUhFiGhJZ/WTo+noCODXtiN77LBLectt+7NkwzN8QBCbvUnPza6XNJ/dZlNav2XR7
+vKs5+/QdKsEPgsNrFLHAl0ZX1bzZoWv7vPUlu/8Q1qGMmIItnjIakeWgkcseIMii42YL0P076y7s
+DASShlm5/XN281yW7eQeV2b62f6v0/lJUIltzgOL5eQI+26KArJnQxdAgHHVpRbQPpSB73kf8AOb
+Kmuj4uJXx6FoT6Ip2X+BcqcLaOPEDRnu5KGYS7RqIK8nPAUuFuBT504NzDIy3z0SEMW6xgG0b1Ba
+5mKfsnte97ffo94ibIGVWyIdRG23voVcUG9dRB2PTrgQI6ZZJkFY43n1TB+meybxk5iz6ftq8dJU
+v2QR7P/i/Oa2xAfJNuVw9uRYxJZBaiQ+yv+8FktA1mkryar9byzztx649J51bObjFCAw20eabthK
+gpQsGo/g8Kiup/AndjwIDU5aLKEfRIZpfdwROMJeZ0R+aVo9DMzqTbiITTej7upyortB4njg0H8s
+6IKxb7GZTqKbjht94HUY/H3iwHCCgGbGDYTnjV0l6bHGU5kkJokneI7ZrEUgMCo6AP2Qk+DugVyP
+HxI9rsO/lIu9FI8gj/rVOmOE2fGR1GKZy2AsDUkiRroAcG1oGTBYBbPSefqcywuRfg3qVlU9foVl
+EauFZ4nnk1MmiUS9xFegjxxncAKP8wwXvl5WkDTxeQ6J1lH1FXRZgBaJwJIkHipqmY3zGR4J4/a/
+Mm0kRPwU1lwS/QfPc6rXvy0Ehr+oS7/AsDyFlVPEHXrQg5TeSVjkt/03FxRsTxP7nuYzSlFkUF2C
+X/KSYQ7ecc172MsNIpxGcBMadfi3J6gA0iS1YILvXN1WIIXckPobbvq8yxCCSNZ3M9krByrL13LB
+In2YfCrtMSr5TZVfDzAJaq6JNgh1c9JTnC2VmbmmAwDlKU8pMZXa2FWWKLigMcGZl+3yqxulGYJw
+0MhzE/q/TdJzgi6DVtQ7ikZLcxslxWvj18M7cjwJnPJQihg+DG6yAurKQEoEgkiB6PiC/O3KKTf7
+DRwuk9DzENGlkr4UnfWOLohOOCVqIoLxRZVgrGbiCN0+KAAJZcG4uaL1lQfK8OLWoi6IiQs/vBI+
+Iu3wzfB1r/MUKKLQSPBPryXKktWe7atAYCDFUPOeqQvw/8a71b8nCGGofWtGi2pi2w==
+	]]>
+	<![CDATA[
+	OsCSTieF4s1g1bvdpBAYlGhkBOEQ2LCcQaAl0NpsOjpB6RX8aiWL3ZQIuhpuvYL/hLnAlDLcBrhT
+uL/3eCWz4VdQkISbSO/BreumhYps8Zj8oUS6lrvCItNbWKyu0ATJF2eZkTxxx4c//yVn/DOc2orw
+zqUCR89jJtMQtjiwkdTjjGXZndSfchr9QMRyRjJUpnYUBN9cREgVlOu19EmFMVMNxKep1dSyKFFO
+4PGMmOzlcChK69+PWYcOlheQ5EX/F4AMoq8VYQoIZE+SzXuVZz0XzALJpZQ2AW11IBKTwqKGoUoB
+RU79kqfTcc7UlfQC+G4tASI4W9ujecKQCgtlJbs+EszX+lFwkoaiNI/vB8DXLh58pisPXF2i+BTu
+tCGSXDh77AUkMp0YMgl9EMGjkh1Z9lOsIyvqlW/tkL/ul4CEw7J92RyaM1ez/Hu6tOs+4vaVE1Ht
+OkoREARqnTL+jptXRmhpU8+WbHaXsn2IeQbxHsBLIHGZQUjgBawAhwNh1frOh3Mio/syX68gPNy6
+LmkKgs/IlyBO3FczzhhCRYdJj0XEg5uI6QF15ocmx6SbdFGpuKK2kzo74wUbkQfpSxP5bG50JjBq
+sRjGMWWBCCisDPkrfQ2CniLFasR1LKZXW0NasRpzbnhrkudijG6gvA6YmcgStAksrPKo9LPPg3Pn
+rwUr+4jNXtG5aeJ3/v1xwLJG0oqBBePaE+wKNqdRlOfUmaC3hvLEj0hvVXX3TbGvV199VDmoYsFO
+HU0smdiyONoimkRjvjAtQxtCT0vY7I2bcB+jBBz/QepEqh8pFJTd0OkW1VuGb1SILwIYsLltWoCG
+tostCrMEbDswLMzh4go/j6MamJY22fYyWsIEsemlvAFRZWE4QvjugtKlUT9e1u19YkwHpDCXTqtD
+e6JisVORLaklpBHMHPIMIhacIaI3JHzeV1VBHfXRsOvD5lNq1ZGkJC0Ehg0Da2zSgl4tJchgh0Nt
+0pmpmz+7v5ITG+mIWNF4WAiRRMtIj+Wi7Co5sPN+0BRW78uNEaYNUR0G50t/HOMSS5gjB45lsVD0
+bRfqQbmHPFuiVgVaqhTfTqmZrgher2Kmmh+51J/IEYXIg3/MGKgmnJ7kTGKsPNqGclUBYgzbWlx7
+xMZ40vGuqSx1ihMscB/awA/wZdQyKBIm2xyg1K2drJGdbeYyJuRhhE7sKMKslPCocjD3Vw2+PEtN
+gpPlx3iaAvuvl+nUW6hZO++YJxjPJJpiCi/NrVI8Y/btihlNhX2LvuJQhKvxEDkl5ZBJqZEQIg02
+OsGEkuzgr3XGe+ry/Hw7iFFf+sCxVI2ErpQOAeqA2BtUkJStcwAAADWsmxYwrpnWY/9bAQZwgaS/
+d3yiN8rbLb8JQEbNu2YBjK1jpDWwv+Ud1VgfIFvwTZQ8z3q/RQvqhuMrND1kc1t/m+c2GW0iaWVU
+NysDvwFrAdwBXxiGF3ueB4JgKpUKhUIkEun1eo1Go3svCoW63W4oFEokEr1er9frJRKJMMZhGLpc
+rlAoRCKRVCoVxlilUoEgiDG+945GIxQKJRKJwjD8vg9jjDH2PA8EAplMJpIkQ6GQ53mpVApjHIbh
+jSTJEMdxXddxHGcymUaj0Q0EAqVSqdFoxHFc13Xd930YY47jMMZd14lEotvpdPI8j7v34q7rTqfT
+DUvQo8UCZfxQ8uPGCEWGuNQwwADsgTBYIAsMQXEFroj0AFfgqgX6AGO0whiscaXF0gpbC4why6oD
+7FXQA6yRY4dLS5ETXG4wgL0cPcAViMCQEZAsgACMdQAMNNLyA4kRGOzFSAsJGIBBiphQAgYwGAU7
+LNAA3AFBBBlYAIO93IDBlLwUSWIEBntJ4vLygsFk2DgAe0lclLz82CGDNbLG1RiOq3EcNxjHcTWO
+PMZxhDGO4ziyjOM4huOoYzWKLatxFFvGcVxhWYUjuLIKW+MosogiK7QhsqzEDVgtsSWKYmtsiTxa
+Io+VUGyJYkscxVYoiqPYitESxVDEXsvYgiGKMUQW0UYorkIboTiyRDEUYYRiKIrYswGurEJRZLEC
+Z7XZwppu+3bXps3vrk+afzYFdZ4nKbVQaTrtknq73lW7jA6fHrz8tZrrdFu+8yDS23/f97x9NsPp
+2e11Y9vP80Sz+cv3fPpsB5DvqmUz9a+TJAmCYMy82qyx95h5/0kyj91aEAi0a8y8eVddYzqdZpRN
+v93I85P3vTf/aWlG+q0uv8r+M7u9Ku3jVr+fNZs2tmNOL2/Pu77LaJXEGMdOe7vdyLzr4x2wtdnC
+/LEZ1zvr7ad/lam5edv89fs+2Xn129kMl4Qqb7c25nRN89j2mOdsttCeN2beHUD6aWhS29/q9/yl
+Ukl23pjnspRaSOax/ig01ub3s5rupekyj0vTet6e3283MvYO6pf9h6bLL1Nz/0nlu/uu5a5RaGz5
+Vr/r1+d9+x5zerNaqdw1513N6uXb2RTU930gEKjrOu5dv9dqLq2/lqbfbqTL5cqm612r+Snfv+rt
+2qwl7Z5OJ11j0qbnr/ld75rfymgBNH89u71K2cxHjzLCkwD+UERRRAIJGABAiRJR8qZMhkmLAVS8
+j06AQZf3F2HEeePGjAIoTMjs9prNcKYTUAyBJElLrR5KaSjSIUnoEZgnNrygomKK4AJ6BGZPIUKK
+Aw/EGIByECTvZ8KJKSEY8dHpdEwnCgvCMZ1WK1RICfQIzKdOUQUSU1SBhJMZlqxYAYBb+vLBeXKD
+J+/65AbPywfHLaWUYo7e0EGPwNAjMKbHPKfkBCE+/DBjYVmxzNjE8MQTwxNPjBkbFipUgx8UhgxK
+Z0moWgygwuFwVFpQGBY6MCx0VASglFLv0++fSzkAwqkBB08NOHg4AML53E+M6Z8GaGxkgOKRAYqn
+ARob24IAmkILnRRa6LQgQL93HgzhcB3WX3NdODhNtEd7XDg4m42M9uX/23m0yEunyEun87TpIBDo
+izH9hWqzhIlnCRPPC9XmU6uBHA7FoYPjROZxIvPg0MHhcPSMpX1AHw0iQgeKFA8UKZ4gInRAX6lU
+qjG5eLFZAQbPCjB4XLzY7M9mQ2nk4DQpPU1KD40cnM2mch79gAjHhhw8NuTg+YAIh/MqCbrYqOBC
+RwUXOqCLDQ1N6t7rM2psljDxzKix2dfmTbt51xlrS9Oj0Nist+c3axkcx3WjVCr1er1UKtX3fRhj
+EonEcZze593W9Xt+r7kxWkot5P85b9d1nud5IBDo+z6RSAQCgUQiUalUIkmyNF0/mGs10DHGrv08
+Txrnz51r0/O7fo/p8+o/ydhZSZK0/6T3bLOFjzHedctmPjLa51a/jPbVaq5KszKPabbcVZtus+m7
+5h68f9JM1S/z2J5V33tl/yl3zaeXZ63VwNhpy9e5B89l5y1Nz181zWV0+MxqJau3v95ueuxpdjs5
+u730vyZrrnZt5hkPothfGpqUfi9jNNd17PzIZuqW0b7ybT6vNj82Wxjb73l2e2UqEn0wxKCCKLIC
+QFFXDvr56K80v21+AHkpscQPQUigCqyyr6wsUPMhCg8QKIuT1aXSqIkTFqSg4ggjKFAbE9CLrUql
+qjGn1+l0hhDpgIkmgnBBQhmAQTcbtzIaCIEQAocNWuhJgNkUlDar1tZmCwMIYAUNT1zAUQHlOr39
+ba0eEpAAaeKJIYQkoS2RcjiUUm2zhSaTqeu601ktFRG278CFrmBRq7lM+9Y+aQOKx6jE+AR1xiSi
+ApAgIQHTE8BBOBwOCUWnUlVSbMcNFIABGjIcLGAUFEQsJFQ4NEAgEFAcHIgYDJHCgEEAKAiLASKh
+SDQaDwrLDwCAjMNRtSkB7TfaQEwCC4E4OdhffDCXCSFGn3oy+5Z8ITGl6/CX9F+Vt7iKu+rP/Uer
+AU6Fe+KkDyGyOZIzBF/JJfCFPKduLDgXidGt1XMiu1HjiufKnYX2v/gU8fCLIPWfG/xBRuw86Xrd
+xZsaVKbe0jvtjbC8TCD4VWTR3tp0MLCGRa1q7QJm4U48L6ZmSGvAVNzu2DhKmNXJRLZpkmorSsI6
+d8Nd1OCkWerbkTQjjUl/v2Kn3A2lHrKCTo/KzGm/Ezw8mX8RBmy+B52JntWh0apJOK1n5kFsbSWn
+SYwseGXImJMKRg1cejWjm3pCAdzr+GCxlNufQ0B2AxR+fAfTXRerWJH/ER0mPVYuWkCrk73aBi4k
+xut8DvMBsMkmpobNqeuWbLY127a86s9UpkWwzVjaaQcdcYfZJl0Nx1nWfWFRq0aH2o3Qb5S5L3nJ
+qXuOD/UalinCbtpUxpefAliXziA53itzqmLktzoaFhyV5+XXuwBGnPM5P3BuHq3alIIudC5zisPv
+5kzhTFCyoa7IqVVKH62MgIfSha+dw5yRx5Kh+lpHFzfnC6BMfN/kNTWv7efMiJNSAFh4mpivLrnK
+0oneHzVv2qoSDkDRi++HfHXEawEudfhjRhDXhrOqY2oFopjMdh8daXEPX6vD+uHAmRZGHp2tDRwG
+zTnKbY6HzGmssQYgHy59ZtuhMPNW50AzAuLEkS5haCd14K2bTZLGYF6GDzRawgvz/mf4oURC9BQS
+O1ZjCs3XmoIhP0VO4Ql/bHrTRVYB5xlfkOug3jDMChSBIHo8mdJS4HjjCYCY4++ruX5WhkNAhPdj
+HE9gHDAcXg7nfoA/ryWIOeMBH5A+IMoQ8dObppIsPaM2Yivp/I7E4gFVRK3ctXlZtd+v4MmxwXtv
+pWHSsVFgJtqB3IpIbZzihENhRczBWolTvn2E+P/lY0QMQRzt6iaEMoDAFgZefwgKZzXtlHDhigq9
+Z/1JwOu6kJpYjIRTPazncOAVEkhXjEZVSVaS8h5MRCUfHOZrV/6QBHbygi6YQdk7slnxj4oM+/uI
+eaogjP5wrUWCr0qEMwHWOf6CofzAAR4WotNddq2wI1ahTq4K8QlY77PB8VESzuyZRRiZjbX3GRse
+9g7kGOKP3Y19Sffa+g3eEfuNSaeFqmkBhZn4JO5LVfNQwYO1eprlPjPz22dBk/MHkXefe2UDvZFK
+RYI6REBLSpW4qwl000DudWcuohgRnt5wrhwQWoR8v9QxZtiRJe5rMemfJ6nG0IolAAQ00+IfHKo5
+5f2uc37Pf8E6P3KVgxXyEk03RUrzTcJJeb+sQSPTura4bfHGePJ2nyJekKqkB8czzizzLPCDYJgq
+TgdzATN8axGwg1Iz3YwNztHUqKXTurLuPqPX9lLL/Tkv6c0uRTMG7xGRCXjsuRLHHHiH6MzGJg+h
++K5BQKYk6RsEeeRBEBx6o4vawWRG03sCWV35YBMxMPqltG4PbClsiSV/Xeh1pozNdwmru/Qg+jvd
+f6kDf1xdW0ojLY5AcFsMA1S9aNr/Ri5c3GGciTWKSNoMGbGb2sYJkV/phfyWUfoTSoZs7AHS05oD
+SacaaQTZ4SqS5usrC0NkNpaZzswU5vYpcVjLyFEjhtqa/t80JalH+FlexgFeHZ5EBg==
+	]]>
+	<![CDATA[
+	nOu+Yk5X5i0QEzeZqlFTBRUEuTpYvNIG8oN6+CRUmIph0DrUjeNDtQyV+YTh6B8jZI4RCRgUjeRN
+W1TDyX22O9JQcZw6+eQVOgYOjuNr9YlpODEH3lL1dgl2TZ77sPHcVRTiIl6Wnd3XzRkSs91y8lIT
+GcosxnlDrlG1CBPrMnzbhqZhrmkQZjizrIOVINvRxL11sVal/4oZ0Vd4omtOemuNqMymFqukt4/R
+d8GflB2Y9qzUDk73SHsEGPO7d9tcpvy/ZEzUilk1ThI3ORXswXanSeUuTr8yZMBH08uXNYKQm5YG
+OZHiN7oclTg3GWHhX5qE0yTqRTjuF9LozethqanyjWmNTCRHVMdMLiyupClPnBDhQBPOT+DyKzoN
+NkewSbMPsPYP3EZvIyy/KOgpRUHA6V00Pas4VFACHEV/0yhfsprqeusRvcmjcerXmAUgAPSbcDqq
+MJoagcEsvSJC26nHiOyRHCmuqjx/5c5uuDXgAzd9p4a5Q5cDA2f+ZxkK7jGAH0F/aL/FUte3sHHW
+N+bWgRdqpuPPreFxBC+Sfh/oVdjq6EhIC9EzQylPwmafYpHdCqtCCrCAccBaewMAUF/qAAQv9dqc
+2l+UE8QA6wmI5cTs/LOSZFHY8dZ3aVawe+RAfeeCQW3liRkVjnGxtm+pLnqZgBUstuocEhguqBsC
+0gQLmqYJYxDoTeTU3K1Dc6wdox97KEvhh3dUKnasaGhzshoUFqdxOE6ydsqc8GaKWd9V453HHQ3y
+Mex2xKLG6ECDvvveNyDR6Eb8z7HPJmc8wHceah6BE8VyuGLsKm5z52+0qPA+ERnwrxIbjp7B0/0i
+mqnRJtOyJcW4F3AAMVxdhUHO3zlkR3AnRg53iU0H5uq43WI9HRf5HLo0CQovY/8i30hVMaMSjhXB
+K1o1bOB8epA0Wh4Ses0YbzCJjzbr5eHZ61vVqWv7sOC6dFq94lOtYlD9GbKCrXD9eqKjvGRjjRL0
+4DcVz75bHzqg116yRAY3e/8gZx6BvW41C5Kxg7uMVI+rZ4WZEUYOldk8MonfpWQQ1RP3EgbDamBJ
+8GflBwX8oAYDeo2S8c5bqinmhK7D1mhQXl50WWYCPGKtEonNnBnxwNQ4rt4ncTVRjvMUQgnZxBKJ
+LzKoJ2KuCwSfb1tmNUQ+WbtBpk+5mkP+cHzQ4EPmwKPycQZIfiRspfvnE7wF+3+Y3yqJnH/Akh6Z
+Wlht2M061CGIT1SkNUxFFBxHPjgAFnFXu6Vp1YxDeCM7YhKHhr2fA9ME66hbBHPGBkMdA1hW9ykU
+OsYLYZJVc7gj2DFCCYAXJnSxaRISIk5tKeEHNGBpMFJexs7DT6GmqYhmn1HdNgf/YZ4uZmuvSKSM
+HtQG1SJoS2O+hOPfU7Mz7onqKmiVcwBnztOm+GU08UcATtQiooqUtg6ujjbOqlB4juDRZRJg2ld7
+ftbUZwrzLKkS4oV7xCARaGHLiIJCDDNF8xVpHJszrLLwc2KSnY9pcfHimK7MM6Lmi0tJcCY21W40
+wgqyc2mIjHEA/9i8cw6b/NW05/HFRB6yKV1RAaheEkdZVUq8ecGuk2Mcg5WYgwohUjAC0D83mXlo
+AqN+etymo9CH4CPG3dvLyRTs92hBjeGEesNz7aAwvs9ZUH3PGDFpLZi8jSyjYY2fjVN1FBlqb5MO
+98AkXq37vJuzHkd3p2Kw9PyH6jBHoCmHDsvLoIUrWRnfD1BS3Dj1wqFKpTaNzXmaXIPEvbQI0pzO
+q7zmWRZsi2j/QczZ+hdxxhjOuB11Q8ghyFjDgMFJ8HJhd6ojxBHckBiMIti3qTPEoEbRq+vnRvG9
+r3M059VQ2UAhfCsTy05e7B0NG+b8JsCUzmwHh2X0UObGQMWjLmUdEfgVXBVsGlJizi14nKGnFpyL
+hmUX6ZZSu6TmHTDqcgreqnaOBAPHbLyf0NY/6DsOTS8qHhhmgiKvXeQY/gZHbS//gscZiSQDeWp5
+UDhd/Yp7HkIjS/svTUcYFRVOjVCYI6wjnlrOMawe2tAkgxBw2qODetNRm6MIhPYHPDmLwJxH3CdT
+StphbKHFzucMsxlcGxmEexlSlieg5nRLU3nAZDi9LRnREk/dIx1OwP3UA+zMud/U/2QNwvPCACXt
+Tz4PAEn63f+cEqHNwh7WA+CiRrHTzC9aTP1BZw6TTiM2G1J+aAfj1FNtVDwe9V1C5ohPuMJiI8dn
+QQRD1+h8YMaiSxyV5zmwaTgl1tHDx49uscvniNwhpVnhq7NKPGBTZresOQ1EOcNce8YZxIVzrLM/
+dav/ZY588I0CQTR8SHpMVVfnYPG2HPEirUYExStHhQ6cGrbivqBqAjBuVsaEgEuQWxsfAYmcwoBr
+F3sIAvFi4xThKJZiNLvlxUe8W3ycs0fwWo803+3BW+2I3ekhJMDSJVM8Gw3Wyy+NQ5pjmXT6WaCS
+H10a7Kvqtn0kfvbyYDw4AmC/GKMxFuxcIMc4pp1IMqeS3WVp6iLS6VyM8Dha4/1LokzCmdRQ+aOJ
+WBFe6LsOpUTPKc1pgugugTPimfHYmJHmRHXsTbTCWSEKP7qSeGUYlgFwFB5SFD96RplvUIcskkxq
+WZZfgAEfFZtflL25/ROb82ffIYvlcm2QtikYLPhgkCS4vl7MCAhgjCYz43TinJWt4OEx4wPx528o
+kwdpu2ZQDhPeoukl3MVX3ffSfcH1yuSMbTWJf2hELRxKGU54LEiyNXjmXEpZg6jl5Jiw264/9OkG
+Tf5kKQuqffSKOjJoYutysmcs6zmbDw/OOPEjZlmOVy3spU06ngPBaXTNLwZ7o63oo8kV/dvTFBRI
+proMwmohE74IT8Fw7ijmLmBq8JC+B7Y5aT7gh12pfLs9Th1W4bfW8OWj34fe0Z5eVSRH4/At5uYO
+ZQSxtBN/GGDD1RoTURfeu+V93E5AM1qoqF7+9Jx2UXxuw7xh3vhzmq/4zvgwscUAWTUz3cE59O4B
+LMH8kdA8otv6sO8bVkCUkGd5KTPfORZ7OB7Zex0jTYZO4yXd7ErTYRtohxQHFpZf5vDJGwcO6nBK
+elxhOsEcxTYcFiqj9P2j/4RCD2Y4kBQaidkQ9CsvqXaG8spmVKZkYhxuYdj4nMCbCUv0xiApHK3F
+g8/X03uQDMco1HRFigyC1GIEDEftTJHjy5E8hybipw4Pv1Xqv9hnt90d9YluTFyyJVLmUoTwtD1B
+GWeybpw49mdaj81IYAvwZH8Gx6rqGhF13seRIpXrSY3VGYjvkow/uS/0xjyKmQiajy2cGOo/q3UI
+XOOAmayCzRI/jfuW5ChYn2xFZX+AECLUkEqGgKIb9RLNqJtypAK3dBA+hcZH3qsC4/K16PpEXbYI
+FqZ/IBkbzYAY67jrZkMRf+yqz1lG/C1qY2GvBsmigKD5hd1YZeozF3kB3gZKhw9MXguJrv1WVPTz
+JTkihH7G7MH+wc61XBJai66d1KrhnT0y++XaC462U2yJCPIYFx5n1ojBvTuHneD9VgD3vo3U/Bpj
+Mgrh5Wh7bSUkb7oggAeMRtGpRqQI7znzNitDU4+MYad1+gSfs0lbIHwsIplLK9UQsg+SyAGMLuKN
+UELNxrEIgmOlyfzaHIgozfuqC1VHwEqnOgn0TK+yoXhP0W6VXoQ7bWVW4w3pfXcLAiyTMEfm1/8o
+JxwhYDNZQVoZLDm0bmZZBdyONK6uPAt366PeK+SkiGunoTPir5jguGagj0PR+HBRd3B8rqlbQssM
+XxVLRvRxtYw1FpGFt7KYi8ImD2dKk4kYF5sTfRwEyTB47VxRceLEQRQfQhdUZtXtHk4Rac6siXTp
+5fPK4q/eGVaLSQo8rsqhK71dkmwQ+ywDhRqPndiHOFTg1KAI9PQtyWWEtpN+f250hsMoOdnB+n6I
+52chu/Bh29CAQ1lDPF94IyEoy5PzytTc9JPGGh1RKrmlDABtYSkvbA3mFqVOCTgNM0KiDIDzz4DD
+n06rKxi0JX/6SZfKFAaE2dr0GKhPEahjKqPWFUBcFXhmZAk3ppfHurIs44TTkdmkhVoyk0HDtzP2
+yXCsueT3LLkMOLnjMy14ljUpC633XbFxphn60ltkbEwv8KoiiQCGKCtzxe3hJ9/v6eFwN7m/9W17
+jtSdFEuKSS/QUFYrelOlaQwOnNmTSeVk5ELVujRUhQgHUeE3IZxBlyRQR5vcrNPpJE8fg9Y5ER6D
+DXjhhpVh1/OS5fRkRTiIYkO6NHEPdkhdQzQmUFMl5UdVIYsETGwG63kGxlBjDLYqaYKNq6VkF6/1
+NJd5Hc0iaxPSjPhEPl4uOyAszOfkAcfc9a+dNAkXV810OQdRt5hvLDhHNCpT3OpjjrzRwDgXxdXl
+OednKmKifhQgGsh4PShWxR2BMGiClPZRBC59Aie0WtaT0+7GGCBP5v3EE+zMkL8o6zgdEuQIWnCc
+OZVdIOaS1XqyYo0KucqAb+lXKOn4RXlLxKJAB5qWEo7ehWUSkC5XB7HC9clMaDTKcFHJmyU+2W3P
+oaMUOR2ra6/q3ZgTAHsZHEsS9fpIIXttCTk4B41vvTTpMPwzByskOlI02UHwBAtScnAy9+bMgWp6
+fsulM2Q6ecXlRbTuIYoSjq4KMHrw8UDT54cXXkUmHeCXlmeSCBHu/Qxe0xcVuxVNg6na8IGmccxZ
+MkTU/Q2YdxaDgVsYr0CghOaMTTCWu2aIsIS6TefDN8pKsoau1p+CnJtcmD6QHH1OI5zQM5qY6khE
+BJLM5tEMxxDKziqwMBjooBzSiDK2y2Tl9VFPfeuUrD9E6XJEeGEa0HRHxsg1kwalAeDsw4ydmg2l
+8y+ykiCBMJHQjoCrBnkN/pAK5yA4GAtwpf6+/Bd0EI/JFaTddNbjm4XwxXcD+awLdyvj4g5P3Hyk
+ioSC8CQ/oDpNO8KKz4bAIA6Afwmx+NKpPswZEc4aBGmfpa5AiYvguB9wroFahwIb11O0ODuAgrny
+DAIKzWmOMMfM9eEQFQM6n7DxgqjPwwzTRqV3wMPt5Vl6B2ECjKUim8W5sl414/ZTdkFo9K3ZLFZd
+NZLToWLOoAAr1hktTFm3xzUo5rSNRkaYQRI4hRCs5mj3C45lMofn2jqvifBMmmDWZHTRabTMoazF
+2QlR+UTO0DfJ8iGiHiyzaitCBiLGLWFm2IoHAgtk5njAgCgDs7XwaNCPGY1yZgh2kYv5qK7Q0uyT
+1J4q4ej9BGij7tpklqIFyB7AQVfeiDn+dTuo/mskzZatgo0heVo0Krd0lFUyWbjG5CCBph120sqC
+bjAoK7ZUAZgs4kGgD4LvA8aCPLxrC3bYnChNhoUP8SXCksFhGGvMX+w/kPijxibjRt10NJkQbT/m
+yUnOmX8uzl/2gmNsuZ2ba4f3bU5UoeGPCHnEjpCl7K2tCWVh+lZNdJ4iPOcWAHoSeGq4o752+Noa
+3sDYl86ZS0kiBQoXDaJSLgjOX4NjVqtKEjE6yi2rBjk2fcAJbNwlS8Nrj5hcIsq/9A==
+	]]>
+	<![CDATA[
+	aoQO20v33ghxkuGQEjH4kYImzSSsg1MXeXyPdfBuPCaf0osR4JeZGL7lkZ/JDI5CWneNHp/VsXHG
+Scu9cWEpLK9bY/99WZIatK4Z9TTVi653wUw/8HmaqcVHQfK3XVZFa94oCfevhayXRt4O4YY4Ce8h
+ZeJMz6j4DoOxh+dxM33jdp4V403aYLOD18Hluz7zhLS8AeL5ogYfhr4Fde5dhUkskpjqwD6QSRet
+HBGIdr2BpQP+QOh7H1HjRsm5IpNYy8BGSC+P/OKbZfXP4jokigVsQwajzYK8S1uj2+DsNR81TbsS
+i5A9JnWkTmKoHiVClwOspeYTxKxnB7P5Kif3fmZM7/Ihm5RSup8ZW75m2yc65+oPqLlcPhzO/4gn
+iv1LZ5zSO8ReKKK1WgVUwphKUdnEAPSFxNA7EhQw6WnLIaLTpQOwqc4nAXdyjwkcWQWPlamD0ENK
+f0geeN7Qidibngt+1CvbIUilY4LHMUcy4GQtxEEZnDvHD33lukSey6GLwVG4ETLEQIAFDvvLq3Uk
+AdxdJD4sEu5iPFXRFioe2jZ5+r0XJRQO/KcqgtKjrVIKtQOsBT1lJFsCrh3l2SQDCC3opp/zVDXt
+fDG2VrhUO7Z+iwXHJkeU6KedggbQCAYgX/tn1dEJhmKN2dKt4GnkLrBkG0uZDZoVILMaSNwUC7oC
+CzKA/3BMs8b3NFoFLENzo4bfrJ4cvxRMl1hjV7Uss+NsvY3ra4++CqnqSbL5osBWeMA6/SWY7KiG
+XoOLdzWo6o0HbN78BKXrTjn+nqz20olEJ0YqgljJVdW1RZwR6r/1/KmpVWBV/ErQTn5JsjK4HM6X
++A1rP9dF+pwAATpqbJQN/hSgoosRpZT9QtQ5zApheFi5oFROXrCJ9OBFMbJ1wZQ0aliVmeP/fiVt
+co4fuepBVM2oDFtYYOrikWaHDn137HFHybBOKDwrztENW60s6qHaes00ZUjgnr7LTfMG8Evp/Sgf
+2LUkl0IVSEUxoKGKhVu7n13bEeEofGtHWQpNHb+c8KgTmB/s7hLUCFRRdRb7cuu+yhmytmn2cgBw
+1ApCnY3PdF42Qj0bEIyhI/J0nFAQ2gCFyxK2cUx6F9VHNN1tb9UKjgbPuk/57TwROJJhsXKXOw4m
+Qus7GNraxjMtWonfCxxirC/qrABmk1GlJSVLgbxWk8hLKoKukXSMl7DUvCSBB8x8pAfYHL1IshCk
+Mo419+pTZxBA2sO+4hTiETK4yvuW7SLGP56LXfoBSq62XUHaforVIEhDmGqM6X2DStyie22kreXa
+rebsenhLEg3Y2LxswyUnBFb0OpjnLlb+lY48miudrCbKGj4x6qq/JV5tZg99Pk9HCG4H5A1+zgsp
+c4nVwydEuhQtvCuJlpHg6WeiFG3f13Jk4WEZlYwM5NZGuVK1pYC701uE84bEfCFzT+199AamOMY7
+W9h9ThWnzvXlkzB80E8JLk67mSdMhRx2lxSC+5tA4VGaIhaFrM7v2Wfkuz5tLVKDr6QAX1hhagvj
+k2XDBXLELILIo4rBpesDR0AjfwB10DEeKpwvQJqhhgLFAx/m7AVw7xCIU9lGMyDjATDkVzxupcjK
+BK9gwLZLUtjodH8cAqEtjawlQDKOs98u2UN++ejitr030AKMdoUonK2If8Zrli/T0sVy1PQYGmE4
+dHcspnWr1goBCVC3YmaNdGYNmgpVmmdAwQplWEQj3ozLlfKhycjGl2oHYDhqQVbMuYVJNo9+EnmZ
+v/URzVsup+9lMvYh096U2i1IpPMhARhDSch3b7g3d80+iJZJISdsxwro6xkZW91nVUoGz/tG8sF1
+yG4d4k3FD2EoZa3LSoVELlVhTT3WIFl69tQX1qOg8koMz6e7Tp4EdPgcMWKuo4p7dDB134Fz43zQ
+OigRGyA011XzIFRLvRRtjJST7uoa9TxaQmh2TSKRAv4yjG8fcgV1VAJatDVVShAwLicd3VVln4k2
+rcEr45FjD9gRzEzXDX5kksOq8xFuytL8g9xEqZ/ce8/2N7UQdMPhjD6rTFLKlOQEkehJFaHksRsE
+1bG/bdsBWgdCBSgEVRWCEksNqGw8mJOHIUx7TnMMuYBBVVVUuLRghRAMKiKe9ClSGWBQh9HEgaUt
+R8jQ8eLJlDFFtkwxh4464nBACyvaaGFFETODigJGlI7MLGlRtRxxgBSAAKAJDDpPKiRw4CEBDR0M
+WaHpg6SahAsZoDBncEgcMKe2oKWJOZqMyMCIEHsg8oYWQOq0QASFWCNQrdUKBloogaiqKqOTBUsj
+NIlTayJW9hCq1oiwxZ2mWvOQgUQMIQhVVWWlzxYLyBmqghiBSAqm6kYUaP6IARvjYHCxM7QElxfW
+DpU/cpDI4sYEUhwABVFwWVJVlQglXHuGliypKiFpBBdeJFFDB0MgmMCHEmP4wcRQ0wCuO0UVGRkg
+oaFACZRqrX66WDjg4CsO8EYJg6qqKiQDkFGKmFRRBZMXjAbd8MMZO9UDHKohRkz0ISJyUg2iApIl
+KCDAh08ZoqqqGFC3qJQsVRRUVcVOFBFipcpgCUlViali5KiqqlJBUA1BVUWgiUpC1UUtg0WVDTIy
+qAkftSbVyQKKpiQeqJKgKbqjiqDEHHcgoKqWagaKPJAkBR2UqGZMqaoiCeDD5gIxSWPU8CBgqqpi
+8kYIFRc2WERRBCjNc3OGaYQO6hNt/NFxal3BDyYhiIowuYnjDjB4apVTpSFIG3XQMWrAnypCIHBI
+EEceb3jgpk4UnOCNOvKkAcaHOINUa+ixR4wmS4yxJOSBPH+8cKIEURh7mNxsgIQQIEBPjHBT6xZ7
+3gCgCVCeIlUCSFV1gTz8aFBVVZWnDhJ8wAcjcezRQh0gOJJACky1VjSqxPFFlj4qDnewGUAUTVQG
+DfHBgscjU4F5ABOUGwDBQA0B5JQACCAWLBGoVhpCiMOOKlmEYVS/WIMkThwLBBmiDxGY9DhBzSFq
+iqqqoqMiIwBXUJHEAk9aJWeJuqUAdVBwApFqBppDlCTx4ZNEVERPCKghJ1o01aqFk2rIkS612lBV
+RpSqCyOIYNQpKiM4OIIWUggdYiJIjAqqqrpCyhUqmKhgooMeO1VVVQmowmCeQ+WKCDbo0WODkHWE
+mi4gCD3ZAY9aAWAFGyU2SurUPm08cQMJRWd88MWJFTasjFFrrXXACBVSg5uhO2oDevhijh8j4IIF
+Ii9v9rzxYtRGraBCISnEqKou6NLmTr0iRppaszlqbQEJFgx4Y+nLA04icFEtoIYcgGgaoUgiX5qK
+mKmVieoEBXgiAV/KcFFHqQYionqjVigEIELYwEhiDm3k+FP9yMHEBk2cUuqD6Iqg+kIPJWBhi59a
+uZiBSYWm1vpDPWFQrbWWITTFHxAAsUIMKKHWJlAYepMCO0QgUfI1hPkjBTxBolZePMAMU61rqioL
+oapyIqgpBBj+VDrYAKJWNd6QJAkg4kNJVUStWugpGqqQar1TVUMo0AMJoCrl1CSU5YwSUbBpIokn
+KnCGCOS04QQWojTqOKFWJIR6cD9UDYyQFMMbGobokAAcLUOGVL9Qcgg1wcEOggSKs1SNWTMnMMIG
+KgK4gKcPlDaB0rz5AKLZII8WooQwxQoVDYqqCgchEzjQVOvDoASTprpEhgxHfHiijCEY5NRaBclj
+QQgqFdDPBRUREJCMseOqDJzghydVFjj44QMNcoQqEAedIQ2E2fPmoDCIGyiVGXWJJgbBMAUIaI50
+gYgAsKiEENFkEFsw22iqN5iRQwWDEPGBlClVUOxfAgpYCrBlBRZc6OIFTJgwr6iIPdgcsdRlSARy
+FJmjqYoQAbQ4pCZiRWlACPTsqQPFlTZ/qrSSUZIawMATKA+cMxjoUAMaMMTAJEUKgsAS6I2iiolL
+nyeDSmBEzwmAQvCBHjkgYoYHMjnQ6wYxNHzpMkXozhF9vLhB2uyp1QwKfcQgIqTWWlOAkOj54ggN
+SrXOBXlAcAGZpiZ+SAGlilrXOOLDjiqI+ocJctQaxpE8qkrMoLrEACIufGrdgsiOqqq0+KlwoECg
+1jVCJugjkBfi1KqAOnhOdtRaRQUrDKIDHUAygKPW0Z58gTSCCiawZglRmT61tsGBCAgJ46cKYgnJ
+wQQRHCDEUWuN45dMwVQNSbnRp4mmLjYockMgtc7xQA0teqofII6MZHrUGgEjTrjhxIxaU8AEB0h2
+8KPiYYAm6IsOe7KYYnQGkBqoiCMzpKBWpSGqYOJACRoIMUhNQ0oGLMzQwcKp9Q0xSryQoRQImArM
+HxWQBmSoQFrBR4olSQSqQKooyhB2Khnugy4GtfHCQRMZrMBDA9yBE35qrXlsYUlJogIE6DQxeWHl
+AiACAaMMFgEMnVQ4gwUcg7gQ4chlhyA7yoiiBxaoLCm6wAMUCjIs4AJ0EjnEiihCXNBYUvKjhw8T
+jAAOGm7U8aNP0wfEJHGygxtNdwgBBUqaEeyp4qUsoI7aRMcaBByBckMFAql1jzZfnFCxrqCjxAcG
+sChXsjVn3GkKJI4EklBYMgCkG4awws2bOXcIwsfPH0FMgPbkwaMOnAxQUYQOXKwYMWHC5HQ6JUmS
+pIgiijg6OqpSpUoFAd0mW9fkK8IJLWlB+p7sJuPL1iu9YdFx473o+5h590O512/pmy5m7oqvYU7O
+lmXt7bGXtehZdGut+8yt5653EGLNtZMNsuXNY2Y16Rn2MNjQ/Ub3J/ty55rl2GzvvbemizXqWGax
+m5Gj+3/uUcsuysbiP8+w/yb7Z+tMenMx6+YyyvsPvovUctmUNNLpzUFLttjvDaMe24xx+rWWdE/K
+j9blLvfmvK6F7WXYt+fR22ObNetRB+dFly3orPma8n5zGfbtvb3RdqxtZxiUKzmja/0155VB2aZz
+VqNteePM6raQH5QPcx6fu+ga5ZnPxWb2rEzGdr3P1vve2n3bRZ2Er2e/g425xQ0x2Nw1v01ubpn1
+zZKuv33njz3MTWo1y2qryWdvzhZtvnN7/7nseUdJnZPbLoazfcxcyxxD+JTCVBL8lY664uPsakyx
+b85abzA+bdnM+q/4ccoLQuwfLo3tG8pmPeltWtQ1Cz59mYU1M0wlNfzLevbtv9q1Ptu0Lm8ZFmF7
+mV/OeQY5PupYW9bHuTRrr1s2//fWl7UN8qQuy75Mqpuvh825rSnLNll6w/i3xTgz6/p1Mj4Ks8th
+cnKj9GeT2HuznNPGzs3162p20Tl2UfgavTDZ+qk3K2Ld2mGRxvlcMoyUL6vfXu1dbzbLRW/wTdka
+xpUv6yd5Udzu1PzZP9jX05cYbBZ2WY1amLePD2swQvrelcGFMbrMsrYw2vr9m5zS2/Ue1uZnLOHG
+CLEkneGBoikzz6QZIUzch/qfEgaIHM6kmUlTbJBidHQmS3OGhx6SVAgiC5Zt8dKFKVtX9hSuey3y
+fmO43r6xbvBZzi0GvzEI3eHvy7IWmVoNUufNrYRt/30xSCWEzkVKLb+2Z3uW+8YSeg==
+	]]>
+	<![CDATA[
+	syj2ja2Mnd/340tHuX/ITrJDudjSxf2G+xLlEUYuc0wPZLDEOK/MSQe39bNscF7eZNxttH+6x3wK
+mXl1OZGZU078ZmcbacQmvxaxno1d9HZFq9tvN5yZT+EBhiQ114UlS5YWsDIGkCKFCIoJNATxBAXK
+kGPnD0L6AGISZIgfJ5jDRgcwkMUTZ1qgggQFJgkx8FBqwsNGmx+6WBmqZFgDRyA+ZQBRgpFKhjZ9
+AGoDiS1HRMxhgqODkyTsUANjouYEZYhR4sIYSnz6oAMOGWWsIYcEdvAUkkgTGFfS9JEHGRDICGAF
+ihKhNwMQWKihhxIMQ1EcYgEhulQ5EgUBSYDgzwSWLoCBUATNZCCQWo1wIsIE3OQwJUNDiQoN2ixR
+YAtRkyyNpVprVWMEiQIOqbXWM8IkoWossfDlTq3VzAZo7tRaqTAP1ynKm1oxsEW+KEGBQVUNXVFr
+BTSmiJpEpIjBZMGKBDpsOpgiESZQoBF0RBMpllJQ6uADtTqhpMqbJIosvbCnWrmjigAEQUyEKTLD
+p4qp/jRJo1YoljShAknfqbVWElLAU2utTObgkggGYNRaaxQ6kpiuWIh0HUNr6pwV7Cj6oqoRUoIJ
+q6o8R8aotUoshdRa8ZzBRI8t8CRZo9Y6NOfIGrV2YANWiGliQRAKW3YoYyaND0EMQYQRSCwhp2mr
+qto/VxIZVPGxQpUEU1WhUWs4cwUJ/Pip84Q0o0Yef7zBBgWGIe2QOlRlC0EX2EmDBiM7b1qcPZhU
+VRlNGrCRhQlUVNCClMIJV6IzqsqUEKIIIAAbAIDJEguGSPASBxI1PyAJVI2S9qi1PsCPC3NUQxRS
+QjVTRIdJi5IVD1Tx5OGkmrLEH0ngVDvCFAmgDxYtFvhDq6r6Uoe2HN0pUpLFqdUIzweGXICFUlX8
+3f9g+HLi2E9+c+TXG1k+jJE7RobeUDrkRu3Gd6def460DqHLv94t+3LSW34neV1JCxslGwU9ti//
+o/pdZI4StR6lO5ZJWZb9GR0lZXnRRRcdiqPbfo2K8At0/rHtM+o5Mjt/LWW/yO4gfLy+7cuO9Jb9
+fbl9Ge6nfFu2jPDKYq+Tc8ZLNtpztgept8cyNo5WhOxiy2aZ0flvrjeM7myW9bz53G5xYb93j5R/
+abOcZ2tsenOHZc0/zizS63k/RznoLL4idkGIWX41nvttuufNZc+bdJLuhWX7svcmjW6fc+2p+/ay
+vU2WrnX27z0scmyMnX+xy72WZS9b9jZnuXBinUolZZmM8HKe26J0q00reruwj23O7Jung/wXjNCx
+rH2/2SzHvEHsdZudTec6Y0dnvODs7DFJm+z3ZtHstQtiWDvf5ujLKIbLV3+kkBfuw/bcyXY994Zl
+mWtxd/J7kNLMgn81fbit4WU1h5i3ddRq/BrKi76Y4l+O3O6fWisZ+9ZXe4svoy17WLQwuO88f78p
+y9icwm/TuTcsYrE91/+Wt/Rv6QslajnuXMtNbDrZaK9sLzpv1rXeMAiX/v5Oir3M0Zg9xRpbO1u2
+09tnc9vlHJYxfNypj0+2P4wobiix6ezoldHnWvZ2Nt4reoPOfbSyddvt7W8t+d4wxqzm2PJmTUkb
+T2f1fLNTMslB998fp4MNTvntYdMb03Yt+rMsl+z+DbGOVNLLak5a3xhm3rCWsTnrJ/zrvU61v3uH
+kvL0/iAqyshT0nf17Bhhg5St1pF6e8xfy1y2jjmE7ynmbl2XdElb5j6bZ+5tOrqNRvmyC6PxpV7s
+VFLkbtQ/qmE2pZsyexRj2qZD2Ry1vP3P2dwfc4+UPTp1HtmZwuZwv1kuvXmErrnMZXZNf9cls8wt
+9mKUDct4NoeWt2tpy46WS7GDLh0V3Uk+f3DdxUi3mz9mNeuK3mKc3eKzprusCD1e8Ttznq+9w9na
+MW8MKW17Sf/PPHIq9fF9s5/RrefUstpnTja32Ntzyq0pxRZa/Qz/3euHzznL3OUOa/ykbPC5t4tG
+qzFD68nMkuxktJx7mXSwRZp9i/+8xXXdqL+s/em6VMrd6Ciply51+fptd7OetNr75809ts2a3hjM
+3EP2SVc6q/2cs1lLva1FZ7uaX09/fS1f04JLFzb3mdXmrrdpRW7PmLtlf05mFvboi9sm5mb7z7w9
+h32T2eXb9PkxdCjnl7M/Xtt0vm4bp2yPWd4mttyyhVA+Btkx/+Q3Nzr4mpRxNndl3rJuq1HHMnMN
+net1dn01Xawpndw8i7JJCr39Q9eYo9USclsYtLBfa9+3zW6rwezyBuGMjftaDFJ2+Q2hN8pfY0z3
++2G9l9Xctd8ui71dl3uLUVr0yh7StSi1rOwjjM3C/JvszJvsD0ZHWrgYQIoUKVKMjjIcZg8/8DAG
+zSk7w0MaNNkZHE4ZDrOHLM1Mw0OZMvOU+TDR4GB0dCYjk8M8E0OGw3RBihSjo9aypOC7xy0dx4co
+jpLjskM9KJ0hfOfY3e5t96JchB6dP+r9s7/m+OzYPffn+KGkb/fz1xCm+p9D79O6jcyNcsdklr9h
+v0S1hO/t7bjh8jr57Q61EsbmdreSZXwPWT5n34eCD+VvdPL9ozim4vuHz0lu94haCck0w/6Hav92
+seWT8qH3g/JFlOz/t/5cPnbsyyjYn5L98jl+3xJyw3eyvVHrT+afg/1kTrzuvWe4Um7vy/jcEUaO
+/uJDOeyTe+nb/b/tUDGmoOtuyc78jmrosh27P9QzmX6S4YO8sF9ExSdzcund0pv9Sbgcf1Ed/b3H
+3w715Ind98OHktE59d6wP7p86Nhbnh6E7TxuO8fQOfjg292G7knX8n3Z+d2zgW2IL+V7/s+PT/8f
+nbdkKX//kSKf/rl17nLOXXxu+QWjozJGRzMYHY1xTkH3i5+zc8ns1r3l1Eul+PV+qzEzJkt8yy35
+5JqljM55IXzUyv/Hb6WD/vsaJdele+kgbKdF8Z6e+363fBLVr7djN0eXz6M/MA/JMUMnn1/OXyrl
+Xqr/U3xi+V4+F5FcSvY6KDt1pZDWpZZdSva6k4OpKJvGFEPoqO4+9T+/oGfSohtnnA2blmyzqbdH
+r6tNNzvjCSl/nG/3yh7W9qKyOeje3qHVMr8evDBPJUXnR0F3p/iyX744KXWPk7YMy6x2vfUWYeZa
+lknOVl6yn2TosJYX3W7ZStnohXlj/m3cmGVFyzcF3f97d/B1T4qt88xbwynbBTNv/jZrC5c7y9jn
+Yuwvr6a09Xuz7T5vlOk3X8fe9PJUyiUMXxq17xshL/fvtosQvnW5qOfkSgljXG52flFKGR2UvO2v
+9+26jS+yu3y//N6d9AgfS+fX8r3fI2qhF7fMfOpd5lOEUPK72LBh7I/uvddumx/Kdfvbfu/99TY3
+x0aBObmX6Lss5fbGmLr8ceoh9V+uO8a/IkQCA3343W6GnPpefudcOwfZveeQnOt2+NdGMP0XBPPL
+p2akyPz+YHyMFI2OqGvZ3S66d25TSN3dy93tXnOK4fLD5bd8isunt5tCghAJQrgM5VuGy4z04kt5
+7XvvSoHxwb2378H4v7f8y/7ck/7dLjvV7hxpfVhe7pOE8tTuRkc0hfRYvuX3LR+/ZHl6SMwvhYS0
+/Pz9W04hObt+zm173Pb1d3jqGNk9Ir37xnWuPe7LVG/LbV7ny/2+7A6+93Xn0v89GHndQSlhy4bR
+H/SI2tP2i5Cb95cfc/P7RoL/Cx+yXN59MBXhMnPcjzAJLi9dpHYsl6MzM0c+eVx+NIXEzMzL/PtI
+73i/efl/40pe+V7/MvMvp5BeLvc6GE9imkJ6Z37ml/F9b5XEqOSzbXyOKTMDAgIAAMAB4xMAMThM
+GouFAwJJz0KEwwcUAAVCOiZkMiAgIjY2OpdLxKFAjIEYhmEYiMIgCKIohmLMaXQGSw+T9KDUu+NQ
+syhxAY0OcdKMxliT1gxgEHA9WVYY5DQzhL6UUfwlE6r/iYee8Zks0w1omQY+nA6eJP4r/L9gI5kW
+eQsilRXE3T/BrQt0PTY55HggZVn2rPYhGb18VxhmyGSF0yP+ULHsFDnIxkk9LK25CCiszzjl5eSf
+WCBWwbj+6xPbKzUbcE0nuQyZJ+OpaBYPRPenRjcYmTnmGTur14W9ZZRZuRUCNgDwRO5B+A+vyxWY
+XhwmtjvAzG8PvkaZEnfjmYQziryQRHOGLJPHIGGCYIkI2RYJujDKKD9yhhANMBzjFnQrUsNa0b+G
+VRfZNNAgmljD9WTP/BaImyfUPbG9MAhEKaJ82psUfqUwSIgKTbDb/Hvhog7ONCpMd2fCc7UroEE3
+/roP9H9nemaD6JZKSROjb/8LzxJDhELnatIROrsc0ZQYLkucNEkM1JE2dG40TLWTybwpzKYc9Hs/
+xvFtI4CR98suDYXjRmhSm+Y7TQQ3pzJuSy1nR9fvfBOfbVd4ZdyUbx2x/WDDRJjyzD8T+9FJ195a
+PwjKuTpkvcVxwz3Vd0LKIURa6SIaQQWIsmrXAjr7P9y5BlJRnEEBhQENin4OSy3kxSU8U88eid5G
+uq6Dwt10nED2jnbdkG0NhZXtOLYWycKNYZkLWGQb2BHboSN3hX1FikDVdxgbILbu/u2SogZmTogX
+1IeAnZv5At/qI9NtuoBd0pmdBbH4zEH8gJ8gS1Vt09fpJ8iUQfLe5an4fdRzJloUdgWysHpBvnus
+z3u198ngDt3OFdTCbqUhKpTlZgo9R0wMegcxLKL1yoPTJui9WiLl2sHJIhOP8d4NTLbLAtqHO2IZ
+socVUeV1VDtXofWRv21Cq+BAKRy0imT4lnMh8MAX5mUy5x2+ZY/Q8U+miMSBpx7sRNzsPRW+ZPDV
+gncfl9yod7MjyMGmV6SgoYI80t0Jf4whQueWB/keOr6vw+sQzwNmRyXp44bJjpQY9wyDi//jfREv
+VGBfkgW+HS5nYwtqGfodrbJ2Iso8w+Mre4uick2XEYEEiQ8Ez5bH+ICpzIVOMMJlzbfJVLumZHkK
+8c/wWxxTT/qZbalmYNQeOSKQmZY2ceBFs4UVK2zP/VE5+HEMJ4YoDkv3NEDLWSo8gVUJ5j/gxoSP
+tvlagv5oYpE81IrL4eMHXcNgwvVPOQCst+SvLf8+gkAs48mKifJRsaUCbKNsZOGMVLtFIvfpLec5
+nCLVKC/XcAONI8W6pYmm8R9I1MgB99n9uc9wj0nJXJaWU05rOOz3llV5iK5qMQHdjQDq3Obth+I5
+pGbfDQgNYN/Juxyor9xbA3TbDrESAWDWRm89iv8A8oYkPDuHseBgF/HihgureIAc5FbyGg5CouvH
+BQmzoUfbr/0MLPC0cUJyJ2+bD0ecSEAnXyoIdoTZO91F+TxyHj8rEiHvjXt7mIKAI4dlCEp7TLjV
+B8VAdqgvJUelh2KGDg1awdwcM0/nDI/54l5A2usEFTBFqK4tC8Ahyfp5D1rjg/AJ8DP8OJRt1KgR
+cC/kFABShyhJgALRauzljawBuNakLhRgol9wpVRnAuoRLOOpjJGt3n+I571Yh4xp1w==
+	]]>
+	<![CDATA[
+	ktfra9x5TBN2FxLRWb8V/znHWfyGFkkZwHbW5us92gGcHxa1A2/W9fnkrNi/y2EWVSpfgOFZ/why
+0hrQP0TsADifuGSywFpEa7eYYxiLH11X1ZiYWyC6rJgrmhDmedLln/AvwEQIi3/mnsrk+cXGR4bS
+g2yz5YyLCQkQq31kYgHjloloXEQT4Bq5wT/z2z4J+j2gH+PnlYhS+4r8CuNHtkYV8J19rhmB3adc
+JYRyCKoWGhbpv766IHi98IohlIAeAVF32/AjXDZQYZ45/RiV0ggOtUSsyl9ykt9SjaEPLMjsit+T
+XRySN7YPvHvKnXxmGqKDxF6ZFVarUOu1M50syMtSwg/2mFQC9GYG9DWUY9GmM3LZrELJMu1OfHNR
+MwBxyfv9cl1ZpkV6dPorFphOQmaMdYi2A8gljN51lptGmxE+otin5n7EnGVeJ5pZw9iSwe7hDFhB
+QDmXSsZNul/U5xW+QlR0TWpW569OLOsf6aQhKqvrqHNfrxM82UyE3IU5P0Zh0mRFYWvcpNAWUu6S
+cGUWAAdMK0uUM3HP8bwh1/2122hclXvCgjSqN4Ad5AVKfzTT7iOKKE2XH2MRSDCk6Hl6mBBX/KIr
+9uliwKqA9ZY5G6sKbGZGJhc51BsMMiCV04fBkdka0/EjH58rHCQYZ/5Oc/SLPo/88WTBX+GJs857
+XqPg0goB9UrNlzovshGMXsSzim/3G48SVyrt+ljtgLma7wlIyfmmjzeiTlR44exerA8FL3dbu337
+mrcck9eMUWQ2r38s0TW5QpQQ4iV95kGKgif138mgQAgRkggCXbLNO+hYIRlsIeodSeIWAVLT71mT
+OmK+9yj6tSdwzmtuF5Jor5VVoHLb8uu4CCr9fghCD6EJthwspLg1d2x4RpPg/3aynigljcP0Fq/1
+gjckGr8WV5A7lxgiNhXpZTYneBmaFJZrWRm5DSgxNqFE9Ge59mj2/XLx098OVHVyMIF1q21Bkhpj
+5NZ/VRLQ4gP1uvmksij43ngR/MCEh3zmS4l8kN3WMKb/RQUTuEwFdxfhQVNW4/+u1Qws3amognMA
+TYR+AwHN1AiJZa0EutwxUT11HaxOIW/Z/S92SuSypxjtk0s+epiUHMgGLkIgsICPz/uG4kOPijxK
+X4XO+DCe0xcJ/IbvIeZwPofBml2ZyEU04hJ9/FH43lFC2kthy4QAX4SQd0zbxhMORCxJ7qZScLml
+mWGgHqnv05QblR0sAOodwG8deV3i7EUIJBsRg7FpxNUbDmwomA4LDSWLEy2mF/q6u8pHPjdyiBrg
+4Lz84J20qlPWq6WBoLC0YLAlbIbpdFqgssJZ9TuUl6z4WDZYV2z+Yw5YehXEibIcUKQ+xDlqcR8q
+e9OKiqm4nMjYDxMPFnub6cAO3+R8KjSbQ+2RsExF6WerXQlzsIVFm1ZTfOdIegdXzCYtzbuh41p6
+/XLs7+C0SnjTYHdt5xrM50lk2MvE0c+fRjZk2Mm887tS+HvkXgbJERclTidDqI59HFVGRa+qczmJ
+TGHDSlCXRzpoouMndmNNZ+3BVPZDutov99SBakOUSdjkjaBkcg7C73qrJhRDhbVXVg0Et+m+FQVU
+57ucX4YmsOtJWx0GgGstVyYEhA7Fz37470bYN/lMX/sN5lWmtwLGCUO6sNvKypZ4td8/mIRgAQNe
+5Wsmcn7/ZAxCQ+TR3BSuRE+fqFOSgStMUmSlZkPC5CEhTgZgYc3IZdUVOHrq+I3iSoS+y877+H5H
+wfwG1K/nxlxo8p1/HqeX4917H1JiKqcO1NCE5PsKbelHojhpKOZHwpp8SE6KYfJt4wvwe9MBnnwm
+cdXgew/hCSO5sLDOQXj78Yu5g+tcg+eVbh5vN5zPM4gkQuMaPoL5BwOEL2s9Wp6Hzn1slqlE3Nt+
+goOmJQJs7OcNCAHKqQIOiCdPfDfOaoC4QWFqohWJ3eqiLRxoyI2wQa0sT6DgUrATn8QZsBhgEopd
+iD88UBHub43eDx3xCE+7AMvAtbNtapU2AiiCLUXW+G0cYMT2ztDka1DZPGaIHMxK2xrBq6a42li8
+cz/Zzp/sFwWZV0jVF1yXF6Ci2svtQeiOg8oiK92Kbl3HSF5mfohMlekWp+gFUF5s9zAxjfkUOSyl
+MAyOBYrZx+RndBBVZyYC++84JUSFLJjVkOwb5t9Q721UCmFulIUVWTeQ4kLyPc4GmNnzqef1Nl6I
+xEaToonyobdBgUsFAcscDOVyPevsFpG1MFkZeyeZv8CNApyu1V4hdEa7bChY7cI6dTR+lC+7KjOU
+7HKm8aRVtxQ/bGJFjZXqvKtS4cPpvJdLQegxUFHvDIThvtFj660KZVVOhFXyB3SHqHzNJgaY+oCM
+7RXO5Ngad9Zs1hQDmj9LMYmTFx2otxkQZs9yyFWvZMZUg1ycpU76Zm2BGx00aBI2pE7IpTx0qocx
+ZYoUndcvJtcPt/wlDKpfiaVFT8rCRzsiN9V0zqcwK8Pko3TYMG+QhdlsvlxknwmxpAxUURSsccU8
+xWL6FFqPWkJDFmNZjBOJOlqGerNYjTixY6EpFGQa5JIrPGjwS6XMFwyrojnZFzxJ8VpJIVyPwnNT
+cgweWfdnhUbLoaOuiKwkI7Q70MzlFFY8wIfUOR4Pogu7arlAIbqaYZuvKjLGgWMEVC6xfFMPx9jo
+6UW4FDSwFLYLK1NwvVcAJtYqNF/jjDXfmzRXtVt0UybxnBfthjDNKZhcqkKdlck9eOxea/CvoNdb
+TeHTyNtKhGPqFTZsqUR17JkH6bQ/RC2X1VLyZeqUlzraFGMJCWyzUY/qgal18/5ZlftX/m5S1cRF
+C+BRULk3k7NPSLvSyD3lRwQ+W2hUS/u8i5EtoUvIVt1fBw0xZlhpC0J3SSaZIbGTcJZL6dSBDk0e
+zKGpUmQITyi8j39MeiIv9r7WJhJYoKf3HdV7ZbqY4y0au2+i+wUnChaHtCCB6HCgFlXamYk2PpDd
+C2DMgqZBv7STdDVZacBd8mPvx8Aew6okLhOACuAW7buXMjmM6+q2LwN4RYSHwSl5nCRnRpFKwlPd
+HOUl5W0oWV0yEH5yBzIEpvhiAqRNBMqVx1ylQo2s1Pzjxpo28BA3to0kziyj4pH6ZCo6xyja4aUn
+o4UkwPQui14/7XuLvadsHb6Ac7D1oDzNYOM+G80BUg2SnYTFx6eTfzcd+YwwNSEDBH/LXTyxgUlT
+RukHnqrx2TeJGnSOpiemuqrej5iDJpX0E9bl73RZUb7aQAR7Pdm4Sc0L5zLKVud2K2PHiDZsryZg
+Ii98IxL24bfoMCifh+M1HFdpomMHksUCdefkuE5iiEmpOG+IdGqRKe5Zs9J6bARHwPOE1Jse4p2I
+P6zXZZRd3kmgHZU9Omxkqz7KhZDOjagySR72C2QrJBDUTkmkzSm9ZrdwKuH2yb0JFApRE0sBCc2+
+IP2vc8LB7Gb4/yuyYMmC22vhqmlqSY/2LlOUsKFwEOQDptOuwgaNbwBLd8tiL9VcU7YqsTZ/Khcw
+u2SETEkksZj8Pw5GbDqY0ZqfKCnvMp61zu1DmLtoKtXFmbQF911UW39dJoB1RGvaoPbCZ4sjqTSk
+A4SNb7I+LYnuomkqDBqRASB1jSuJozwnB7WGjtb1w3LhXLoR3BlIQAdnrcq/ciEc2hkS2Kl8MUUF
+O/BDt3MCH3KjQtuSlen7U39DFerQkw5MXIV2CEDvIMpjj2vus4C7P8aXxQPXuTxFlLU/3lhPuwpF
+zKzhshStJpKwVvquBakZyNzK6RZLuShaY+SBZF8WVg2t5pJluWT7Vrg3Lv1N6oiMlxNk6ejUo6lX
+IAW5NnTirRnuxIHeX4Wi3DYu8X2CrOEdZffB4ZQ0A/ouVpG+byYQnRKWz0dPCy2ptMDgwchQP6at
+RCWCRYaUPc/jDKGtxQmvlzmav57ZfbNFQWOaNRMAGq7ualkEAn3C7Doj8QlM+1qOB9D/36kwdb9t
+gaLP1dBUqRnBwjEg9yKdJZBBu0MnYWKcMAoPWwnMW1tOswrE6nSf2ePjaR7D/voaHGCkpEafkE8P
+xRD5xRlsSLRZCbl+2L2xq4WoujBTsOM0OyTxJ+DtUg0jFxxgyComFqZ0eGxJXPMf32QfCWwq2Ubt
+wBj2WHxfhZx6IyAlMfBBcKYtGn7yZSZVJS+2SamHeFjXW6FejasKQv8Hals0CqkcQYxRR3EuUShJ
+FZxHo0KvLKcojmKQTA1Y75+TdhrEAzK24D+ZHwtMp5rXN51FFoF3ht4leleejMZqrapJGsW0UFcq
+mheH+IxpLE0UrLyWDBZ9ZCM8/tCADqgLRfWPmtTHzQdkKltM9vkPZhgz5FLG9wvhAQGXyVizlq4Q
+2zXEhmRlDGFeSFxjmHLCUYzP2CHqsNRsA62yGVHxMMIUPttjYumDC9sMOBrA93kloxf34z7SAcCy
+mFQta0IPix4WteHWUy6OrOFEezbrZ/lZAuB+DV78ei9YvqeWJF5YTEpdugy03c4PEO9bSeAXXWOQ
+24k+yxtVQPyGt/lIU3xw00IRWDD6gcynC0WZbvfDT3EIxPVzMk4Vp7UqwoYsGcRDHeVP+6fSSTpi
+UTMp+LptpIRoVraPP5ZRA9qE0aqKb70XkT/a3C315vrxybGcBfJFuHXAYeB8K2xKbdJlQIzd63Ro
+PloB+Yyy0JpDdDDI4qLPip6n/Il1togyunAmMZfDYN0snUgnoYSwOk5Yq+S3Aw1Dg36GECseBiCu
+k6xYbMXJnP4H0CwoK8S2Btc2ORE9MvK5FGvX57tiBoOOuIjJUkaq+8WDGqsR6pk4Dxx1jbchSyGh
+Hrtx68wQfpQrJhKfse32Hplk50iL6n9193AadibkMVz+d9DI/m0FysnV8Pi6jzv2SI5/EftqKdLe
+WvOcqCWM4d+MtN+r0cx0uRj0lkvxaZNbTp5AnIPb6paAiHtm7ZjXqCn9PjmIbsIOARqAgPSKLzu3
+X1jIkJbAqlO5FYmPa4ZsqVr6fM83yhfmpwVajZtetgjMxRa1uRf/Q/uKfzD4yClsNBiDLAwsgbDl
+CxWYcB02kHMi6xpuTiIcYtOthvoU+kwiRR5ho0RFz3Z4tw/6CiNhVcpCELI31pfTKDuFUgWAjdhe
+QjzSVNQy4wWziik8ltJKVc8JerN2fOf9pI7Qb660dp7dfo9YcUtdrWOdVS9Mtx4IcYjG2FUAjydq
+TldAOq9k7+uc1Qzw78OztaULGAzpgyYr4awuPclGanYP4i33CaKlHp28MpfUafBb3iJbaRbzQtlK
++C0oTH68FlFrDt0tfgyjgLZVJhIMIflW5eah/JSuK4yjX8NpLV5mJrN31a+qCapZCARLZanC37Bl
+al8oSLDdTU9KB8wwpRPBUnv45IUV7wn08XDVCzmXwJ4zx4w9W+FxTjBXYXF0tdZ7K1qu3VeqKDL2
+3I7a1i+24Q3Wk+2zKJ7GddBpeoJ8tS6XsglYPyutgoyGTCbPKMnVdQnbIMHARk3UFQ==
+	]]>
+	<![CDATA[
+	AvXgrhmUbSZDDuxpztBBq4otxC1mIUgILiFmhTiKPhVkE9MsXBBtmNtBmvuy3GuKY/PQ5/XSS5vN
+6eADearqRZIC6r+oPBu40l6BbNHliyG9q82qXRGEvqt86uV2PUNbQcnp1Z1iIAqsn/gI2PE5js3l
+RHoYRHkSxlxAe7ooU0eUXC0WOnLAdrlHnicOPAANeo/PvzgXk3zpdFOZ1dVvw2QxaN/KIL5hG/A/
+Fs5CMJDOq8dcldRVI+V17glHqjNLUHLycYpi+wBTU12NwJu/6kqdC8nQwWkeqnQwP0QG3xAWKjSl
+n25YetwqeSabWPaJg7jDBBNk4581rGJOZP4O+Ao3uqKG7mb8L7PHUjNlM88C2leo8JbHILzorvGJ
+Rxf/92chX8offhacY7PkFYSLEG4kClHQOCqGk/tGiSgvhy62mgLgE3HDG14IIpWunp500O2oFEIN
+fgh6Qv6nyT7F/c7mpEP8GRXY0BosP3MVqGFAWV5TmPiZZKIFx6CCMxCKjoVRLOkzhn9HQnImURG7
+19/m75gVeCYUPlDvZYxd/XMyHYm2dyF31GXzrI2mvhPXZsv4w4dGKVxyjqNkYODjNaEbW75cXhQ5
++k795s7++ZkZHBb1dD343s9AK1Yb+kQWGXSSHjBLpzL/bYB1iWH7gbCU1AiSY5V4m+8LEAmkA+1u
+a/mvYWwQzBuSSLW1Uqd9cF0KAX6hzXuhIhlx2PwmCNJeUcf+7J0AkSSYyfM7tUR0xyY5hB2LZSyc
+YGsBB0h75yqAeWPOUE2oKMB7m+boqMu2TYF62RxVXI3haf7uOyneaftxsKuKTp55a6puxAnGazcf
+DuQP/hXGjiDpnCBXACRXdm+xIf/XacL85HajkZZyrdwQnBXKfvv7npDRUTzwli8KqyLOFUEzFxeX
+N9G8iLUxEkABB9NGvOYCY3qGe+ubwdNwsYoLB5W3AVQVSDoSju+Kbhn8AgBzAZkky9Ep/CubND4c
+x7l24x9X6HUrCXcB7mXbO8GOsUKXPEil8f7WFEJjHuUlX8mfFmiF+HDdynT07j/am/jx7AtR1iDh
+WIYvZlsFTc9N5drbTD5IqnVqSrnJD6ovw63YF+jQ5CPYJDuyy6acRu3SKi0g1ATJ2q+40dDZ+fJK
+AWrvuFraLMSAR1OottwW2lSfayEI4U2FN4PYdtyidVfbrBrP6MkUxmL5sUbBIwWfLaaKVchguD5t
+ARo9uDo18F3cAXGkbzhiKu8Feya7m1EHipyytssZLy7Ue2nAREzhmHM60SsVnUX2RagxqWXRzTFH
+sXlv55XNkWTqIoh+JXwJcQ5SOk7wfrZ6WRm0ohOnaRWmouEr98KPxporgSE3VGg0lqvscwJwdXRI
+kbJgCMPpGCz+ImOsHAFcg8Z4RAxCyVs1oJmUKvxQkIeoksKrvBQ99FEZSmUjFaiwrPC8xNTmuLOk
+KrpX+LnLQaC2WjfTOcgLkTld7vLt4It1YkkD+aMsuMb9xVF4L1gGCAilh7/4V+X1csvpHDi8AcN3
+K/S0IKy86NQDoGkKMhnyL0B2F+FsN8YH1jVCmJCzHrsL3JxvMScx6nAL8waNCbdXHbd+G9lWqp4y
+GSUVPCvJ7s6FpEU6IdNWk/z0xNxFEKeJNxvDhag5quCegvNejHLVjMSfv+PP6cv6guM+1R+Veo5v
+MmJpCdFCYx+/BwddSnuWqGsKAu3hyIdaGsd+IYDowW3jZQnV0MQqbbjDC0eqYxHA56gkfhYEAyqB
+WHTFeXPhzFHS5BTYvnIsC+9wZqkqK+YW5G2DVkzFXAgQqt3XQekNXxSltnOwQ0Sz6rCsUTyqPhdU
+FC1W+yY+Ai0qZgU2DpW7QmOY2nZoCoRtA/7TC+GFvntVhzhvNQg8a6MVerxoW7hhzfsI44obomoD
+GbKBr6hbn1+cqVRj35wMv87PEWo4sSqgZTaTtAlnhCpp8aJIARDdI0U6zSX7ww6IOQZ9+KEfsnAX
+JNFOCQmPCZ+y66NEslTInW+R9l+En7siPbwA9oL7QOMGxkmy4tfIkhAOphB6owIT/knmMm1hbWah
+EK1Z0uz7woGFYr9ZC6dCLD5JZycNLrrjA3PAqkCVpsnhygqe4JKR+a5a9sYUc1/Pc+UqsefhpkAm
+kpB0D5JjSF1CsoREszgr+6CuOIH2UWp7lak0hp3BMilgv30RBDYpx6Qv6+kFI6ANjdiZ1OWdhn4h
+Rd9NuU/ur/yXOKjAB49/uHL2uUmymKXoJ4xLa4OyWy0cKupUYaIs6Lp8ICjSGG/LGpeTmLich7Y8
+xfuC2w9a+TGKRZ20TeMqL81+OCTRXBMWzBIFl/LyWtSBM0q9p2/dC9VZZgQsh+cFOiLLWRT220CX
+HwJI28fRjarrAd/YWO4JdJ3UQr+G3Z05+9h/gYFFpNB/LSSKMpWuTo1TIpdSRnC6ALgQlh2SJ8ol
+dzQTXrVyxH4Ktkj0TzNTwFrdTb8uFEeF/9RLdAZOA7AwjWQ1/EN8EQDf3hFG7wSg+emWP74ZJP5j
+iZJw922dpzWjXZMe8BFNXH1VJXiEDLvoJemjexsgo+MKapr1IfYmyRqDUz9NAeN4kWerZ7mYHc5x
+IrimYxQ04zUpgqrQPT91W4zCyaHLHWnJOU8MdFAvlroOznEACgz7327Ej++GXZbvNy0k+mxu6oQg
+sP52lJVilPIuWgJYB8tJPI11yepPrDVj2z2JCSWJE5faoM/cnmoJX3o3XjKwKrDXz2t7M0B5cr1d
+1jTIpqcAHTmTdbgy4vQ2ckw5KWm8/iiJsivGKeZxUuJl+u3WBscFRta0pQt45WiETLfnBmAxv3MT
+5rMBs9nnDkku0YrTBF3npnKFpX/oPkJ5jHlKqYTvpoW4CZZzCEqdhC8abpTOt79BCPjYECf5xPOQ
+FbT94lPF4j8XUw3oT4MTx51XqFSoQ+CMjy4BuAzTfqQT9AbGZxoEPYn73TrfZw3AKA7K2RYEGlgX
+0DhDNAMi6bRgoRwBv2BSMZHF7+iJL6vSKBg2EKr925P0l7AvRAggSnjvRi0oWx+hG2X1SDMxa2Sk
+b3Sm9abQGMQJ5iXWygvB9C1HsiBc1EioA52JWQJwVk6KVR5+7RW9k85xd6Qll1E1PNQbEeDWBxAj
+GfbnAi8mfybV1QmNFMu7RDLXhMUDcnJZ6zAd+C1HO4w+zfC3pe4i31sj8t1bnmCLHnR7P9SUbIg6
+U7j7tl0WGhkghUf/bCr7+iXsA6olty1Ofdz5zkUqUy4avfAdKhebV5MBC68nNYaHNVNfFiRvh/VW
+pxvgpS+eQy/L3UEuS8maJs7EgLCJ7bjNl9D22B3gW0Z419+yRSYla2WIRTav+dfrOnQFroMRaBrh
+kW6XWefxlAXpPPxf1FVbSDa51tRyGnBKW66E4wPBme2C+c6zEpZT9fCvy3qLmHcwhPrjaLXVX4nT
+IHnHtbe0yva/Q56DRCq4N4egTx1TbVJcdBAlwnvQUsgh5nMtNeoQS0eXWEivQqhewup7htKC8Awq
+NtEugiPowqv+fnU6TzQNprVDxzUmKxSohO2PMrselOTFWiUzGOWz7EH05oTQGasX/uCOlgWs2U+2
+L07pqJ4jHu64qLZxYBxIDSo3KwyfV5plvrIv2IX+i23W32vMX1KumDRIsRaB7hgnGSkuSV25XNm0
+w4xBp91SgYDSEh9zsVW+B3E85aCEpbDdpA5YLkyEFoSeanXd9MLIXp6sAb1eC9OyRPlblsQot98O
+4rJUS5rgvY2DbiA7SF4UtSGaygmuTsW2QTYPj8rp/irlQYFjl2+8Erqp3Ic44/wyg0eOA3VA/ZA8
+pQpDxeQl5G1PdiR8LAAXKWoaB9SOqGFvCZTpnQdvtadwrq9GuFWMJvaQP3GgHlAf9sYlLIW1++kA
+Sw8qVljFHM6sSF1jeERKJYVu8Bv+5SsCDiANGPcsAav4+MSpEyDP52yPC8cSgSGYvQWHLq6ULg+o
+0vLeAWZGzYNioLGncPsaUJJJftuHcKgpkdBwUO+vw42Ez/MaUSTfcbOFizx8IHu003bRkRMXAqrd
+XWnAgMDVEcEH9LMlWKF7iFnad3mVdl/RO8WmA97qD8nIhOiygmxzOrwGtomF4Nnnyv93pJEOounB
+vm2E9Ab1v1O0kPsJUQkrQQWtBA/nFdv/9iPyY4a1kKwM2pdmKd7+HvL0DbE/wqHTgDW4/i6tRiKj
+f7hr+iwehGCcdIPpwUIfOOLEAIoJ8jtNC+T5J+Ia98crLWdPgSrBmqIxFvDhu+3iP8oIN6GCuFcZ
+zyaI5E/ORZ/0yAqhTkmFuCF8gfw70IQ+LuAvUU6k+Ak/EIR0/yCLj/ECSm+KPMDCQxjc76CmwZFf
+Gf2I8yq0A0lFG7RxjGmnwBReReKOfYe2jzZx9IFAhYPoMNDNzrMs+PpXdE8TnY+4usLAQipO4aAh
+S89pcna13huaLJauh7bqbygp1/2IM1ZkvcMmKxKbhtirWMx8NrzLWw7isF1ilepgWpn9EUdXIAAk
+zTWM7CY+SgPXOpmUtiGaprc4iXM8QP0yaBaPLRi6cDAVDBTKOJ7RonE9hVGsRVTnJQdCcHOgItU2
+jLRPtLQG3PaUus7GYhscQBw3mN103tDnRRcizk9p7kMjUtA6CkussTqF4e4EQbxmBj/5s7EN6IfH
+Lb0KWSKzJjabaFE8/4S41E7ZB3YB9kKvukDaNYiLZRESNNEhTxPqCMDqg9BZHLuuL3f9aAHfB0wc
+j9mJQuiJG8eRC2rnP4KceyhPOkqyQMgUJ8dS59480LOEDvyBZzP1Ke6zwQBTJWDAqUOP2WsBzcSW
+sf3w0gGnd4QIV/8+l0ge6zIxC13zO1psKF8gD+eZRg2drPFD8qPSUoyHU9h1fY+pdWh2ZaRD03xI
+qogbQ9gE20cNYYIOYXpC1CdHxyRAV5i2VqpEKTD+wY+dUdQ9vflL5hWdZko+FzvZcFu5PohxX4Mb
+XxiLD+AmDqaBA1UZqmMsS6e32akbNXg0gcqFg3QFCOTK1yJTNsQBtdnHsJ+UXb+BjykMQoo0G0AS
+nRuNjmt08gLUd3Yptotd9ZiJBLxYMsecBrh8v6AYftJisjd/stg75HEGRnycszsb0ZXANIy9v96Y
+aSwzwdZGd1NEvYK9iMclzHetQ+n3FkPT5XKfwsY5cjXpLJ9s03ZoMftnpNi2bSXIPxVqTIiXFuVw
+Cea7Nl5ho0kW0gJ0sF6AJBw8nDo5NLGDC7E7+0Vu+RRn/Oc8pcjzEsE9azA65quMWr00C+OyOi9Y
+HwkmwIvhLIu7WxwTmvr0pcx7WYCLU5Fv/FP9LXbHBi4gY+Pn4NvpLjqHLVzUQKzFIICGC3yENZDR
+ITR4UJs5xAdrpVeRa0qove3yLceb0RelcrEUoIx1m0eA+HWUd21RHMyZaenNCzmyQl52UVxkeqKK
+pzNrtPnWyqnQ2Dmv7bcWe6/yk6M1lsgeS4cxv2lr5ddKiYu+Z12/kO0GBjDjLpaTKg==
+	]]>
+	<![CDATA[
+	VT4FEmOYsD02ih/BE0vTwv1uE0S4D5srbNFwDRGQb2lbva7kcvBTo96ayOyPi7IGFHc6wlIMDvq5
+tPjjIGJeW3I0b7Xg3OLsst6lAeCoiYjSS2altnJbrIdV9a3J4G9Ozscnc4Eg0UM1iCv/sGBnewzQ
+ZpwJrKCs4SkoGtRC+RUgfOoAm0ECtpGS8smeWOuO99KkqB8Q1AHKUwh2Og+aUs0PyFfa289rYGEh
+8qG5aqFYjmc0ur7UnUhOBM6I2PRWxX2u1IkCW7pSNg2hnGgcfB36iFFGy+/Ws9u2pfyCt0FlGBgF
+RJ9B7JZp8tUAf98ct5KjHXwECVFVXdg+a8tZII/0kePM3PTruH4BKHYXaS9XxOP+lAVwBjczExpU
+1l+jLmFH1pn5Od5eS7I4B46ZwjFd44qXOQgM6vFzUdO934ggnZ7E20Hf4XHRJ6RSPk4DQlrFH93q
+ddEhj9JqepqztxtV1I8xrzfdlpPj6ANXQCntveFN0d74q3lmh9TolEowrpQbDSCZ6A21O//9T3y/
+VlxEyL3Mb8pyM4UE2hKeuIvnOuC9fLC9ypEmKise+1HvTmCOCvByNsEPLFBVqYOCpmiWEhwcOJQH
+N8GD+nbxO6ATPgjkmQbL09aBVjB5ItYx+nbHAbSj0B+P1sdmHFXpeheqK1A0dtxY0pg6oOVbpize
+CCl4M9AvruUbABjbNxyKpI+N4W3YCEvLO0GeFWpcGrfJReXWoK7CrIRTjpfobvzTeN+Cwfi4NUSz
+WksDwCFUj1pfva3gb7Cglf2HUWCnAerJGOBpwiXvk3FjVb0N4xNWJEqIo/N1qLMLvHoh+xoitNJJ
+oQC84EJMONc8ls6vBa4JQQKIvGLoiKIcE+QC/l81Az4r1Rdlm92mL/I469xIQI6Ri+k5Pq1Iz3Z9
+GJtghIwQr/Zq93Koi8CJQKK6o2yyPPSSeeJZ/VVe1z+GkzZ1G0n5QHhvK1B02F8AmG63iyqRKAm2
+L1VxbK8NeNTTuFgurQd+rrtU5KIQXNzkokBw1jcvHaBWHRE8IypRQ5cMWBF4O/E7wGT2LpZt2TI6
+mFaw9lBxi+maPbFVViQOWy4dqVJJ+Ng4xEpaKfiXg6JKnigX+kv8PZhWuU8+rA9mMnsxoAuz9rS5
+Z7r7uM424g9CyEMBauum2uPykSCaJkCu2lXHeyIgdVEA4JSdPu9+jdUSClnDThQbc1K949UU8rZW
+eYvFyxBoVKz6g5MOSqdDHigwMGgysiOiNL7OVqOsAvML4DUB0HyALbYUf0wVe0k+W8UTpPK66u4v
+GtFA+wZ3erK0JdhDGcvg0Q9y1mJx8DWtu1FY5s81OGhIZC/l2/n64Ej450LIa0iqbz9rsohPD86t
+i6S8RL2nRux7K5DCqC20zUkyRLXoY62Pc6PWK1jSSmwnDJyzvjRmbAhfS/A47RJVs1o/lLK0ehkz
+qN5gLegYl/UJzkMF9HFnvRv1YqLtcja8ASnhI5bwlYp7aWGJJIJOPuV7ohZwFG+gBlIoXZjeSTeh
+vfvgnzBA0WqT2pnyt8o+GaQT+Rpmsg7MD4OKfmfOF+cRrc/AIRKo3JZUadYqSFQatiRedghV+kHp
+kGNB8CuqVCGfh7LUGTVSgTGqhN8ml4B8I3Uau4S1pzSS3wLHjnYAgScZQeY0xXrOWQ7OQEGT2zcf
+gDIPwCevPxXZiWYYbvaXBWEzyLzRpiVyv/kgv71igsIAbnE94iLHFYJpW+GEz4T7WRZTU47GWWjq
+PcZSZl7koDmHJRJxsByFSVb9uV1W5+z9Q8GeHSGQQYRHlbYSIwgy3e5BoMNumsEQbsi2cd5TKlFh
+YD8iqK/emblSJ5MK2aIjhyGhVg6QBusHfKoqIeeU92btkW+J0FGlSoCRNNikPwQCKoBAgVgXbn2h
+dgY0VDgduyWTTN6A2DK+JFNU5kIPBN0gpi2F+d/ElImV3pxUArI7WaOQPKGKQ8plk0Oo6sizkvrt
+Rkw2YsuZSIsaUhnL5b5R9Hk1J4D4lEgMtAJGBdDkwyZKiPrprx+yqM5s5KwwI28pciUN0rIF6AZS
+9RMf1wa/ppkSQ19J0zak+j3AU84gLXRNrBJkMCc+abKHxpOHh7AcOMBSK4PuRlZH3owfhz4PLR3t
+MNiPCL0kUMnI+fmS/CnNCx/490NUxwbyg+CdgrVceuRlTCbqlRjWVyIv/+tHnJyVD3Z4lIkBhekY
+6pv2Aqsq38nSaKglytu6NYXLsigE6q9Cji6g0eiiRLWUwDU/KqfeJie5ojqQNjWgAJ3GgA7qWrqa
+ZtOf04H0PRSGGxpDSf+gVY4sIvqrKqCizSyDxQYg1Wodk7VAi3SFOQAlqVb3ACFpao07VYYIMnLU
+ImWkNhAkF2OZUCL1gFV+MQsX30jGOHFnNalsGZprH1r0SMhNfY+h5ovjzVKUyhZImQ4Bv/L6xxZ7
+OdM8ek+JjyKlxycEbqwwM02zDM6aIykp9RbfOGrSoMTNBkwEcANakjgedk336QKBK9Z5kVb2KRGK
+J0vSDeJ58iGAMTXsza/6Yo3ptdx/v8ogaiBvMXXNBYI2Ep1nuZnDVzP+qh20YVbuyrz2bA2Z92Xy
+Om90Zkp/mF1QnfzSNP9FZ9wwo20fQtudxyzn9+jcSuh80/jL/AWadwmemwc/b9bQCYCnZtkMXujh
+ZayOLl0M5k+NLVktzJUaZWSBkPUz0tVfkEJlM38GaapCRQfgMzA9qIaZdQZcGZD52GPco+Gn6Qw+
+lxvqmH9xj+m15rKbyN93iPa6KkMsMIfXhgKDnYGv8P7oPsPZVwW0L/C+0jUc9Txuxxnhgns89OqO
++sAkx4aF2uXb1zOSDtct4qA6yIV4gYoW3bXVLzVAi83tEB7SM5c1ajx1auWZue2LjGcXeS0nTgJ1
+fqVpUroosLqzWZx+scOEf0dQMQUR+v1I51jBYpt3bhbDjcZY/Rginys7iTx7e3BXKFVs1lpBDcEN
+2nhnknbng33MVwdSigXuAICNmqKFn8uAbX8QhK7ZIRr5+4soMm8bDrDTFkH/J6PHtwPmNJ6a8UkL
+Hs3fB/6WgAotDhY/wNMvtCHLEjgIOzlTGmDlD4ArSApJr7alJDHxb6/tQFhJHY2nRFQ+tSuP6qCz
+wLD+QWnnWtQmgzmazJ3y3WkiQqdpYXMkGQ8Ta3apI2yqAYFXZS1AB9iAnyktGasSHHXWCQ8nBAyv
+UwuMHlde8F+VnMkoIavezYNBQt6Yqa/nI6Og0ltGm7/yNUlzEu2HUkt9COQ00V6lhFhxwNZGle5o
+BALCVpsVFWfJG4DiAdjF0qqk6ftntNQc8e4B3nKk6VNX7YgvxyOnoZgBwYm35dv0Ps7lAE+nydVi
+O+kHAaIpYOTx2axINhJR9Pj2aEiQjiQwnGa8yjwDQazqYPFvzrnnlutl0Lpeng2cWG1iGl9v4aw5
+lpwyJQ/VBBr+kox/OwRNz3+JgKURIUAlK4WvhhzqLk4zoR1V4b2VZADhlqFFZIuODrSSQlyv/JhJ
+c+KlTfV7XTJIai2nUep9qHgNIuDhsu6uBTp5MESLndks3dZpT/K+zJ3CobdwJRmcgXyg553gab25
+Xo5ZHkTVX3NePB3043L4gLmou2BCGwqmZhRo/EI1ITYA9mB/SNq+NrYaG0wLfZTv+cwp3N7yTHle
++jL9WLUE7trM3lEGuj6eJf0EJo+ynQ8Sal2LhjZTwJXu3k5PNipH7pILlzaR4T14gfTJ97119zVK
+i/pSzjKyBa91/dL1un6RLo3+FEVPVTveMKBS5mQAM+QlveDeiBdzpSISUspOlpPXK+G2UWq/GWxu
+y99uPLiuCUssOdDm7IwEI54xbufzqYQueRwBWpdYU85uQBeMpCCyAFUENGB9uVwqSbyiHlYKj6Vr
+iFJqtsP1sNRQ+zmEYZgPTl2+PH357UvesyPx2EHxSMJIgGYk0lSynIi9t3gCJQBdeFLjsCqkkZwc
+/obRO9EbJUuWipkHgh2NMwAsd5Vv08x4APAVlO9XYJUmCWE2HH/7kuwg0nWY3Z9WoaZDiNI2hboa
+Vb3Z/YSwsF/HGYff5m0ecjc1685vZmt2lYWRbu9itCJbxAzCo0Mgs/xZ/ShJ5hvrJpynjY2iq5QF
+XH27p8o1uq1ciyDLaDZiYLlYnRpp9TFU0D6bDyzNb64NF4tW+4+2GpXf1vDsEqV90hJ1+xICXv6f
+qZlqXApWbG5DxAWqB/nzWvszOhsmGFHev83qt4IJKgCmuoPOVFok/Ay1DHVvyzNJx0fkRGFmbepb
+mj6sL42Csr0AWIY0fY4POQgYORsQr42+hbSI/jCzUBGx8iIQx5Jp8FhjAt5BblYqEIwDkoQhXE35
+phm4pxNTweluETFGoKaHxsT0N4zAgIVaNmFFv8tEGw4VK0nu35LW//pXu56zpwxcGv8cDVk59Hkg
+4KH4rIik8eLYCylfgu/WYnTckCXEGr3V8QWQ/d3F8G7KN2+HieLvFtw5BxH5roMzoIUqsitFeDOx
+ylYNNeGC42NEeKorKtEKUlmFzJRRjvlfRI+BdD18ldRH/v2AWRTOqlU50i9CmZ+FAsDU3uhj3CHm
+slOnguHExYrfbMoUP/E/f+PZZrGBRcYM9gwkTEYOhmiZZqF2cs5Ykl4iRVrQ5S5/jPzPwsGWc9Rc
+d6j7/J5N0Jkh3AgP2bmaJVSnC7sIgAUiae8htNtmvAeozSYmDkKrYushZQ4cZjj/LshjRUN3fCwf
+2JcAOgMuODuHBJYv3/A+A6s+JlSvglZJp+9zDdr1hQgLsCjHQvaA1tFEIH3e++E1M5E7DxL1IZCu
++qfk+6baXodoaSImMjhsTZqvM8QB24+4YHfKLLRGF0R8izK1llLIKQFCWhxxLN5EYjE7XZI0uGJK
+95+rtN2hRmxVAWlLAMmRGOd5lv/GpiT8JWiscsW3rsr1b2Fk4vgyrw98ppbv+oNx+BuMxWisBTAY
+eBUaj4GMfDAukH4AaoINRgXx4l3PhKB/22ZxB3P2igC5ECg/jkfnWr8M23o2yNIOo87f390UAzaA
+YJmgR8KtfwVSXE/QY1vVpSSMzCxztJNXSnEOwIsvQCTFHlBSCl9xGkJYIgb/V3hEWcki6GGVE/jx
+H3WWkYspsx98O0WQXkaVSr93/oMzZ7xEwgwksWKPxxt7d2uBh7IpVeO14pJX41lePlgwyDrLbNsY
+G81MorqjqphxUSQplDvOiijg1kecacSYKJ2MBosx9lFrUjxQmyGQXGJllXoHQaYqLZFNoJ6jsNh1
+UmG3cYsyo/8MvJkWGDqEFqlSiNWpMVs+6FWtuTOEFOodycQqBy2MJZuU0IES0i2FXrMeGcYaGc/K
+UmusUNboG40QvOi9IYBq8D8Z0H/WMhZbKIaffxL/c5MpPrFiBTUXqs/ahtj/DoWZTvRd5o9M59/1
+j20on5aW8QfpQWBmlhlcTDniLvkuQZR/rTaydcIwjzPBpiNtVI3eXi/GEbmG47bgcQ==
+	]]>
+	<![CDATA[
+	JF4jIiF6nKc3vjMuva1WilJyQHPbZObfUtOjPqH7VirGb0ZYpGUf6oA0MX/IIPc3HmS0Xt12GNdf
+20VJG80f8SWjTYAHqu0E
+	]]>
+</i:aipgf>
 </svg>

--- a/images/architecture-public.svg
+++ b/images/architecture-public.svg
@@ -1,1411 +1,1983 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 1124.73 498">
-  <defs>
-    <linearGradient id="linear-gradient" x1="133.14" y1="156.76" x2="137.88" y2="152.02" gradientTransform="matrix(1, 0, 0, -1, 2.79, 298.66)" gradientUnits="userSpaceOnUse">
-      <stop offset="0" stop-color="#86d633"/>
-      <stop offset="1" stop-color="#5e9624"/>
-    </linearGradient>
-    <linearGradient id="linear-gradient-2" x1="144.34" y1="142.59" x2="149.07" y2="137.84" gradientTransform="matrix(1, 0, 0, -1, 0, 300.13)" xlink:href="#linear-gradient"/>
-    <linearGradient id="linear-gradient-3" x1="125.99" y1="142.59" x2="130.72" y2="137.86" gradientTransform="matrix(1, 0, 0, -1, 0, 300.13)" xlink:href="#linear-gradient"/>
-    <linearGradient id="linear-gradient-4" x1="199.55" y1="-123.11" x2="199.55" y2="-143.28" gradientTransform="matrix(1, 0, 0, -1, 0, 300.13)" gradientUnits="userSpaceOnUse">
-      <stop offset="0" stop-color="#5ea0ef"/>
-      <stop offset="0.18" stop-color="#559cec"/>
-      <stop offset="0.47" stop-color="#3c91e5"/>
-      <stop offset="0.84" stop-color="#1380da"/>
-      <stop offset="1" stop-color="#0078d4"/>
-    </linearGradient>
-    <linearGradient id="linear-gradient-5" x1="199.09" y1="-165.77" x2="201.45" y2="-168.14" gradientTransform="matrix(1, 0, 0, -1, 2.79, 299.63)" gradientUnits="userSpaceOnUse">
-      <stop offset="0" stop-color="#86d633"/>
-      <stop offset="0.24" stop-color="#83d232"/>
-      <stop offset="0.5" stop-color="#7cc52f"/>
-      <stop offset="0.76" stop-color="#6fb02a"/>
-      <stop offset="1" stop-color="#5e9624"/>
-    </linearGradient>
-    <linearGradient id="linear-gradient-6" x1="193.74" y1="-165.77" x2="196.1" y2="-168.14" xlink:href="#linear-gradient-5"/>
-    <linearGradient id="linear-gradient-7" x1="188.4" y1="-165.77" x2="190.76" y2="-168.14" xlink:href="#linear-gradient-5"/>
-    <linearGradient id="linear-gradient-8" x1="516.14" y1="-108.02" x2="518.51" y2="-110.38" xlink:href="#linear-gradient-5"/>
-    <linearGradient id="linear-gradient-9" x1="510.8" y1="-108.02" x2="513.15" y2="-110.38" xlink:href="#linear-gradient-5"/>
-    <linearGradient id="linear-gradient-10" x1="505.46" y1="-108.01" x2="507.82" y2="-110.38" xlink:href="#linear-gradient-5"/>
-    <linearGradient id="linear-gradient-11" x1="579.44" y1="-166.3" x2="581.81" y2="-168.67" xlink:href="#linear-gradient-5"/>
-    <linearGradient id="linear-gradient-12" x1="574.1" y1="-166.3" x2="576.45" y2="-168.67" xlink:href="#linear-gradient-5"/>
-    <linearGradient id="linear-gradient-13" x1="568.76" y1="-166.3" x2="571.11" y2="-168.67" xlink:href="#linear-gradient-5"/>
-    <linearGradient id="Teal_Gradient" data-name="Teal Gradient" x1="253.38" y1="-60.37" x2="253.38" y2="-32.18" gradientTransform="matrix(0.71, 0.71, 0.71, -0.71, 105.93, 134.1)" gradientUnits="userSpaceOnUse">
-      <stop offset="0" stop-color="#258378"/>
-      <stop offset="0.42" stop-color="#49a498"/>
-      <stop offset="0.78" stop-color="#60bbad"/>
-      <stop offset="1" stop-color="#68c2b5"/>
-    </linearGradient>
-    <radialGradient id="radial-gradient" cx="-5966.72" cy="-4993.12" r="30.05" gradientTransform="translate(3378.58 2855.08) scale(0.5)" gradientUnits="userSpaceOnUse">
-      <stop offset="0.18" stop-color="#699cd3"/>
-      <stop offset="1" stop-color="#2e76bc"/>
-    </radialGradient>
-    <radialGradient id="radial-gradient-2" cx="658.77" cy="236.06" r="11.32" gradientTransform="matrix(1, 0, 0, -1, 0, 300.13)" gradientUnits="userSpaceOnUse">
-      <stop offset="0" stop-color="#9f7db8"/>
-      <stop offset="0.21" stop-color="#9b7bb7"/>
-      <stop offset="0.43" stop-color="#9074b4"/>
-      <stop offset="0.65" stop-color="#8068ae"/>
-      <stop offset="0.88" stop-color="#6c5faa"/>
-      <stop offset="1" stop-color="#6059a7"/>
-    </radialGradient>
-    <linearGradient id="linear-gradient-14" x1="658.79" y1="242.13" x2="658.9" y2="228.75" gradientTransform="matrix(1, 0, 0, -1, 0, 300.13)" gradientUnits="userSpaceOnUse">
-      <stop offset="0" stop-color="#f2f2f3"/>
-      <stop offset="0.23" stop-color="#f2f1f2" stop-opacity="0.99"/>
-      <stop offset="0.37" stop-color="#ededf0" stop-opacity="0.95"/>
-      <stop offset="0.48" stop-color="#e7e5ef" stop-opacity="0.89"/>
-      <stop offset="0.58" stop-color="#dedbee" stop-opacity="0.81"/>
-      <stop offset="0.67" stop-color="#d4cee7" stop-opacity="0.7"/>
-      <stop offset="0.76" stop-color="#c4bdde" stop-opacity="0.57"/>
-      <stop offset="0.84" stop-color="#b5abd4" stop-opacity="0.41"/>
-      <stop offset="0.92" stop-color="#a094c7" stop-opacity="0.22"/>
-      <stop offset="0.99" stop-color="#877cba" stop-opacity="0.02"/>
-      <stop offset="1" stop-color="#847ab9" stop-opacity="0"/>
-    </linearGradient>
-    <radialGradient id="radial-gradient-3" cx="805.04" cy="233.15" r="15" gradientTransform="matrix(1, 0, 0, -1, 0, 300.13)" gradientUnits="userSpaceOnUse">
-      <stop offset="0.18" stop-color="#699cd3"/>
-      <stop offset="0.56" stop-color="#669cd3"/>
-      <stop offset="0.69" stop-color="#6198d1"/>
-      <stop offset="0.78" stop-color="#5793ce"/>
-      <stop offset="0.86" stop-color="#4a8cca"/>
-      <stop offset="0.93" stop-color="#3b83c5"/>
-      <stop offset="0.99" stop-color="#3078be"/>
-      <stop offset="1" stop-color="#2e76bc"/>
-    </radialGradient>
-    <radialGradient id="radial-gradient-4" cx="889.55" cy="41.57" r="17.44" gradientTransform="matrix(0.94, 0, 0, -0.94, -33.07, 104.13)" gradientUnits="userSpaceOnUse">
-      <stop offset="0.27" stop-color="#fed70a"/>
-      <stop offset="0.49" stop-color="#ffcc12"/>
-      <stop offset="0.88" stop-color="#fbac1d"/>
-      <stop offset="1" stop-color="#f9a120"/>
-    </radialGradient>
-    <radialGradient id="radial-gradient-5" cx="713.58" cy="238.18" r="14.91" gradientTransform="matrix(1.01, 0, 0, -1.01, 3.96, 307.1)" xlink:href="#radial-gradient-3"/>
-    <radialGradient id="radial-gradient-6" cx="785.35" cy="25.88" r="4.78" gradientTransform="matrix(0.95, 0, 0, -0.95, -21.4, 87.82)" gradientUnits="userSpaceOnUse">
-      <stop offset="0.19" stop-color="#8c8e90"/>
-      <stop offset="0.35" stop-color="#848688"/>
-      <stop offset="0.6" stop-color="#6e7071"/>
-      <stop offset="0.91" stop-color="#4a4b4d"/>
-      <stop offset="1" stop-color="#3e403f"/>
-    </radialGradient>
-    <linearGradient id="linear-gradient-15" x1="869.44" y1="219.41" x2="869.44" y2="246.9" gradientTransform="matrix(1, 0, 0, -1, 0, 300.13)" gradientUnits="userSpaceOnUse">
-      <stop offset="0" stop-color="#2e76bc"/>
-      <stop offset="0.06" stop-color="#3179be"/>
-      <stop offset="0.34" stop-color="#4288c8"/>
-      <stop offset="0.59" stop-color="#5693ce"/>
-      <stop offset="0.82" stop-color="#639bd2"/>
-      <stop offset="1" stop-color="#699cd3"/>
-    </linearGradient>
-    <radialGradient id="radial-gradient-7" cx="-5722.78" cy="-5563.55" r="34.06" xlink:href="#radial-gradient"/>
-    <linearGradient id="Green_Gradient_" data-name="Green Gradient " x1="632.6" y1="80.32" x2="632.6" y2="115.1" gradientTransform="matrix(1, 0, 0, -1, 0, 300.13)" gradientUnits="userSpaceOnUse">
-      <stop offset="0" stop-color="#5e9741"/>
-      <stop offset="0.02" stop-color="#5f9841"/>
-      <stop offset="1" stop-color="#76bc43"/>
-    </linearGradient>
-    <linearGradient id="linear-gradient-16" x1="841.36" y1="-50.1" x2="841.36" y2="-64.13" gradientTransform="matrix(1, 0, 0, -1, 0, 300.13)" gradientUnits="userSpaceOnUse">
-      <stop offset="0.22" stop-color="#50c8e9"/>
-      <stop offset="0.47" stop-color="#4ac7e9"/>
-      <stop offset="0.63" stop-color="#3bc4e7"/>
-      <stop offset="0.77" stop-color="#2abade"/>
-      <stop offset="0.89" stop-color="#21a5cb"/>
-      <stop offset="1" stop-color="#1b8ab3"/>
-    </linearGradient>
-    <linearGradient id="linear-gradient-17" x1="840.96" y1="-42.58" x2="841.99" y2="-55.32" xlink:href="#linear-gradient-16"/>
-    <linearGradient id="linear-gradient-18" x1="839.47" y1="-16.03" x2="839.47" y2="-34.37" xlink:href="#linear-gradient-4"/>
-    <linearGradient id="linear-gradient-19" x1="841.36" y1="104.9" x2="841.36" y2="90.87" xlink:href="#linear-gradient-16"/>
-    <linearGradient id="linear-gradient-20" x1="840.96" y1="112.42" x2="841.99" y2="99.68" xlink:href="#linear-gradient-16"/>
-    <linearGradient id="linear-gradient-21" x1="839.47" y1="138.97" x2="839.47" y2="120.63" xlink:href="#linear-gradient-4"/>
-    <linearGradient id="linear-gradient-22" x1="912.99" y1="-67.13" x2="935.61" y2="-67.13" gradientTransform="matrix(1, 0, 0, -1, 0, 300.13)" gradientUnits="userSpaceOnUse">
-      <stop offset="0" stop-color="#005ca1"/>
-      <stop offset="0.07" stop-color="#0161aa"/>
-      <stop offset="0.36" stop-color="#2571b8"/>
-      <stop offset="0.52" stop-color="#2e76bc"/>
-      <stop offset="0.64" stop-color="#2973ba"/>
-      <stop offset="0.82" stop-color="#166bb5"/>
-      <stop offset="1" stop-color="#005ca1"/>
-    </linearGradient>
-    <linearGradient id="linear-gradient-23" x1="795.47" y1="25.19" x2="795.47" y2="-14.81" gradientTransform="matrix(1, 0, 0, -1, 0, 300.13)" gradientUnits="userSpaceOnUse">
-      <stop offset="0" stop-color="#008bf1"/>
-      <stop offset="0.22" stop-color="#0086ec"/>
-      <stop offset="0.49" stop-color="#0078dd"/>
-      <stop offset="0.79" stop-color="#0061c4"/>
-      <stop offset="1" stop-color="#004dae"/>
-    </linearGradient>
-    <linearGradient id="linear-gradient-24" x1="798.65" y1="7.41" x2="811.47" y2="7.41" gradientTransform="matrix(1, 0, 0, -1, 0, 300.13)" gradientUnits="userSpaceOnUse">
-      <stop offset="0" stop-opacity="0.64"/>
-      <stop offset="0.57" stop-opacity="0.22"/>
-      <stop offset="1" stop-color="#fff" stop-opacity="0"/>
-    </linearGradient>
-    <linearGradient id="linear-gradient-25" x1="799.95" y1="8.08" x2="815.47" y2="8.08" gradientTransform="matrix(1, 0, 0, -1, 0, 300.13)" gradientUnits="userSpaceOnUse">
-      <stop offset="0" stop-color="#00315c"/>
-      <stop offset="0.79" stop-color="#0080e5"/>
-    </linearGradient>
-    <linearGradient id="linear-gradient-26" x1="790.99" y1="8.08" x2="775.47" y2="8.08" xlink:href="#linear-gradient-25"/>
-    <linearGradient id="linear-gradient-27" x1="799.95" y1="2.3" x2="815.47" y2="2.3" gradientTransform="matrix(1, 0, 0, -1, 0, 300.13)" gradientUnits="userSpaceOnUse">
-      <stop offset="0" stop-color="#00315c"/>
-      <stop offset="0.58" stop-color="#0e71c7"/>
-      <stop offset="1" stop-color="#0a75d5"/>
-    </linearGradient>
-    <linearGradient id="linear-gradient-28" x1="790.99" y1="2.3" x2="775.47" y2="2.3" xlink:href="#linear-gradient-27"/>
-    <linearGradient id="linear-gradient-29" x1="792.58" y1="9.64" x2="792.58" y2="23.21" gradientTransform="matrix(1, 0, 0, -1, 0, 300.13)" gradientUnits="userSpaceOnUse">
-      <stop offset="0" stop-color="#00315c"/>
-      <stop offset="0.79" stop-color="#008af0"/>
-    </linearGradient>
-    <linearGradient id="linear-gradient-30" x1="798.36" y1="9.64" x2="798.36" y2="23.21" xlink:href="#linear-gradient-29"/>
-    <linearGradient id="linear-gradient-31" x1="798.36" y1="0.3" x2="798.36" y2="-15" gradientTransform="matrix(1, 0, 0, -1, 0, 300.13)" gradientUnits="userSpaceOnUse">
-      <stop offset="0" stop-color="#00294f"/>
-      <stop offset="0.7" stop-color="#005ba6"/>
-      <stop offset="0.83" stop-color="#0457ac"/>
-      <stop offset="1" stop-color="#0050b2"/>
-    </linearGradient>
-    <linearGradient id="linear-gradient-32" x1="792.58" y1="0.3" x2="792.58" y2="-15" xlink:href="#linear-gradient-31"/>
-    <linearGradient id="linear-gradient-33" x1="254.1" y1="72.62" x2="254.1" y2="96.1" gradientTransform="matrix(1, 0, 0, -1, 0, 300.13)" gradientUnits="userSpaceOnUse">
-      <stop offset="0" stop-color="#2e76bc"/>
-      <stop offset="0.82" stop-color="#699cd3"/>
-    </linearGradient>
-    <linearGradient id="Teal_Gradient-2" x1="394.82" y1="66.59" x2="394.82" y2="94.78" gradientTransform="matrix(0.71, 0.71, 0.71, -0.71, 57.58, -3.1)" xlink:href="#Teal_Gradient"/>
-    <linearGradient id="linear-gradient-34" x1="394.04" y1="452.24" x2="394.04" y2="482.09" gradientTransform="matrix(1, 0, 0, -1, 564, 534.13)" gradientUnits="userSpaceOnUse">
-      <stop offset="0" stop-color="#0078d4"/>
-      <stop offset="0.16" stop-color="#1380da"/>
-      <stop offset="0.53" stop-color="#3c91e5"/>
-      <stop offset="0.82" stop-color="#559cec"/>
-      <stop offset="1" stop-color="#5ea0ef"/>
-    </linearGradient>
-    <linearGradient id="linear-gradient-35" x1="52.83" y1="63.03" x2="52.83" y2="91.22" gradientTransform="matrix(0.71, 0.71, 0.71, -0.71, -40.07, 239.77)" gradientUnits="userSpaceOnUse">
-      <stop offset="0" stop-color="#258277"/>
-      <stop offset="0.42" stop-color="#49a498"/>
-      <stop offset="0.78" stop-color="#60baad"/>
-      <stop offset="1" stop-color="#68c2b5"/>
-    </linearGradient>
-    <linearGradient id="linear-gradient-36" x1="13.29" y1="-147.6" x2="13.29" y2="-172.6" xlink:href="#linear-gradient-4"/>
-    <linearGradient id="linear-gradient-37" x1="77.1" y1="-30.67" x2="69.19" y2="-15.68" gradientTransform="matrix(1, 0, 0, -1, 0, 300.13)" gradientUnits="userSpaceOnUse">
-      <stop offset="0" stop-color="#3085c7"/>
-      <stop offset="0.9" stop-color="#5fabdf"/>
-    </linearGradient>
-    <linearGradient id="linear-gradient-38" x1="73.69" y1="-26.31" x2="79.16" y2="-35.75" gradientTransform="matrix(1, 0, 0, -1, 0, 300.13)" gradientUnits="userSpaceOnUse">
-      <stop offset="0.1" stop-color="#5fabdf"/>
-      <stop offset="0.29" stop-color="#5aa8dd"/>
-      <stop offset="0.51" stop-color="#4da0d8"/>
-      <stop offset="0.74" stop-color="#3b90ce"/>
-      <stop offset="0.88" stop-color="#3085c7"/>
-    </linearGradient>
-    <linearGradient id="linear-gradient-39" x1="36.12" y1="21.32" x2="36.12" y2="-1.91" gradientTransform="matrix(1, 0, 0, -1, 0, 300.13)" gradientUnits="userSpaceOnUse">
-      <stop offset="0" stop-color="#b3b2b4"/>
-      <stop offset="0.38" stop-color="#b0aeaf"/>
-      <stop offset="0.76" stop-color="#a2a1a1"/>
-      <stop offset="1" stop-color="#979797"/>
-    </linearGradient>
-    <linearGradient id="linear-gradient-40" x1="38.26" y1="-0.53" x2="48.99" y2="-0.53" xlink:href="#linear-gradient-22"/>
-    <linearGradient id="linear-gradient-41" x1="43.92" y1="-76.62" x2="43.92" y2="-50.18" gradientTransform="matrix(1, 0, 0, -1, 0, 300.13)" gradientUnits="userSpaceOnUse">
-      <stop offset="0.05" stop-color="#949494"/>
-      <stop offset="0.36" stop-color="#979797"/>
-      <stop offset="0.54" stop-color="#9f9e9e"/>
-      <stop offset="0.69" stop-color="#aeadae"/>
-      <stop offset="0.73" stop-color="#b3b4b4"/>
-    </linearGradient>
-    <linearGradient id="linear-gradient-42" x1="51.67" y1="-58.77" x2="51.67" y2="-80.06" gradientTransform="matrix(1, 0, 0, -1, 0, 300.13)" xlink:href="#radial-gradient"/>
-    <radialGradient id="radial-gradient-8" cx="828.06" cy="-28.07" r="10.55" gradientTransform="matrix(1.04, 0, 0, -1.03, 120.65, 336.15)" xlink:href="#radial-gradient"/>
-    <clipPath id="clip-path">
-      <path d="M993.3,362.6a10.89,10.89,0,1,1-13.17-8,10.88,10.88,0,0,1,13.17,8Z" fill="none"/>
-    </clipPath>
-  </defs>
-  <g id="Shapes">
-    <rect x="0.25" y="0.25" width="1124.23" height="497.5" fill="#fff" stroke="#fff" stroke-width="0.5"/>
-    <g>
-      <g>
-        <rect x="556.04" y="140.4" width="563.2" height="326.26" rx="4" fill="#fff"/>
-        <rect x="556.04" y="140.4" width="563.2" height="326.26" rx="4" fill="#505150" opacity="0.07"/>
-        <rect x="556.04" y="140.4" width="563.2" height="326.26" rx="4" fill="none" stroke="#505150" opacity="0.15"/>
-      </g>
-      <path d="M1115.25,467.16h-.12v-1h.11a3.83,3.83,0,0,0,.6-.05l.17,1A3.84,3.84,0,0,1,1115.25,467.16Zm-2.12,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.79,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.79,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.79v-1h.79Zm-2.79,0H992v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0H978v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0H964v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0H950v-1h.79Zm-2.79,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0H936v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0H922v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0H908v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.79,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0H894v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0H880v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0H866v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.79,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0H852v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0H838v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0H824v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.79,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0H810v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0H796v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0H782v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.79v-1h.79Zm-2.79,0h-.8v-1h.8Zm-2.8,0H768v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0H754v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0H740v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.79,0h-.8v-1h.8Zm-2.8,0H726v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0H712v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0H698v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.79,0h-.8v-1h.8Zm-2.8,0H684v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0H670v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0H656v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.79,0H642v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0H628v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0H614v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.79v-1h.79Zm-2.79,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-30.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.93-.2a4.93,4.93,0,0,1-.82-.35l.48-.88a3,3,0,0,0,.64.27Zm559.32-.78-.62-.78a3.86,3.86,0,0,0,.5-.49l.76.64A4.76,4.76,0,0,1,1118,466.18ZM556.27,465.1a3.78,3.78,0,0,1-.41-.8l.93-.37a2.8,2.8,0,0,0,.32.62Zm563.39-1.55-1-.2a3.17,3.17,0,0,0,.07-.69l1-.05v.05A5.26,5.26,0,0,1,1119.66,463.55Zm-563.12-1.4h-1v-.8h1Zm563.2-1.54h-1v-.8h1Zm-563.2-1.26h-1v-.8h1Zm563.2-1.54h-1V457h1Zm-563.2-1.26h-1v-.8h1Zm563.2-1.53h-1v-.8h1Zm-563.2-1.27h-1V453h1Zm563.2-1.53h-1v-.8h1ZM556.54,451h-1v-.8h1Zm563.2-1.53h-1v-.8h1Zm-563.2-1.27h-1v-.79h1Zm563.2-1.53h-1v-.8h1Zm-563.2-1.26h-1v-.8h1Zm563.2-1.54h-1V443h1Zm-563.2-1.26h-1v-.8h1Zm563.2-1.54h-1v-.8h1Zm-563.2-1.26h-1V439h1Zm563.2-1.54h-1v-.8h1ZM556.54,437h-1v-.8h1Zm563.2-1.54h-1v-.8h1Zm-563.2-1.26h-1v-.8h1Zm563.2-1.54h-1v-.8h1Zm-563.2-1.26h-1v-.8h1Zm563.2-1.54h-1V429h1Zm-563.2-1.26h-1v-.8h1Zm563.2-1.54h-1v-.8h1Zm-563.2-1.26h-1V425h1Zm563.2-1.54h-1v-.8h1ZM556.54,423h-1v-.8h1Zm563.2-1.54h-1v-.8h1Zm-563.2-1.26h-1v-.8h1Zm563.2-1.54h-1v-.8h1Zm-563.2-1.26h-1v-.8h1Zm563.2-1.54h-1V415h1Zm-563.2-1.26h-1v-.8h1Zm563.2-1.54h-1v-.8h1Zm-563.2-1.26h-1V411h1Zm563.2-1.53h-1v-.8h1ZM556.54,409h-1v-.8h1Zm563.2-1.53h-1v-.8h1Zm-563.2-1.27h-1v-.8h1Zm563.2-1.53h-1v-.8h1Zm-563.2-1.26h-1v-.8h1Zm563.2-1.54h-1V401h1Zm-563.2-1.26h-1v-.8h1Zm563.2-1.54h-1v-.8h1Zm-563.2-1.26h-1V397h1Zm563.2-1.54h-1v-.8h1ZM556.54,395h-1v-.8h1Zm563.2-1.54h-1v-.8h1Zm-563.2-1.26h-1v-.8h1Zm563.2-1.54h-1v-.8h1Zm-563.2-1.26h-1v-.8h1Zm563.2-1.54h-1V387h1Zm-563.2-1.26h-1v-.8h1Zm563.2-1.54h-1v-.8h1Zm-563.2-1.26h-1V383h1Zm563.2-1.54h-1v-.8h1ZM556.54,381h-1v-.8h1Zm563.2-1.54h-1v-.8h1Zm-563.2-1.26h-1v-.8h1Zm563.2-1.54h-1v-.8h1Zm-563.2-1.26h-1v-.8h1Zm563.2-1.54h-1V373h1Zm-563.2-1.26h-1v-.8h1Zm563.2-1.54h-1v-.8h1Zm-563.2-1.26h-1V369h1Zm563.2-1.54h-1v-.79h1ZM556.54,367h-1v-.8h1Zm563.2-1.53h-1v-.8h1Zm-563.2-1.27h-1v-.8h1Zm563.2-1.53h-1v-.8h1Zm-563.2-1.27h-1v-.8h1Zm563.2-1.53h-1V359h1Zm-563.2-1.26h-1v-.8h1Zm563.2-1.54h-1v-.8h1Zm-563.2-1.26h-1V355h1Zm563.2-1.54h-1v-.8h1ZM556.54,353h-1v-.8h1Zm563.2-1.54h-1v-.8h1Zm-563.2-1.26h-1v-.8h1Zm563.2-1.54h-1v-.8h1Zm-563.2-1.26h-1v-.8h1Zm563.2-1.54h-1V345h1Zm-563.2-1.26h-1v-.8h1Zm563.2-1.54h-1v-.8h1Zm-563.2-1.26h-1V341h1Zm563.2-1.54h-1v-.8h1ZM556.54,339h-1v-.8h1Zm563.2-1.54h-1v-.8h1Zm-563.2-1.26h-1v-.8h1Zm563.2-1.54h-1v-.8h1Zm-563.2-1.26h-1v-.8h1Zm563.2-1.54h-1V331h1Zm-563.2-1.26h-1v-.8h1Zm563.2-1.54h-1v-.8h1Zm-563.2-1.26h-1V327h1Zm563.2-1.54h-1v-.8h1ZM556.54,325h-1v-.8h1Zm563.2-1.54h-1v-.79h1Zm-563.2-1.26h-1v-.8h1Zm563.2-1.53h-1v-.8h1Zm-563.2-1.27h-1v-.8h1Zm563.2-1.53h-1v-.8h1Zm-563.2-1.26h-1v-.8h1Zm563.2-1.54h-1v-.8h1Zm-563.2-1.26h-1V313h1Zm563.2-1.54h-1v-.8h1ZM556.54,311h-1v-.8h1Zm563.2-1.54h-1v-.8h1Zm-563.2-1.26h-1v-.8h1Zm563.2-1.54h-1v-.8h1Zm-563.2-1.26h-1v-.8h1Zm563.2-1.54h-1v-.8h1Zm-563.2-1.26h-1v-.8h1Zm563.2-1.54h-1v-.8h1Zm-563.2-1.26h-1V299h1Zm563.2-1.54h-1v-.8h1ZM556.54,297h-1v-.8h1Zm563.2-1.54h-1v-.8h1Zm-563.2-1.26h-1v-.8h1Zm563.2-1.54h-1v-.8h1Zm-563.2-1.26h-1v-.8h1Zm563.2-1.54h-1v-.8h1Zm-563.2-1.26h-1v-.8h1Zm563.2-1.54h-1v-.8h1Zm-563.2-1.26h-1V285h1Zm563.2-1.54h-1v-.8h1ZM556.54,283h-1v-.8h1Zm563.2-1.54h-1v-.8h1Zm-563.2-1.26h-1v-.8h1Zm563.2-1.54h-1v-.79h1Zm-563.2-1.26h-1v-.8h1Zm563.2-1.53h-1v-.8h1Zm-563.2-1.27h-1v-.8h1Zm563.2-1.53h-1v-.8h1Zm-563.2-1.26h-1V271h1Zm563.2-1.54h-1v-.8h1ZM556.54,269h-1v-.8h1Zm563.2-1.54h-1v-.8h1Zm-563.2-1.26h-1v-.8h1Zm563.2-1.54h-1v-.8h1Zm-563.2-1.26h-1v-.8h1Zm563.2-1.54h-1v-.8h1Zm-563.2-1.26h-1v-.8h1Zm563.2-1.54h-1v-.8h1Zm-563.2-1.26h-1V257h1Zm563.2-1.54h-1v-.8h1ZM556.54,255h-1v-.8h1Zm563.2-1.54h-1v-.8h1Zm-563.2-1.26h-1v-.8h1Zm563.2-1.54h-1v-.8h1Zm-563.2-1.26h-1v-.8h1Zm563.2-1.54h-1v-.8h1Zm-563.2-1.26h-1v-.8h1Zm563.2-1.54h-1v-.8h1Zm-563.2-1.26h-1V243h1Zm563.2-1.54h-1v-.8h1ZM556.54,241h-1v-.8h1Zm563.2-1.54h-1v-.8h1Zm-563.2-1.26h-1v-.8h1Zm563.2-1.54h-1v-.8h1Zm-563.2-1.26h-1v-.8h1Zm563.2-1.54h-1v-.79h1Zm-563.2-1.26h-1v-.8h1Zm563.2-1.53h-1v-.8h1Zm-563.2-1.27h-1V229h1Zm563.2-1.53h-1v-.8h1ZM556.54,227h-1v-.8h1Zm563.2-1.54h-1v-.8h1Zm-563.2-1.26h-1v-.8h1Zm563.2-1.54h-1v-.8h1Zm-563.2-1.26h-1v-.8h1Zm563.2-1.54h-1v-.8h1Zm-563.2-1.26h-1v-.8h1Zm563.2-1.54h-1v-.8h1Zm-563.2-1.26h-1V215h1Zm563.2-1.54h-1v-.8h1ZM556.54,213h-1v-.8h1Zm563.2-1.54h-1v-.8h1Zm-563.2-1.26h-1v-.8h1Zm563.2-1.54h-1v-.8h1Zm-563.2-1.26h-1v-.8h1Zm563.2-1.54h-1v-.8h1Zm-563.2-1.26h-1v-.8h1Zm563.2-1.54h-1v-.8h1Zm-563.2-1.26h-1V201h1Zm563.2-1.54h-1v-.8h1ZM556.54,199h-1v-.8h1Zm563.2-1.54h-1v-.8h1Zm-563.2-1.26h-1v-.8h1Zm563.2-1.54h-1v-.8h1Zm-563.2-1.26h-1v-.8h1Zm563.2-1.54h-1v-.8h1Zm-563.2-1.26h-1v-.8h1Zm563.2-1.54h-1v-.8h1Zm-563.2-1.26h-1V187h1Zm563.2-1.53h-1v-.8h1ZM556.54,185h-1v-.8h1Zm563.2-1.54h-1v-.8h1Zm-563.2-1.26h-1v-.8h1Zm563.2-1.54h-1v-.8h1Zm-563.2-1.26h-1v-.8h1Zm563.2-1.54h-1v-.8h1Zm-563.2-1.26h-1v-.8h1Zm563.2-1.54h-1v-.8h1Zm-563.2-1.26h-1V173h1Zm563.2-1.54h-1v-.8h1ZM556.54,171h-1v-.8h1Zm563.2-1.54h-1v-.8h1Zm-563.2-1.26h-1v-.8h1Zm563.2-1.54h-1v-.8h1Zm-563.2-1.26h-1v-.8h1Zm563.2-1.54h-1v-.8h1Zm-563.2-1.26h-1v-.8h1Zm563.2-1.54h-1v-.8h1Zm-563.2-1.26h-1V159h1Zm563.2-1.54h-1v-.8h1ZM556.54,157h-1v-.8h1Zm563.2-1.54h-1v-.8h1Zm-563.2-1.26h-1v-.8h1Zm563.2-1.54h-1v-.8h1Zm-563.2-1.26h-1v-.8h1Zm563.2-1.54h-1v-.8h1Zm-563.2-1.26h-1v-.8h1Zm563.2-1.53h-1v-.81h1Zm-563.2-1.27h-1V145h1Zm562.2-1.52a2.67,2.67,0,0,0-.09-.69l1-.23a5.28,5.28,0,0,1,.11.89Zm-562-1.08-.94-.34a4.31,4.31,0,0,1,.39-.81l.85.52A3.64,3.64,0,0,0,556.75,143.22Zm561.1-1.15a3.79,3.79,0,0,0-.51-.47l.59-.8a4.29,4.29,0,0,1,.67.61Zm-559.56-.69-.51-.87a5,5,0,0,1,.82-.37l.32,1A3,3,0,0,0,558.29,141.38Zm557.45-.44a2.74,2.74,0,0,0-.5,0H1115v-1h.23a4.48,4.48,0,0,1,.64,0Zm-2.73,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.79,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.79,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.79,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0H989v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0H975v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.79,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.79,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.79,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.79v-1h.79Zm-2.79,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.79v-1h.79Zm-2.79,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.79v-1h.79Zm-2.79,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.79,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.79,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.79,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.79,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Zm-2.8,0h-.8v-1h.8Z" fill="#505150" opacity="0.65"/>
-    </g>
-    <g>
-      <g>
-        <rect x="175.79" y="140.53" width="297" height="326" rx="4" fill="#fff"/>
-        <rect x="175.79" y="140.53" width="297" height="326" rx="4" fill="#505150" opacity="0.07"/>
-        <rect x="175.79" y="140.53" width="297" height="326" rx="4" fill="none" stroke="#505150" stroke-width="0.8" opacity="0.15"/>
-      </g>
-      <path d="M468.79,466.93h-.11v-.8h.11a4.07,4.07,0,0,0,.61-.05l.14.79A4.74,4.74,0,0,1,468.79,466.93Zm-2.11,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.79,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.79,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.79v-.8h.79Zm-2.79,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.79,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.79,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.79v-.8h.79Zm-2.79,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.79,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0H396v-.8h.8Zm-2.79,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.79,0H382v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.79,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0H368v-.8h.8Zm-2.79,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.79,0H354v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.79,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0H340v-.8h.8Zm-2.8,0h-.79v-.8H338Zm-2.79,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.79v-.8h.79Zm-2.79,0H326v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.79,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0H312v-.8h.8Zm-2.8,0h-.79v-.8H310Zm-2.79,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.79,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.79,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.79v-.8h.79Zm-2.79,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.79,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.79,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.79,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.79,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.79,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.79,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.79,0h-.8v-.8h.8Zm-33.57,0h-.8v-.8h.8Zm-2.9-.2a4,4,0,0,1-.8-.34l.38-.7a4.21,4.21,0,0,0,.66.28Zm293-.76-.5-.62a3.58,3.58,0,0,0,.52-.51l.61.52A4,4,0,0,1,471.52,466ZM176.09,464.9a3.59,3.59,0,0,1-.4-.78l.74-.29a3.51,3.51,0,0,0,.33.64Zm297-1.5-.78-.16a4.17,4.17,0,0,0,.07-.71l.8,0v0A4.21,4.21,0,0,1,473.1,463.4ZM176.19,462h-.8v-.79h.8Zm297-1.52h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.52h-.8v-.8h.8Zm-297-1.27h-.8V450h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.79h.8Zm-297-1.26h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8V436h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.79h.8Zm297-1.52h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.52h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.79h.8Zm-297-1.26h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.79h.8Zm297-1.52h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8V401h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.52h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8V387h.8Zm-297-1.26h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.79h.8Zm297-1.52h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8V373h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.52h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8V359h.8Zm-297-1.27h-.8v-.79h.8Zm297-1.52h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.79h.8Zm297-1.52h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8V345h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.79h.8Zm-297-1.26h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8V331h.8Zm-297-1.27h-.8v-.79h.8Zm297-1.52h-.8v-.8h.8Zm-297-1.27h-.8V327h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.52h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8V317h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8V313h.8Zm297-1.53h-.8v-.79h.8Zm-297-1.26h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.79h.8Zm297-1.52h-.8v-.8h.8Zm-297-1.27h-.8V299h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.52h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8V285h.8Zm297-1.53h-.8v-.79h.8Zm-297-1.26h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.79h.8Zm297-1.52h-.8v-.8h.8Zm-297-1.27h-.8V271h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.79h.8Zm-297-1.26h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8V257h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.26h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.52h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.79h.8Zm-297-1.26h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.26h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.52h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8V208h.8Zm-297-1.26h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.79h.8Zm297-1.52h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8V194h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.52h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8V180h.8Zm-297-1.26h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.79h.8Zm297-1.52h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8V166h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.52h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm297-1.53h-.8V152h.8Zm-297-1.27h-.8v-.79h.8Zm297-1.52h-.8v-.8h.8Zm-297-1.27h-.8V148h.8Zm297-1.53h-.8v-.8h.8Zm-297-1.27h-.8v-.8h.8Zm296.2-1.52a4.18,4.18,0,0,0-.09-.71l.78-.18a5,5,0,0,1,.11.87Zm-296-1.11-.75-.28a4.09,4.09,0,0,1,.38-.79l.68.42A3,3,0,0,0,176.4,143.32Zm295.08-1.18a3.43,3.43,0,0,0-.53-.48l.48-.64a4,4,0,0,1,.64.59ZM178,141.42l-.41-.69a5.23,5.23,0,0,1,.8-.37l.26.76A4.22,4.22,0,0,0,178,141.42ZM469.31,141a3,3,0,0,0-.52,0h-.22v-.8h.22a4.34,4.34,0,0,1,.63.05Zm-2.74,0h-.8v-.8h.8Zm-2.8,0H463v-.8h.8Zm-2.79,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.79,0h-.8v-.8h.8Zm-2.8,0H449v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.79v-.8h.79Zm-2.79,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0H435v-.8h.8Zm-2.79,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.79,0h-.8v-.8h.8Zm-2.8,0H421v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.79v-.8h.79Zm-2.79,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0H407v-.8h.8Zm-2.79,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.79,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.79v-.8h.79Zm-2.79,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.79,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.79v-.8h.79Zm-2.79,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.79,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.79,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.79,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.79,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.79,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.79v-.8h.79Zm-2.79,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.79,0h-.8v-.8h.8Zm-2.8,0H298v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.79,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0H284v-.8h.8Zm-2.79,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.79,0h-.8v-.8h.8Zm-2.8,0H270v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.79,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0H256v-.8h.79Zm-2.79,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.79,0h-.8v-.8h.8Zm-2.8,0H242v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.79v-.8h.79Zm-2.79,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0H228v-.8h.8Zm-2.79,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.79,0h-.8v-.8h.8Zm-2.8,0H214v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.79,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.79,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.79,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.8v-.8h.8Zm-2.8,0h-.79v-.8h.79Z" fill="#505150" opacity="0.65"/>
-    </g>
-    <g>
-      <g>
-        <line x1="574.86" y1="210.83" x2="323.12" y2="209.83" fill="none" stroke="#207067" stroke-miterlimit="10" stroke-width="3"/>
-        <polygon points="313.59 209.79 327.05 204.35 323.84 209.83 327 215.33 313.59 209.79" fill="#207067"/>
-      </g>
-      <line x1="574.86" y1="210.83" x2="323.12" y2="209.83" fill="none" stroke="#42e8ca" stroke-miterlimit="10" stroke-width="1.5" stroke-dasharray="4 2"/>
-    </g>
-    <g>
-      <rect x="437.77" y="6.46" width="157.75" height="52.96" fill="#fff"/>
-      <rect x="437.77" y="6.46" width="157.75" height="52.96" fill="#83b9f9" opacity="0.15"/>
-      <path d="M595.39,6.58V59.29H437.89V6.58h157.5m.25-.25h-158V59.54h158V6.33Z" fill="#83b9f9"/>
-    </g>
-    <g>
-      <rect x="921.37" y="6.46" width="197.75" height="114.15" fill="#fff"/>
-      <rect x="921.37" y="6.46" width="197.75" height="114.15" fill="#83b9f9" opacity="0.15"/>
-      <path d="M1119,6.58v113.9H921.49V6.58H1119m.25-.25h-198v114.4h198V6.33Z" fill="#83b9f9"/>
-    </g>
-    <g>
-      <rect x="771.77" y="6.46" width="136.15" height="114.35" fill="#fff"/>
-      <rect x="771.77" y="6.46" width="136.15" height="114.35" fill="#83b9f9" opacity="0.15"/>
-      <path d="M907.79,6.58v114.1H771.89V6.58h135.9m.25-.25H771.64v114.6H908V6.33Z" fill="#83b9f9"/>
-    </g>
-    <g>
-      <rect x="622.17" y="6.46" width="136.15" height="114.35" fill="#fff"/>
-      <rect x="622.17" y="6.46" width="136.15" height="114.35" fill="#83b9f9" opacity="0.15"/>
-      <path d="M758.19,6.58v114.1H622.29V6.58h135.9m.25-.25H622v114.6h136.4V6.33Z" fill="#83b9f9"/>
-    </g>
-    <g>
-      <line x1="124.31" y1="152.23" x2="106.67" y2="152.23" fill="none" stroke="#3c3c41" stroke-miterlimit="10"/>
-      <polygon points="107.76 148.49 101.29 152.23 107.76 155.97 107.76 148.49" fill="#3c3c41"/>
-    </g>
-    <g>
-      <line x1="166.3" y1="152.23" x2="149.31" y2="152.23" fill="none" stroke="#3c3c41" stroke-miterlimit="10"/>
-      <polygon points="165.21 148.49 171.69 152.23 165.21 155.97 165.21 148.49" fill="#3c3c41"/>
-    </g>
-    <g>
-      <rect x="126.84" y="150.8" width="13.21" height="2.75" transform="translate(-65.07 191.66) rotate(-60)" fill="#a67af4"/>
-      <rect x="141.07" y="145.79" width="2.75" height="13.21" transform="translate(-57.11 91.64) rotate(-30)" fill="#a67af4"/>
-      <rect x="131.24" y="158.79" width="13.21" height="2.75" fill="#773adc"/>
-      <circle cx="138.09" cy="144.08" r="3.35" fill="url(#linear-gradient)"/>
-      <circle cx="147.16" cy="160.38" r="3.35" fill="url(#linear-gradient-2)"/>
-      <circle cx="128.83" cy="160.38" r="3.35" fill="url(#linear-gradient-3)"/>
-    </g>
-    <g>
-      <line x1="496.59" y1="406.51" x2="478.47" y2="406.51" fill="none" stroke="#3c3c41" stroke-miterlimit="10"/>
-      <polygon points="479.56 402.77 473.09 406.51 479.56 410.25 479.56 402.77" fill="#3c3c41"/>
-    </g>
-    <g>
-      <line x1="551.3" y1="406.51" x2="534.69" y2="406.51" fill="none" stroke="#3c3c41" stroke-miterlimit="10"/>
-      <polygon points="550.21 402.77 556.69 406.51 550.21 410.25 550.21 402.77" fill="#3c3c41"/>
-    </g>
-    <g>
-      <line x1="871.86" y1="371.17" x2="855.24" y2="371.17" fill="none" stroke="#3c3c41" stroke-miterlimit="10"/>
-      <polygon points="870.77 367.43 877.24 371.17 870.77 374.91 870.77 367.43" fill="#3c3c41"/>
-    </g>
-    <g>
-      <rect x="194.79" y="153.93" width="117.54" height="124.1" fill="#fff"/>
-      <rect x="194.79" y="153.93" width="117.54" height="124.1" fill="#cccccb" opacity="0.7"/>
-    </g>
-    <g>
-      <path d="M208.52,432.6c0,5.91-7.15,10.68-8.7,11.64a.57.57,0,0,1-.59,0c-1.55-1-8.7-5.73-8.7-11.64v-7.12a.56.56,0,0,1,.55-.56c5.56-.15,4.28-2.59,8.45-2.59s2.88,2.44,8.44,2.59a.56.56,0,0,1,.55.56Z" fill="#0078d4"/>
-      <path d="M207.78,432.66c0,5.42-6.55,9.78-8,10.68a.52.52,0,0,1-.54,0c-1.43-.88-8-5.26-8-10.68v-6.53a.5.5,0,0,1,.5-.51c5.09-.14,3.92-2.38,7.75-2.38s2.65,2.24,7.75,2.38a.51.51,0,0,1,.5.51Z" fill="#6bb9f2"/>
-      <path d="M199.53,433.33V423.24c3.82,0,2.65,2.24,7.75,2.38a.52.52,0,0,1,.5.52v6.53q0,.33,0,.66Zm0,0h-8.22c.49,5.11,6.58,9.17,7.95,10a.41.41,0,0,0,.22.07h.05Z" fill="url(#linear-gradient-4)"/>
-      <path d="M191.78,425.62c5.09-.14,3.92-2.38,7.75-2.38v10.09h-8.22q0-.33,0-.66v-6.53A.52.52,0,0,1,191.78,425.62Z" fill="#50e6ff"/>
-      <path d="M207.74,433.33h-8.21v10.08h0a.47.47,0,0,0,.22-.07C201.16,442.5,207.25,438.44,207.74,433.33Z" fill="#50e6ff"/>
-    </g>
-    <g>
-      <circle cx="203.29" cy="466.3" r="1.67" fill="url(#linear-gradient-5)"/>
-      <circle cx="197.95" cy="466.31" r="1.67" fill="url(#linear-gradient-6)"/>
-      <circle cx="192.6" cy="466.31" r="1.67" fill="url(#linear-gradient-7)"/>
-      <path d="M193.82,473l-1,1a.43.43,0,0,1-.61,0h0l-7.1-7.07a.87.87,0,0,1,0-1.23h0l1-1h0l7.71,7.69a.43.43,0,0,1,0,.61Z" fill="#50e6ff"/>
-      <path d="M192.72,458.67l1,1a.43.43,0,0,1,0,.61l-7.58,7.6h0l-1-1a.86.86,0,0,1,0-1.22h0l7-7A.44.44,0,0,1,192.72,458.67Z" fill="#1490df"/>
-      <path d="M209.67,464.7l1,1a.87.87,0,0,1,0,1.22h0L203.53,474a.43.43,0,0,1-.61,0h0l-1-1a.43.43,0,0,1,0-.61h0l7.71-7.69Z" fill="#50e6ff"/>
-      <path d="M210.62,466.87l-1,1h0l-7.57-7.6a.43.43,0,0,1,0-.61h0l1-1a.44.44,0,0,1,.61,0h0l7,7a.86.86,0,0,1,0,1.22h0Z" fill="#1490df"/>
-    </g>
-    <g>
-      <circle cx="520.27" cy="408.1" r="1.67" fill="url(#linear-gradient-8)"/>
-      <circle cx="514.92" cy="408.11" r="1.67" fill="url(#linear-gradient-9)"/>
-      <circle cx="509.58" cy="408.11" r="1.67" fill="url(#linear-gradient-10)"/>
-      <path d="M510.8,414.81l-1,1a.43.43,0,0,1-.61,0h0l-7.1-7.07a.87.87,0,0,1,0-1.23h0l1-1h0l7.71,7.69a.43.43,0,0,1,0,.61Z" fill="#50e6ff"/>
-      <path d="M509.69,400.47l1,1a.44.44,0,0,1,0,.61l-7.58,7.6h0l-1-1a.86.86,0,0,1,0-1.22h0l7-7A.43.43,0,0,1,509.69,400.47Z" fill="#1490df"/>
-      <path d="M526.64,406.5l1,1a.86.86,0,0,1,0,1.22h0l-7.1,7.08a.43.43,0,0,1-.61,0h0l-1-1a.43.43,0,0,1,0-.61h0l7.71-7.69Z" fill="#50e6ff"/>
-      <path d="M527.6,408.67l-1,1h0l-7.58-7.6a.43.43,0,0,1,0-.61h0l1-1a.45.45,0,0,1,.62,0h0l7,7a.86.86,0,0,1,0,1.22h0Z" fill="#1490df"/>
-    </g>
-    <g>
-      <circle cx="583.65" cy="466.3" r="1.67" fill="url(#linear-gradient-11)"/>
-      <circle cx="578.3" cy="466.31" r="1.67" fill="url(#linear-gradient-12)"/>
-      <circle cx="572.96" cy="466.31" r="1.67" fill="url(#linear-gradient-13)"/>
-      <path d="M574.18,473l-1,1a.43.43,0,0,1-.61,0h0l-7.1-7.07a.87.87,0,0,1,0-1.23h0l1-1h0l7.71,7.69a.43.43,0,0,1,0,.61Z" fill="#50e6ff"/>
-      <path d="M573.07,458.67l1,1a.44.44,0,0,1,0,.61l-7.58,7.6h0l-1-1a.86.86,0,0,1,0-1.22h0l7-7A.43.43,0,0,1,573.07,458.67Z" fill="#1490df"/>
-      <path d="M590,464.7l1,1a.86.86,0,0,1,0,1.22h0l-7.1,7.08a.43.43,0,0,1-.61,0h0l-1-1a.43.43,0,0,1,0-.61h0L590,464.7Z" fill="#50e6ff"/>
-      <path d="M591,466.87l-1,1h0l-7.58-7.6a.43.43,0,0,1,0-.61h0l1-1a.45.45,0,0,1,.62,0h0l7,7a.86.86,0,0,1,0,1.22h0Z" fill="#1490df"/>
-    </g>
-    <g>
-      <rect x="570.64" y="154.33" width="285" height="124" fill="#fff"/>
-      <rect x="570.64" y="154.33" width="285" height="124" fill="#cccccb" opacity="0.7"/>
-    </g>
-    <g>
-      <rect x="194.79" y="290.39" width="117.54" height="124.1" fill="#fff"/>
-      <rect x="194.79" y="290.39" width="117.54" height="124.1" fill="#cccccb" opacity="0.7"/>
-    </g>
-    <g>
-      <rect x="336.04" y="290.39" width="117.54" height="124.1" fill="#fff"/>
-      <rect x="336.04" y="290.39" width="117.54" height="124.1" fill="#cccccb" opacity="0.7"/>
-    </g>
-    <g>
-      <rect x="242.48" y="334.09" width="21.8" height="21.8" rx="1.01" transform="translate(-169.73 280.21) rotate(-45)" fill="url(#Teal_Gradient)"/>
-      <path d="M250,337.36l3.32-3.32a.2.2,0,0,1,.25,0l3.41,3.32a.17.17,0,0,1,0,.23.18.18,0,0,1-.16.05h-2a.18.18,0,0,0-.17.18h0v4.29a.16.16,0,0,1-.16.16h-2.07a.16.16,0,0,1-.17-.14v-4.31a.18.18,0,0,0-.16-.18h-2a.17.17,0,0,1-.16-.19A.16.16,0,0,1,250,337.36Zm7,15.26-3.41,3.31a.18.18,0,0,1-.25,0L250,352.62a.19.19,0,0,1,0-.25.25.25,0,0,1,.09,0h2a.17.17,0,0,0,.16-.17v-4.29a.16.16,0,0,1,.15-.16h2.09a.16.16,0,0,1,.16.16h0v4.29a.18.18,0,0,0,.17.17h2a.17.17,0,0,1,.24,0A.18.18,0,0,1,256.93,352.62Zm-10-4.38V346.3a.2.2,0,0,0-.18-.18h-4.29a.18.18,0,0,1-.18-.16v-2.07a.2.2,0,0,1,.18-.17h4.29a.18.18,0,0,0,.18-.16v-2a.16.16,0,0,1,.09-.2.16.16,0,0,1,.19.06l3.32,3.35a.17.17,0,0,1,0,.23h0l-3.32,3.32a.16.16,0,0,1-.22,0A.16.16,0,0,1,246.94,348.24Zm12.92-6.64v2a.17.17,0,0,0,.17.16h4.29a.19.19,0,0,1,.18.17V346a.18.18,0,0,1-.18.16H260a.19.19,0,0,0-.17.18v1.94a.17.17,0,0,1-.13.18.14.14,0,0,1-.15-.06L256.26,345a.16.16,0,0,1,0-.23h0l3.32-3.3a.15.15,0,0,1,.22,0A.17.17,0,0,1,259.86,341.6Z" fill="#fff"/>
-    </g>
-    <g>
-      <path id="f57e105d-6d2d-4ad7-b8c3-c10684c9f9b8" d="M404.06,370a15,15,0,0,1-18.42-23.76l.16-.11A15,15,0,0,1,404.06,370" fill="url(#radial-gradient)"/>
-      <path d="M394.85,344.57a13.59,13.59,0,1,0,13.59,13.59A13.58,13.58,0,0,0,394.85,344.57Zm9.1,4.57a12.82,12.82,0,0,1-3.8,1.42,15.49,15.49,0,0,0-2.21-4.77A12.6,12.6,0,0,1,404,349.14Zm-9.1-3.81a12.45,12.45,0,0,1,1.93.15h0a13.33,13.33,0,0,1,2.7,5.31,26.87,26.87,0,0,1-9.63,0,13,13,0,0,1,2.67-5.2h0A12.14,12.14,0,0,1,394.85,345.33Zm-3.54.46a15.35,15.35,0,0,0-2.24,4.73,9.83,9.83,0,0,1-3.36-1.36A13,13,0,0,1,391.31,345.79ZM385.52,367a9.23,9.23,0,0,1,3.14-1.35,12.57,12.57,0,0,0,2.39,4.81A12.83,12.83,0,0,1,385.52,367Zm11.33,3.88a12.14,12.14,0,0,1-2,.11,12.83,12.83,0,0,1-2.55-.26h0a10.75,10.75,0,0,1-2.95-5.31,26,26,0,0,1,10.4,0,10.69,10.69,0,0,1-3,5.31Zm1.29-.28a12.63,12.63,0,0,0,2.44-5,11.9,11.9,0,0,1,3.53,1.47,12.54,12.54,0,0,1-6,3.41Zm2.61-5.69c.14-.64.27-1.29.36-2l-.82.2a16.17,16.17,0,0,1-.3,1.6,27.07,27.07,0,0,0-10.76,0c-.12-.47-.21-1-.3-1.52a.43.43,0,0,1,0-.16l-.81-.23a4.17,4.17,0,0,0,0,.5,7.52,7.52,0,0,0,.3,1.61,10.57,10.57,0,0,0-3.54,1.5,12.78,12.78,0,0,1,.2-16.61,11.28,11.28,0,0,0,3.67,1.52c-.12.42-.23.88-.32,1.34s0,.44-.14.65l.83-.19v-.3c.11-.46.22-.9.34-1.33a26.32,26.32,0,0,0,5.39.43,26.94,26.94,0,0,0,4.91-.46c.13.47.25,1,.36,1.5l.81.19c-.13-.63-.27-1.22-.42-1.76a13.84,13.84,0,0,0,4.06-1.61,12.76,12.76,0,0,1,.11,16.77,13.11,13.11,0,0,0-3.93-1.71Z" fill="#699cd3"/>
-      <path d="M385.46,354.62a15.69,15.69,0,0,1,2.05-.14,4.31,4.31,0,0,1,3,.92,3.55,3.55,0,0,1,1,2.58,4,4,0,0,1-1.08,2.9,4.62,4.62,0,0,1-3.29,1.08,17.14,17.14,0,0,1-1.76-.09Zm1,6.6a7.85,7.85,0,0,0,1,0,2.88,2.88,0,0,0,3.17-2.53,3,3,0,0,0,0-.67,2.65,2.65,0,0,0-2.4-2.88,2.57,2.57,0,0,0-.62,0,6.86,6.86,0,0,0-1.11,0Z" fill="#fff"/>
-      <path d="M392.83,361.89v-7.44h1.05l2.38,3.71a22,22,0,0,1,1.35,2.42h0c-.09-1-.11-1.89-.11-3.06v-3.07h.89v7.44h-1l-2.33-3.73c-.51-.83-1-1.77-1.4-2.48h0v6.26Z" fill="#fff"/>
-      <path d="M400,360.72a3.53,3.53,0,0,0,1.77.48c1,0,1.55-.51,1.55-1.27s-.39-1.1-1.4-1.47-2-1.06-2-2.12a2.14,2.14,0,0,1,2.27-2h.15a3.57,3.57,0,0,1,1.64.36l-.28.79a2.82,2.82,0,0,0-1.42-.35c-1,0-1.41.6-1.41,1.11s.46,1,1.48,1.43a2.51,2.51,0,0,1,1.91,2.2c0,1.09-.85,2.13-2.61,2.13a3.76,3.76,0,0,1-1.89-.47Z" fill="#fff"/>
-    </g>
-    <g>
-      <path d="M660.94,81.79l1.43-1.54V76.16h-7.13v4.09l1.43,1.54A.53.53,0,0,0,657,82h3.53A.55.55,0,0,0,660.94,81.79Z" fill="#cfcfce"/>
-      <path d="M658.77,52a10.4,10.4,0,0,0-10.5,10.29,9.59,9.59,0,0,0,.07,1.31c.47,4.35,4.62,6.38,5.8,11.91a.87.87,0,0,0,.83.67h7.59a.87.87,0,0,0,.83-.67c1.18-5.53,5.29-7.56,5.81-11.91a10.4,10.4,0,0,0-9.13-11.53A11.33,11.33,0,0,0,658.77,52Z" fill="url(#radial-gradient-2)"/>
-      <path d="M663.11,57.79a2.48,2.48,0,0,0-2.39,2.54v1.36H657V60.33a2.49,2.49,0,0,0-2.43-2.54h-.06a2.56,2.56,0,0,0,0,5.1h1.13V73.48a.64.64,0,0,0,.64.63.63.63,0,0,0,.63-.63V62.89h3.81V73.48a.64.64,0,0,0,1.28,0V62.89h1.11a2.47,2.47,0,0,0,2.38-2.56h0A2.47,2.47,0,0,0,663.11,57.79Zm-7.47,3.9h-1.2a1.37,1.37,0,1,1,1.2-1.36Zm7.56,0H662V60.26a1.2,1.2,0,1,1,2.38-.29,1.4,1.4,0,0,1,0,.29,1.28,1.28,0,0,1-1.14,1.42Z" fill="url(#linear-gradient-14)"/>
-      <polygon points="655.17 78.98 662.37 77.59 662.37 76.79 655.17 78.2 655.17 78.98" fill="#999"/>
-      <polygon points="662.37 79.53 662.37 78.75 655.17 80.18 655.17 80.25 655.71 80.85 662.37 79.53" fill="#999"/>
-    </g>
-    <g>
-      <path id="aacf8311-a317-400f-b613-74bd00da5ce3" d="M805,52a15,15,0,1,0,15,15A15,15,0,0,0,805,52Zm0,28a13,13,0,1,1,13-13h0A13,13,0,0,1,805,79.93Z" fill="url(#radial-gradient-3)"/>
-      <circle cx="805.04" cy="66.98" r="12.95" fill="#fff"/>
-      <g>
-        <path id="bd983c41-db73-40ec-a4f4-da1213fc9924" d="M812.88,64a3.25,3.25,0,0,0,0-4.57h0l-5.56-5.57a3.23,3.23,0,0,0-4.55,0h0l-5.56,5.57a3.24,3.24,0,0,0,0,4.57l4.62,4.72a.87.87,0,0,1,.27.63V78a1.13,1.13,0,0,0,.31.78l2.12,2.12a.74.74,0,0,0,1,0h0l2-2h0l1.2-1.2a.43.43,0,0,0,0-.6l-.86-.86a.49.49,0,0,1,0-.66l.86-.86a.44.44,0,0,0,0-.6l-.86-.87a.48.48,0,0,1,0-.65l.86-.86a.43.43,0,0,0,0-.6l-1.2-1.22v-.44ZM805,55.25a1.83,1.83,0,1,1-1.82,1.82A1.82,1.82,0,0,1,805,55.25Z" fill="url(#radial-gradient-4)"/>
-        <path id="ad2e7e44-9bfd-4775-8bf4-8ef26a544921" d="M803.6,78.1h0a.4.4,0,0,0,.57,0,.44.44,0,0,0,.1-.26V70.74a.42.42,0,0,0-.2-.35h0a.37.37,0,0,0-.53.11.42.42,0,0,0-.07.24V77.8A.48.48,0,0,0,803.6,78.1Z" fill="#f7921e" opacity="0.75" style="isolation: isolate"/>
-        <rect id="a996fbff-3936-4b24-b407-369336c143ba" x="800.6" y="61.32" width="9.12" height="1.08" rx="0.49" fill="#f7921e" opacity="0.75" style="isolation: isolate"/>
-        <rect id="bb12d31c-3352-4a18-87dd-a169a4a8721d" x="800.6" y="63.06" width="9.12" height="1.08" rx="0.49" fill="#f7921e" opacity="0.75" style="isolation: isolate"/>
-      </g>
-    </g>
-    <g>
-      <ellipse cx="724.68" cy="66.48" rx="15.05" ry="15" fill="url(#radial-gradient-5)"/>
-      <ellipse cx="724.68" cy="66.48" rx="13.11" ry="13.05" fill="#fff"/>
-      <path d="M713.55,67.26a11,11,0,0,0,3.23,7.08l3.54-3.54a6.21,6.21,0,0,1-1.77-3.54Z" fill="#a5def3"/>
-      <path d="M732,58.11a11,11,0,0,0-6.53-2.71v4.94a5.9,5.9,0,0,1,3,1.24Z" fill="#33bedd"/>
-      <path d="M717.36,58.11l3.54,3.54a6,6,0,0,1,3-1.24v-5A11,11,0,0,0,717.36,58.11Z" fill="#33bedd"/>
-      <path d="M729.6,62.67a6.4,6.4,0,0,1,1.26,3h4.94a10.92,10.92,0,0,0-2.71-6.5Z" fill="#33bedd"/>
-      <path d="M719.75,62.67l-3.54-3.54a11,11,0,0,0-2.66,6.57h5A6.39,6.39,0,0,1,719.75,62.67Z" fill="#74cfeb"/>
-      <path d="M733.78,62.94a.8.8,0,0,0-1-.44l-7.3,2.94.57,1.43,7.3-2.89a.77.77,0,0,0,.46-1S733.79,63,733.78,62.94Z" fill="#ef404a"/>
-      <circle cx="724.68" cy="66.48" r="2.13" fill="url(#radial-gradient-6)"/>
-    </g>
-    <g>
-      <path d="M881.93,66c0,8.06-9.91,14.55-12.08,15.87a.74.74,0,0,1-.81,0C866.87,80.56,857,74.07,857,66v-9.7a.78.78,0,0,1,.76-.78c7.73-.19,5.95-3.53,11.73-3.53s4,3.34,11.73,3.53a.77.77,0,0,1,.76.78Z" fill="#2e76bc"/>
-      <path d="M880.91,66.06c0,7.41-9.1,13.35-11.1,14.55a.7.7,0,0,1-.74,0c-2-1.2-11.09-7.14-11.09-14.55V57.24a.72.72,0,0,1,.59-.84h.11c7.09-.12,5.47-3.16,10.76-3.16s3.67,3,10.76,3.16a.73.73,0,0,1,.71.71Z" fill="url(#linear-gradient-15)"/>
-      <path d="M874.47,64.61h-.7v-2.5a4.63,4.63,0,0,0-1.24-3.2,4.19,4.19,0,0,0-5.91-.23l-.23.23a4.62,4.62,0,0,0-1.23,3.2v2.5h-.71a.56.56,0,0,0-.61.51.28.28,0,0,0,0,.09V71.7a.57.57,0,0,0,.57.57h10.07a.57.57,0,0,0,.58-.55V65.21a.56.56,0,0,0-.52-.6Zm-2.73,0h-4.59V62.07a2.52,2.52,0,0,1,.72-1.76,2.1,2.1,0,0,1,3-.18l.17.18a3.17,3.17,0,0,1,.29.35h0a2.57,2.57,0,0,1,.44,1.39Z" fill="#febd11"/>
-      <path d="M864.42,64.61h10.05a.55.55,0,0,1,.37.14l-10.79,7.34a.58.58,0,0,1-.22-.42V65.21a.57.57,0,0,1,.53-.6Z" fill="#fee452"/>
-      <path d="M874.47,64.61H864.42a.55.55,0,0,0-.37.14l10.79,7.34a.51.51,0,0,0,.21-.42V65.21a.56.56,0,0,0-.52-.6Z" fill="#fed402" opacity="0.5" style="isolation: isolate"/>
-    </g>
-    <g>
-      <rect x="462.29" y="139.23" width="1" height="1.5" fill="#3c3c41"/>
-      <path d="M463.29,136.19h-1v-3h1Zm107,0h-1v-3h1Zm-107-6h-1v-3h1Zm107,0h-1v-3h1Zm-107-6h-1v-3h1Zm107,0h-1v-3h1Zm-107-6h-1v-3h1Zm107,0h-1v-3h1Zm-107-6h-1v-3h1Zm107,0h-1v-3h1Zm-107-6h-1v-3h1Zm107,0h-1v-3h1Zm-107-6h-1v-3h1Zm107,0h-1v-3h1Zm-107-6h-1v-3h1Zm107,0h-1v-3h1Zm-107-6h-1v-.39a4.44,4.44,0,0,1,.95-2.76l.79.61a3.42,3.42,0,0,0-.74,2.15Zm107,0h-1v-.37a3.41,3.41,0,0,0-.76-2.16l.79-.62a4.52,4.52,0,0,1,1,2.78Zm-104-3.83-.15-1a3.82,3.82,0,0,1,.68,0h2.43v1h-2.43A3.08,3.08,0,0,0,466.26,83.77Zm100,0a4.07,4.07,0,0,0-.5,0h-2.46v-1h2.46a4.73,4.73,0,0,1,.65,0Zm-6,0h-3v-1h3Zm-6.07,0h-3v-1h3Zm-6.07,0h-3v-1h3Zm-6.07,0h-3v-1h3Zm-6.07,0h-3v-1h3Zm-6.07,0h-3v-1h3Zm-6.07,0h-3v-1h3Zm-6.08,0h-3v-1h3Zm-6.07,0h-3v-1h3Zm-6.07,0h-3v-1h3Zm-6.07,0h-3v-1h3Zm-6.07,0h-3v-1h3Zm-6.07,0h-3v-1h3Zm-6.08,0h-3v-1h3Zm-6.07,0h-3v-1h3Z" fill="#3c3c41"/>
-    </g>
-    <g>
-      <path id="f57e105d-6d2d-4ad7-b8c3-c10684c9f9b8-2" data-name="f57e105d-6d2d-4ad7-b8c3-c10684c9f9b8" d="M527.21,86.36a17,17,0,0,1-20.88-26.92l.18-.12a17,17,0,0,1,20.7,27" fill="url(#radial-gradient-7)"/>
-      <path d="M516.77,57.49A15.41,15.41,0,1,0,532.18,72.9,15.4,15.4,0,0,0,516.77,57.49Zm10.32,5.19a14.56,14.56,0,0,1-4.31,1.6,17.77,17.77,0,0,0-2.5-5.41A14.48,14.48,0,0,1,527.09,62.68Zm-10.32-4.33a13.27,13.27,0,0,1,2.18.18h0a15,15,0,0,1,3.07,6,30.36,30.36,0,0,1-10.92,0,14.85,14.85,0,0,1,3-5.89h0A14.63,14.63,0,0,1,516.77,58.35Zm-4,.52a17.65,17.65,0,0,0-2.54,5.37,11.08,11.08,0,0,1-3.81-1.54A14.84,14.84,0,0,1,512.76,58.87Zm-6.57,24a10.65,10.65,0,0,1,3.57-1.52,14.3,14.3,0,0,0,2.7,5.45A14.6,14.6,0,0,1,506.19,82.91ZM519,87.32a14.21,14.21,0,0,1-2.26.12,13.87,13.87,0,0,1-2.88-.3h0a12,12,0,0,1-3.35-6,29.57,29.57,0,0,1,11.78,0,12,12,0,0,1-3.39,6ZM520.5,87a14.38,14.38,0,0,0,2.76-5.61,13.56,13.56,0,0,1,4,1.66,14.29,14.29,0,0,1-6.77,3.87Zm3-6.45c.16-.72.3-1.46.4-2.24l-.92.22c-.1.62-.2,1.24-.34,1.82a30.56,30.56,0,0,0-12.2,0c-.14-.54-.24-1.12-.34-1.72a.54.54,0,0,1,0-.18l-.92-.26a5.23,5.23,0,0,0,0,.56,8.88,8.88,0,0,0,.34,1.82,11.76,11.76,0,0,0-4,1.7,14.51,14.51,0,0,1,.22-18.83,12.49,12.49,0,0,0,4.17,1.72c-.14.49-.26,1-.36,1.53s0,.5-.16.74l.94-.22v-.34c.12-.52.24-1,.38-1.51a33.56,33.56,0,0,0,11.68,0c.14.55.28,1.13.4,1.71l.92.22q-.23-1.08-.48-2a15.41,15.41,0,0,0,4.61-1.82,14.47,14.47,0,0,1,.12,19,14.59,14.59,0,0,0-4.45-1.94Z" fill="#699cd3"/>
-      <path d="M506.13,68.89a16.49,16.49,0,0,1,2.33-.16,4.86,4.86,0,0,1,3.42,1,4,4,0,0,1,1.18,2.93A4.4,4.4,0,0,1,511.84,76a5.15,5.15,0,0,1-3.72,1.22,16.91,16.91,0,0,1-2-.1Zm1.1,7.47a6.86,6.86,0,0,0,1.11,0,3.22,3.22,0,0,0,3.58-3.62,3,3,0,0,0-2.72-3.27,3.28,3.28,0,0,0-.7,0,6.74,6.74,0,0,0-1.27,0Z" fill="#fff"/>
-      <path d="M514.49,77.12V68.69h1.18l2.7,4.21a23.66,23.66,0,0,1,1.53,2.74h0c-.1-1.12-.12-2.14-.12-3.46V68.69h1v8.43h-1.11L517,72.9c-.58-.94-1.14-2-1.58-2.81h0v7.09Z" fill="#fff"/>
-      <path d="M522.56,75.8a4,4,0,0,0,2,.54c1.12,0,1.77-.58,1.77-1.44s-.44-1.24-1.59-1.66-2.24-1.2-2.24-2.41a2.44,2.44,0,0,1,2.58-2.29h.16a4,4,0,0,1,1.87.4l-.32.9a3.34,3.34,0,0,0-1.61-.4c-1.16,0-1.6.68-1.6,1.26s.52,1.19,1.68,1.63a2.83,2.83,0,0,1,2.17,2.48c0,1.24-1,2.42-3,2.42a4.21,4.21,0,0,1-2.14-.54Z" fill="#fff"/>
-    </g>
-    <g>
-      <path d="M617.91,201l14-14a1,1,0,0,1,1.41,0l0,0,14,14a1,1,0,0,1,0,1.41l0,0-14,14a1,1,0,0,1-1.4,0l-14-14a1,1,0,0,1,0-1.42Z" fill="url(#Green_Gradient_)"/>
-      <path d="M636.27,193.4l-3.53-3.52a.22.22,0,0,0-.27,0l-3.53,3.52a.16.16,0,0,0-.05.23.16.16,0,0,0,.18.07h2.07a.18.18,0,0,1,.18.18v3.34a.18.18,0,0,0,.18.18h2.2a.18.18,0,0,0,.19-.18v-3.34a.18.18,0,0,1,.18-.18h2.07a.16.16,0,0,0,.2-.12A.16.16,0,0,0,636.27,193.4Z" fill="#b6d43a"/>
-      <path d="M624.27,197.75l-3.5,3.55a.2.2,0,0,0,0,.25l3.5,3.51a.18.18,0,0,0,.26,0,.18.18,0,0,0,.06-.14v-2.05a.18.18,0,0,1,.18-.18h3.33a.17.17,0,0,0,.17-.17v-2.21a.16.16,0,0,0-.06-.23l-.06,0h-3.33a.17.17,0,0,1-.18-.15v-2a.2.2,0,0,0-.12-.25A.21.21,0,0,0,624.27,197.75Z" fill="#b6d43a"/>
-      <path d="M641.07,205.06l3.55-3.53a.2.2,0,0,0,0-.25l-3.55-3.53a.19.19,0,0,0-.26,0,.21.21,0,0,0,0,.11V200a.16.16,0,0,1-.17.16h-3.35a.17.17,0,0,0-.16.17v2.21a.16.16,0,0,0,.15.19h3.35a.18.18,0,0,1,.18.18V205a.18.18,0,0,0,.2.16A.19.19,0,0,0,641.07,205.06Z" fill="#b6d43a"/>
-      <path d="M637.25,201.73a4.65,4.65,0,1,0-5.9,4.45v1.58a2.84,2.84,0,1,0,2.62,0V206.1A4.61,4.61,0,0,0,637.25,201.73Z" fill="#fff"/>
-      <circle id="e99c3387-15c3-4f28-bd4b-cb209b430e06" cx="632.62" cy="201.72" r="2.7" fill="#699cd3"/>
-    </g>
-    <g>
-      <circle cx="665.29" cy="201.73" r="2.49"/>
-      <circle cx="672.8" cy="201.73" r="2.49"/>
-      <circle cx="680.32" cy="201.73" r="2.49"/>
-    </g>
-    <g>
-      <rect x="570.64" y="309.33" width="284.6" height="124" fill="#fff"/>
-      <rect x="570.64" y="309.33" width="284.6" height="124" fill="#cccccb" opacity="0.7"/>
-    </g>
-    <g>
-      <rect x="878.64" y="309.33" width="227.4" height="124" fill="#fff"/>
-      <rect x="878.64" y="309.33" width="227.4" height="124" fill="#cccccb" opacity="0.7"/>
-    </g>
-    <g>
-      <g>
-        <path d="M848.3,361.73a1.48,1.48,0,0,0,1.51-1.43v-.25c-.6-4.72-3.29-8.56-8.43-8.56s-7.94,3.25-8.46,8.56a1.51,1.51,0,0,0,1.34,1.67h14Z" fill="url(#linear-gradient-16)"/>
-        <path d="M841.38,352.6a4.71,4.71,0,0,1-2.58-.75l2.55,6.64,2.52-6.6A4.67,4.67,0,0,1,841.38,352.6Z" fill="#fff" opacity="0.8" style="isolation: isolate"/>
-        <circle cx="841.38" cy="347.86" r="4.74" fill="url(#linear-gradient-17)"/>
-        <path d="M835.78,347.91v-6a.19.19,0,0,0-.18-.21H834a.22.22,0,0,0-.22.2h0v5.76a.21.21,0,0,1-.21.21h-1.37a.14.14,0,0,1-.12-.14v-1.61A.14.14,0,0,0,832,346a.15.15,0,0,0-.1,0l-2.72,2.7a.19.19,0,0,0,0,.27l0,0,2.69,2.68a.14.14,0,0,0,.17.09.14.14,0,0,0,.09-.17h0V350a.12.12,0,0,1,.12-.13h3.36a.21.21,0,0,0,.19-.21Z" fill="#2e76bc"/>
-      </g>
-      <g>
-        <path d="M847.63,324.67c0,5.37-6.5,9.71-7.91,10.59a.52.52,0,0,1-.54,0c-1.41-.88-7.91-5.22-7.91-10.59V318.2a.5.5,0,0,1,.5-.51c5.06-.14,3.89-2.36,7.68-2.36s2.62,2.22,7.68,2.36a.5.5,0,0,1,.5.51Z" fill="#0078d4"/>
-        <path d="M847,324.72c0,4.94-6,8.89-7.25,9.71a.48.48,0,0,1-.49,0c-1.3-.8-7.26-4.77-7.26-9.71v-5.93a.47.47,0,0,1,.46-.47c4.63-.12,3.56-2.15,7-2.15s2.41,2,7,2.15a.47.47,0,0,1,.45.47Z" fill="#6bb9f2"/>
-        <path d="M839.45,325.33v-9.16c3.48,0,2.41,2,7,2.15a.47.47,0,0,1,.45.48v5.93q0,.3,0,.6Zm0,0H832c.45,4.65,6,8.34,7.23,9.1a.37.37,0,0,0,.2.07h0Z" fill="url(#linear-gradient-18)"/>
-        <path d="M832.41,318.32c4.63-.12,3.56-2.15,7-2.15v9.16H832q0-.3,0-.6V318.8A.49.49,0,0,1,832.41,318.32Z" fill="#50e6ff"/>
-        <path d="M846.92,325.33h-7.47v9.17h0a.37.37,0,0,0,.2-.07C840.94,333.67,846.47,330,846.92,325.33Z" fill="#50e6ff"/>
-      </g>
-    </g>
-    <g>
-      <g>
-        <path d="M848.3,206.73a1.48,1.48,0,0,0,1.51-1.43v-.25c-.6-4.72-3.29-8.56-8.43-8.56s-7.94,3.25-8.46,8.56a1.51,1.51,0,0,0,1.34,1.67h14Z" fill="url(#linear-gradient-19)"/>
-        <path d="M841.38,197.6a4.71,4.71,0,0,1-2.58-.75l2.55,6.64,2.52-6.6A4.67,4.67,0,0,1,841.38,197.6Z" fill="#fff" opacity="0.8" style="isolation: isolate"/>
-        <circle cx="841.38" cy="192.86" r="4.74" fill="url(#linear-gradient-20)"/>
-        <path d="M835.78,192.91v-6a.19.19,0,0,0-.18-.21H834a.22.22,0,0,0-.22.2h0v5.76a.21.21,0,0,1-.21.21h-1.37a.14.14,0,0,1-.12-.14v-1.61A.14.14,0,0,0,832,191a.15.15,0,0,0-.1,0l-2.72,2.7a.19.19,0,0,0,0,.27l0,0,2.69,2.68a.14.14,0,0,0,.17.09.14.14,0,0,0,.09-.17h0V195a.12.12,0,0,1,.12-.13h3.36a.21.21,0,0,0,.19-.21Z" fill="#2e76bc"/>
-      </g>
-      <g>
-        <path d="M847.63,169.67c0,5.37-6.5,9.71-7.91,10.59a.52.52,0,0,1-.54,0c-1.41-.88-7.91-5.22-7.91-10.59V163.2a.5.5,0,0,1,.5-.51c5.06-.14,3.89-2.36,7.68-2.36s2.62,2.22,7.68,2.36a.5.5,0,0,1,.5.51Z" fill="#0078d4"/>
-        <path d="M847,169.72c0,4.94-6,8.89-7.25,9.71a.48.48,0,0,1-.49,0c-1.3-.8-7.26-4.77-7.26-9.71v-5.93a.47.47,0,0,1,.46-.47c4.63-.12,3.56-2.15,7-2.15s2.41,2,7,2.15a.47.47,0,0,1,.45.47Z" fill="#6bb9f2"/>
-        <path d="M839.45,170.33v-9.16c3.48,0,2.41,2,7,2.15a.47.47,0,0,1,.45.48v5.93q0,.3,0,.6Zm0,0H832c.45,4.65,6,8.34,7.23,9.1a.37.37,0,0,0,.2.07h0Z" fill="url(#linear-gradient-21)"/>
-        <path d="M832.41,163.32c4.63-.12,3.56-2.15,7-2.15v9.16H832q0-.3,0-.6V163.8A.49.49,0,0,1,832.41,163.32Z" fill="#50e6ff"/>
-        <path d="M846.92,170.33h-7.47v9.17h0a.37.37,0,0,0,.2-.07C840.94,178.67,846.47,175,846.92,170.33Z" fill="#50e6ff"/>
-      </g>
-    </g>
-    <g>
-      <path d="M924.37,358.4c-6.2,0-11.38-1.84-11.38-4.1v21.77c0,2.25,5,4.14,11.15,4.14h.23c6.21,0,11.32-1.82,11.32-4.14V354.3C935.61,356.56,930.58,358.4,924.37,358.4Z" fill="url(#linear-gradient-22)"/>
-      <path d="M935.61,354.3c0,2.26-5.07,4.14-11.32,4.14S913,356.56,913,354.3s5.18-4.09,11.38-4.09,11.32,1.82,11.32,4.14" fill="#e8e8e8"/>
-      <path d="M933,354c0,1.43-3.87,2.59-8.67,2.59s-8.67-1.16-8.67-2.59,3.89-2.6,8.75-2.6S933,352.52,933,354" fill="#74cfeb"/>
-      <path d="M924.37,354.57a21,21,0,0,0-6.85,1,23.8,23.8,0,0,0,13.72,0A20.78,20.78,0,0,0,924.37,354.57Z" fill="#1b8ab3"/>
-    </g>
-    <g>
-      <line x1="1018.04" y1="120.73" x2="1018.04" y2="134.52" fill="none" stroke="#3c3c41" stroke-miterlimit="10"/>
-      <polygon points="1014.3 133.43 1018.04 139.9 1021.78 133.43 1014.3 133.43" fill="#3c3c41"/>
-    </g>
-    <g>
-      <line x1="839.84" y1="120.73" x2="839.84" y2="134.15" fill="none" stroke="#3c3c41" stroke-miterlimit="10"/>
-      <polygon points="836.1 133.06 839.84 139.53 843.58 133.06 836.1 133.06" fill="#3c3c41"/>
-    </g>
-    <g>
-      <line x1="690.24" y1="126.11" x2="690.24" y2="139.9" fill="none" stroke="#3c3c41" stroke-miterlimit="10"/>
-      <polygon points="686.5 127.21 690.24 120.73 693.98 127.21 686.5 127.21" fill="#3c3c41"/>
-    </g>
-    <g>
-      <rect x="6.84" y="6.07" width="131" height="55" fill="#fff" opacity="0.3"/>
-      <rect x="6.84" y="6.07" width="131" height="55" fill="none" stroke="#75767a" stroke-miterlimit="10" stroke-width="0.25"/>
-    </g>
-    <g>
-      <g>
-        <line x1="46.69" y1="43.53" x2="20.25" y2="43.53" fill="none" stroke="#207067" stroke-miterlimit="10" stroke-width="3"/>
-        <polygon points="56.22 43.53 42.79 38.04 45.98 43.53 42.79 49.02 56.22 43.53" fill="#207067"/>
-      </g>
-      <line x1="46.69" y1="43.53" x2="20.25" y2="43.53" fill="none" stroke="#42e8ca" stroke-miterlimit="10" stroke-width="1.5" stroke-dasharray="4 2"/>
-    </g>
-    <g>
-      <g>
-        <line x1="46.69" y1="23.93" x2="20.25" y2="23.93" fill="none" stroke="#59285f" stroke-miterlimit="10" stroke-width="3"/>
-        <polygon points="44.94 17.95 55.3 23.93 44.94 29.91 44.94 17.95" fill="#59285f"/>
-      </g>
-      <g>
-        <line x1="46.69" y1="23.93" x2="46.19" y2="23.93" fill="none" stroke="#ce74b6" stroke-miterlimit="10" stroke-width="2"/>
-        <line x1="44.24" y1="23.93" x2="44.23" y2="23.93" fill="none" stroke="#ce74b6" stroke-miterlimit="10" stroke-width="2" stroke-dasharray="0.01 0"/>
-        <line x1="44.23" y1="23.93" x2="20.75" y2="23.93" fill="none" stroke="#ce74b6" stroke-miterlimit="10" stroke-width="2" stroke-dasharray="0.98 1.95 0.01 0"/>
-        <line x1="20.75" y1="23.93" x2="20.25" y2="23.93" fill="none" stroke="#ce74b6" stroke-miterlimit="10" stroke-width="2"/>
-      </g>
-    </g>
-    <g>
-      <g>
-        <line x1="562.09" y1="228.33" x2="311.94" y2="228.33" fill="none" stroke="#59285f" stroke-miterlimit="10" stroke-width="3"/>
-        <polygon points="560.34 222.34 570.7 228.33 560.34 234.31 560.34 222.34" fill="#59285f"/>
-      </g>
-      <g>
-        <line x1="562.09" y1="228.33" x2="561.59" y2="228.33" fill="none" stroke="#ce74b6" stroke-miterlimit="10" stroke-width="2"/>
-        <line x1="559.59" y1="228.33" x2="559.58" y2="228.33" fill="none" stroke="#ce74b6" stroke-miterlimit="10" stroke-width="2" stroke-dasharray="0.01 0"/>
-        <line x1="559.58" y1="228.33" x2="312.44" y2="228.33" fill="none" stroke="#ce74b6" stroke-miterlimit="10" stroke-width="2" stroke-dasharray="1 2 0.01 0"/>
-        <line x1="312.44" y1="228.33" x2="311.94" y2="228.33" fill="none" stroke="#ce74b6" stroke-miterlimit="10" stroke-width="2"/>
-      </g>
-    </g>
-    <g>
-      <g>
-        <line x1="281.78" y1="154.99" x2="281.78" y2="88.73" fill="none" stroke="#207067" stroke-miterlimit="10" stroke-width="3"/>
-        <polygon points="281.77 79.19 287.26 92.63 281.77 89.44 276.29 92.63 281.77 79.19" fill="#207067"/>
-      </g>
-      <line x1="281.78" y1="154.99" x2="281.78" y2="88.73" fill="none" stroke="#42e8ca" stroke-miterlimit="10" stroke-width="1.5" stroke-dasharray="4 2"/>
-    </g>
-    <g>
-      <g>
-        <line x1="225.73" y1="145.88" x2="225.73" y2="78.53" fill="none" stroke="#59285f" stroke-miterlimit="10" stroke-width="3"/>
-        <polygon points="231.71 144.13 225.73 154.5 219.74 144.13 231.71 144.13" fill="#59285f"/>
-      </g>
-      <g>
-        <line x1="225.73" y1="145.88" x2="225.73" y2="145.38" fill="none" stroke="#ce74b6" stroke-miterlimit="10" stroke-width="2"/>
-        <line x1="225.73" y1="143.35" x2="225.73" y2="143.34" fill="none" stroke="#ce74b6" stroke-miterlimit="10" stroke-width="2" stroke-dasharray="0.01 0"/>
-        <line x1="225.73" y1="143.34" x2="225.73" y2="79.03" fill="none" stroke="#ce74b6" stroke-miterlimit="10" stroke-width="2" stroke-dasharray="1.02 2.03 0.01 0"/>
-        <line x1="225.73" y1="79.03" x2="225.73" y2="78.53" fill="none" stroke="#ce74b6" stroke-miterlimit="10" stroke-width="2"/>
-      </g>
-    </g>
-    <circle cx="795.47" cy="295.44" r="35" fill="#fff" opacity="0.6"/>
-    <g>
-      <path d="M794.14,293.61H775.47V274.94h18.67Zm-15.56-3.12H791V278.05H778.58Zm36.89,3.12H796.81V274.94h18.66Zm-15.55-3.12h12.44V278.05H799.92Zm15.55,24.45H796.81V296.27h18.66Zm-21.33,0H775.47V296.27h18.67Zm5.78-3.11h12.44V299.38H799.92Zm-21.34,0H791V299.38H778.58Z" fill="url(#linear-gradient-23)"/>
-      <path d="M811.47,291.38v2.67h-12.8v-2.67Z" fill="url(#linear-gradient-24)"/>
-      <path d="M815.47,293.61v-3.12H799.92v3.12Z" fill="url(#linear-gradient-25)"/>
-      <path d="M775.47,293.61v-3.12H791v3.12Z" fill="url(#linear-gradient-26)"/>
-      <path d="M815.47,296.27v3.11H799.92v-3.11Z" fill="url(#linear-gradient-27)"/>
-      <path d="M775.47,299.38v-3.11H791v3.11Z" fill="url(#linear-gradient-28)"/>
-      <path d="M791,274.94h3.11v15.55H791Z" fill="url(#linear-gradient-29)"/>
-      <path d="M796.81,274.94h3.11v15.55h-3.11Z" fill="url(#linear-gradient-30)"/>
-      <path d="M799.92,314.94h-3.11V299.38h3.11Z" fill="url(#linear-gradient-31)"/>
-      <path d="M794.14,314.94H791V299.38h3.11Z" fill="url(#linear-gradient-32)"/>
-      <path d="M808.81,294.72a37.75,37.75,0,0,0-2.45-11.56,11.47,11.47,0,0,1-1.33,2.33,13.75,13.75,0,0,0-9.56-3.88,13.33,13.33,0,1,0,13.34,13.33Z" fill="#5fb832"/>
-      <path d="M806.25,300.94c-3.33,4.33-10.33,2.89-14.78,3.11a12.66,12.66,0,0,0-1.55.11l.66-.22c3.12-1.11,4.67-1.33,6.56-2.33,3.67-1.89,7.22-5.89,7.89-10.12-1.33,4.12-5.56,7.56-9.33,8.89a53.86,53.86,0,0,1-7.34,1.89l-.22-.11c-3.22-1.55-3.33-8.55,2.44-10.78,2.56-1,5-.44,7.78-1.11,3-.78,6.34-2.89,7.78-5.78C807.81,289.27,809.58,296.49,806.25,300.94Z" fill="#fff"/>
-      <path d="M787.47,305.27a1.11,1.11,0,1,0-1.11-1.11A1.11,1.11,0,0,0,787.47,305.27Z" fill="#fff"/>
-    </g>
-    <g opacity="0.7">
-      <rect x="336.04" y="153.93" width="117.54" height="124.1" fill="#fff"/>
-      <rect x="336.04" y="153.93" width="117.54" height="124.1" fill="#cccccb" opacity="0.9"/>
-    </g>
-    <g>
-      <path d="M270.66,220.14A7.47,7.47,0,0,0,264.2,213a9.39,9.39,0,0,0-9.65-9,9.63,9.63,0,0,0-9.2,6.27,8.88,8.88,0,0,0-7.8,8.54,9,9,0,0,0,9.33,8.66h16.31A7.54,7.54,0,0,0,270.66,220.14Z" fill="url(#linear-gradient-33)"/>
-      <path d="M263.83,222.08a.77.77,0,0,0-.77-.76H245.15a.78.78,0,0,0-.78.76v9.19a.78.78,0,0,0,.78.76h17.91a.77.77,0,0,0,.77-.76Z" fill="#821618"/>
-      <rect x="245.46" y="222.39" width="5.28" height="2.34" fill="#e52526"/>
-      <rect x="251.53" y="222.39" width="5.28" height="2.34" fill="#f27281"/>
-      <rect x="257.6" y="222.39" width="5.28" height="2.34" fill="#e52526"/>
-      <rect x="245.46" y="225.52" width="2.19" height="2.34" fill="#e52526"/>
-      <rect x="260.69" y="225.52" width="2.19" height="2.34" fill="#f27281"/>
-      <rect x="248.44" y="225.52" width="5.28" height="2.34" fill="#f27281"/>
-      <rect x="254.53" y="225.52" width="5.28" height="2.34" fill="#e52526"/>
-      <rect x="245.46" y="228.64" width="5.28" height="2.34" fill="#e52526"/>
-      <rect x="251.53" y="228.64" width="5.28" height="2.34" fill="#f27281"/>
-      <rect x="257.6" y="228.64" width="5.28" height="2.34" fill="#e52526"/>
-    </g>
-    <g>
-      <rect x="383.91" y="207.13" width="21.8" height="21.8" rx="1.01" transform="translate(-38.53 343.04) rotate(-45)" fill="url(#Teal_Gradient-2)"/>
-      <path d="M391.39,210.4l3.32-3.32a.18.18,0,0,1,.25,0l3.4,3.32a.15.15,0,0,1,0,.22.14.14,0,0,1-.15.06h-2a.18.18,0,0,0-.18.18h0v4.29a.16.16,0,0,1-.16.16h-2.06a.16.16,0,0,1-.18-.14v-4.31a.18.18,0,0,0-.16-.18h-2a.18.18,0,0,1-.16-.19A.36.36,0,0,1,391.39,210.4Zm7,15.25L395,229a.18.18,0,0,1-.25,0l-3.32-3.32a.17.17,0,0,1,0-.24.18.18,0,0,1,.09,0h2a.18.18,0,0,0,.16-.18V220.9a.17.17,0,0,1,.16-.16h2.08a.16.16,0,0,1,.16.15h0v4.29a.18.18,0,0,0,.18.18h1.94a.18.18,0,0,1,.25,0A.17.17,0,0,1,398.36,225.65Zm-10-4.37v-1.95a.19.19,0,0,0-.18-.17H383.9a.17.17,0,0,1-.17-.16v-2.07a.18.18,0,0,1,.17-.17h4.29a.18.18,0,0,0,.18-.16v-2a.17.17,0,0,1,.09-.21.16.16,0,0,1,.19.07l3.32,3.35a.16.16,0,0,1,0,.23h0l-3.32,3.32a.16.16,0,0,1-.28-.12Zm12.92-6.64v2a.18.18,0,0,0,.18.16h4.29a.19.19,0,0,1,.18.17V219a.18.18,0,0,1-.18.16h-4.29a.2.2,0,0,0-.18.17v1.95a.16.16,0,0,1-.13.18.16.16,0,0,1-.15-.06L397.69,218a.17.17,0,0,1,0-.23h0l3.32-3.3a.15.15,0,0,1,.22-.05A.16.16,0,0,1,401.29,214.64Z" fill="#fff"/>
-    </g>
-    <g>
-      <path d="M1030.77,66.44a10.53,10.53,0,1,1-10.53-10.76,10.65,10.65,0,0,1,10.53,10.76" fill="#d33833"/>
-      <path d="M1010.15,69.1s-.76-11.22,9.58-11.54l-.72-1.2-5.61,1.88-1.61,1.84-1.4,2.69-.8,3.13.24,2.08" fill="#ef3d3a"/>
-      <path d="M1013,59.1a10.48,10.48,0,0,0-3,7.38h0a10.5,10.5,0,0,0,3,7.38h0a10,10,0,0,0,7.2,3h0a10,10,0,0,0,7.21-3h0a10.5,10.5,0,0,0,3-7.38h0a10.48,10.48,0,0,0-3-7.38h0a10,10,0,0,0-7.21-3.06h0A10,10,0,0,0,1013,59.1Zm-.47,15.22a11.19,11.19,0,0,1-3.17-7.84h0a11.19,11.19,0,0,1,3.17-7.84h0a10.67,10.67,0,0,1,7.67-3.25h0a10.69,10.69,0,0,1,7.68,3.25h0a11.19,11.19,0,0,1,3.17,7.84h0a11.19,11.19,0,0,1-3.17,7.84h0a10.77,10.77,0,0,1-7.68,3.25h0a10.75,10.75,0,0,1-7.67-3.25h0" fill="#231f20"/>
-      <path d="M1024.67,66.5l-1.6.24-2.16.24-1.41,0-1.36,0-1-.32-.92-1-.73-2-.16-.44-1-.32-.56-.92-.4-1.32.44-1.17,1-.36.85.4.4.88.48-.08.16-.2-.16-.92,0-1.16.24-1.6v-.92l.73-1.17,1.28-.92,2.25-1,2.48.36,2.17,1.56,1,1.61.64,1.16.16,2.88-.48,2.49-.88,2.2-.85,1.17" fill="#f0d6b7"/>
-      <path d="M1023.31,73.43l-5.73.24v1l.48,3.37-.24.28-4-1.36-.28-.48-.4-4.53-.92-2.73-.2-.64,3.2-2.2,1-.4.88,1.08.76.68.88.28.4.12.48,2.08.36.45.93-.32-.65,1.24,3.49,1.64-.44.24" fill="#335061"/>
-      <path d="M1013.81,59.44l1-.36.85.4.4.88.48-.08.12-.48-.24-.92.24-2.2-.2-1.21.72-.84,1.56-1.24-.44-.6-2.2,1.08-.93.72-.52,1.13-.8,1.08-.24,1.28.16,1.36" fill="#6d6b6d"/>
-      <path d="M1015.45,55.68a4.53,4.53,0,0,1,3-2.21c2.41-.72.12-.52.12-.52l-2.6,1-1,1-.44.81.92-.08" fill="#dcd9d8"/>
-      <path d="M1014.25,59.16a2.45,2.45,0,0,1,2.37-3.2l-.12-.49-2.21.53-.64,2.08.16,1.36.44-.28" fill="#dcd9d8"/>
-      <path d="M1015.53,62.89l.53-.51a.36.36,0,0,1,.28.31c0,.28.16,2.81,1.88,4.17.16.12-1.28-.2-1.28-.2l-1.29-2" fill="#f7e4cd"/>
-      <path d="M1022.91,62.13s.09-1.22.42-1.12a.45.45,0,0,1,.33.42s-.8.51-.75.7" fill="#f7e4cd"/>
-      <path d="M1026.24,57.68s-.66.14-.72.72.72.12.84.08" fill="#f7e4cd"/>
-      <path d="M1021.39,57.72s-.89.12-.89.68,1,.52,1.29.28" fill="#f7e4cd"/>
-      <path d="M1015.94,60.32s-1.53-.92-1.69,0-.52,1.53.24,2.45l-.52-.16-.48-1.24-.16-1.21.92-1,1,.08.61.48,0,.61" fill="#f7e4cd"/>
-      <path d="M1016.66,57.8a5.52,5.52,0,0,1,4.13-4.21c2.83-.56,4.32.12,4.89.76,0,0-2.53-3-4.93-2.08s-4.17,2.6-4.13,3.69a16.47,16.47,0,0,1,0,1.84" fill="#f7e4cd"/>
-      <path d="M1026,54.75s-1.17,0-1.21,1a.89.89,0,0,0,.08.32s.93-1,1.49-.48" fill="#f7e4cd"/>
-      <path d="M1020.87,56.18s-.2-1.59-1.57-.66c-.88.6-.8,1.44-.64,1.6s.12.48.24.26.08-.94.52-1.14,1.17-.43,1.45-.06" fill="#f7e4cd"/>
-      <path d="M1017.1,67l-3.77,1.68s1.56,6.22.76,8.14l-.56-.2,0-2.37-1-4.49-.44-1.24,3.93-2.64L1017.1,67" fill="#49728b"/>
-      <path d="M1017.49,70.45l.53.66v2.4h-.64s-.08-1.68-.08-1.88.08-.92.08-.92" fill="#49728b"/>
-      <path d="M1017.5,73.87l-1.81.08.53.36,1.28.2" fill="#49728b"/>
-      <path d="M1023.67,73.47l1.48,0,.37,3.69-1.53.2-.32-3.85" fill="#335061"/>
-      <path d="M1024.07,73.47l2.25-.12s.92-2.32.92-2.44.8-3.37.8-3.37l-1.8-1.88-.36-.32-1,1V70l-.84,3.44" fill="#335061"/>
-      <path d="M1025.07,73.19l-1.4.28.2,1.12c.52.25,1.4-.4,1.4-.4" fill="#49728b"/>
-      <path d="M1025.11,66.18l2.81,2.08.08-1-2.12-2-.77.84" fill="#49728b"/>
-      <path d="M1018.89,81.37l-.83-3.37-.41-2.48-.07-1.85,3.75-.2h2.34l-.21,4.21.36,3.25,0,.6-3,.24-1.84-.4" fill="#fff"/>
-      <path d="M1023.15,73.43a35.58,35.58,0,0,0,.4,7.14,7.74,7.74,0,0,1-3,1l3.37-.12.4-.24-.48-6.58-.12-1.4" fill="#dcd9d8"/>
-      <path d="M1025.58,76.8l1.57-.44,3-.16.44-1.36-.8-2.37-.92-.12-1.28.4-1.23.6-.66-.12-.51.2" fill="#fff"/>
-      <path d="M1025.56,76a5.86,5.86,0,0,1,1.2-.44l-.44-2.21.52-.2s.36,2.09.36,2.33l2.44.12a3.69,3.69,0,0,0,.36-1.89l.45,1.28,0,.73-.65,1-.72.16-1.2,0-.4-.52-1.4.2-.44.16" fill="#dcd9d8"/>
-      <path d="M1024,73.15l-.88-2.24-.92-1.33s.2-.56.48-.56h.92l.88.32-.08,1.49-.4,2.32" fill="#fff"/>
-      <path d="M1024.15,72.39A18.26,18.26,0,0,1,1023,69.9s.2-.48.48-.36.88.44.88.44v-.76l-1.36-.28-.92.12,1.56,3.69.32,0" fill="#dcd9d8"/>
-      <path d="M1019.25,67.1l-1.11-.12-1-.32V67l.51.56,1.6.72" fill="#fff"/>
-      <path d="M1017.46,67.22a4.42,4.42,0,0,0,1.64.4l0,.48-1.12-.24-.68-.48.12-.16" fill="#dcd9d8"/>
-      <path d="M1025.58,69.16a7.48,7.48,0,0,1-1.83-.25,3.74,3.74,0,0,1,0-.6,1.34,1.34,0,0,1,.63-.13,1.13,1.13,0,0,0-.7-.08,1.07,1.07,0,0,0-.12-.37c.39-.13,1.29-1,1.8-.73.24.14.34.94.36,1.34a1.34,1.34,0,0,1-.16.82" fill="#d33833"/>
-      <path d="M1025.58,69.16a7.48,7.48,0,0,1-1.83-.25,3.74,3.74,0,0,1,0-.6,1.34,1.34,0,0,1,.63-.13,1.13,1.13,0,0,0-.7-.08,1.07,1.07,0,0,0-.12-.37c.39-.13,1.29-1,1.8-.73.24.14.34.94.36,1.34A1.34,1.34,0,0,1,1025.58,69.16Z" fill="none" stroke="#d33833" stroke-width="2"/>
-      <path d="M1022.33,68.05a.76.76,0,0,0,0,.15,8.13,8.13,0,0,1-.79.26,2.05,2.05,0,0,1,.85.21c0,.13,0,.26,0,.39a13.17,13.17,0,0,1-1.21.91,3,3,0,0,1-1.21.37c-.13,0-.14-.19-.19-.34a5,5,0,0,1-.39-1.34c0-.62-.09-1.66.58-1.53a5.73,5.73,0,0,1,1.59.58,1.6,1.6,0,0,0,.79.34" fill="#d33833"/>
-      <path d="M1022.33,68.05a.76.76,0,0,0,0,.15,8.13,8.13,0,0,1-.79.26,2.05,2.05,0,0,1,.85.21c0,.13,0,.26,0,.39a13.17,13.17,0,0,1-1.21.91,3,3,0,0,1-1.21.37c-.13,0-.14-.19-.19-.34a5,5,0,0,1-.39-1.34c0-.62-.09-1.66.58-1.53a5.73,5.73,0,0,1,1.59.58A1.6,1.6,0,0,0,1022.33,68.05Z" fill="none" stroke="#d33833" stroke-width="2"/>
-      <path d="M1022.71,68.79a2.5,2.5,0,0,1-.1-.73c.9-.6,1.07,1,.1.73" fill="#d33833"/>
-      <path d="M1022.71,68.79a2.5,2.5,0,0,1-.1-.73C1023.51,67.46,1023.68,69.09,1022.71,68.79Z" fill="none" stroke="#d33833" stroke-width="2"/>
-      <path d="M1024,69.06s-.28-.4-.08-.52.4,0,.52-.2,0-.32,0-.56.24-.28.44-.32.76-.12.84.08l-.24-.72-.48-.16-1.52.88-.08.44v.88" fill="#ef3d3a"/>
-      <path d="M1019.81,70.39l-.15-1.88c-.09-.93.22-.77,1-.77a2.15,2.15,0,0,1,.8.24c.22.45-.36.35.26.69s1.44-.18,1.23-.81c-.12-.14-.62,0-.79-.14l-.94-.48c-.4-.21-1.32-.51-1.75-.22-1.07.73.07,2.56.45,3.32" fill="#ef3d3a"/>
-      <path d="M1020.87,56.18a1.65,1.65,0,0,0-2,1.2c-.3-.07-.18-.47-.1-.68a1.85,1.85,0,0,1,1.62-1.16c.28.05.66.3.45.64" fill="#231f20"/>
-      <path d="M1026.19,57.43h0a11.88,11.88,0,0,0,.77,1.51c-.21.49-1.58.92-1.56,0,.3-.13.81,0,1.08-.19a2.82,2.82,0,0,1-.34-1.36" fill="#231f20"/>
-      <path d="M1021.43,57.44a4.64,4.64,0,0,0,.64,1.21c.15.14.44.32.3.73a1,1,0,0,1-.43.35c-.52.15-1.73,0-1.32-.62.43,0,1,.28,1.33,0-.25-.4-.69-1.18-.52-1.64" fill="#231f20"/>
-      <path d="M1026,61.81a4.32,4.32,0,0,1-2.94.92.88.88,0,0,1-.11-1.12c.14.24,0,.68.44.74.73.13,1.57-.44,2.1-.64.32-.55,0-.75-.32-1.1a4.39,4.39,0,0,1-1.38-2.7c.25-.18.27.26.3.35a9.76,9.76,0,0,0,1.68,2.29c.14.16.37.3.4.41.07.29-.2.65-.17.85" fill="#231f20"/>
-      <path d="M1015.66,61.28c-.24-.14-.3-.76-.59-.78s-.34.8-.34,1.29a1.52,1.52,0,0,1-.12-1.46c-.24-.12-.35.13-.48.21.17-1.23,1.8-.57,1.53.74" fill="#231f20"/>
-      <path d="M1026.49,62.32a2.25,2.25,0,0,1-2,1.48,2.71,2.71,0,0,1,0-.7,5.7,5.7,0,0,0,2-.78" fill="#231f20"/>
-      <path d="M1021.36,62.77a6.75,6.75,0,0,0,2.87.37,3.3,3.3,0,0,1,0,.7c-1.19.06-2.6-.23-2.92-1.07" fill="#231f20"/>
-      <path d="M1021.23,63.44c.48,1.18,2.1,1,3.47,1a.76.76,0,0,1-.36.41,3.53,3.53,0,0,1-2.25,0,3.11,3.11,0,0,1-.85-.94c-.1-.14-.61-.47,0-.47" fill="#231f20"/>
-      <path d="M1025.94,70a24.86,24.86,0,0,1-1.75,2.76,13,13,0,0,0,.44-3.2,1,1,0,0,1,1.31.44" fill="#81b0c4"/>
-      <path d="M1028.92,73.39c-.62.12-1.06.73-1.66.69a2,2,0,0,1,1.66-.69" fill="#231f20"/>
-      <path d="M1029.19,74.36a9.6,9.6,0,0,1-1.61.09c.24-.37,1.18-.24,1.61-.09" fill="#231f20"/>
-      <path d="M1029.37,75.2a18.18,18.18,0,0,1-1.82,0c.32-.34,1.45-.13,1.82,0" fill="#231f20"/>
-      <path d="M1024.87,77.49a13.94,13.94,0,0,1,.33,2.22,2.5,2.5,0,0,1-.92.19c0-.66-.12-1.68-.09-2.31.21,0,.51-.15.68-.1" fill="#dcd9d8"/>
-      <path d="M1024,67c-.28.19-.53.42-.8.62a1.81,1.81,0,0,1-1.39-.39s.06,0,.06,0c.65.29,1.47-.12,2.13-.18" fill="#f0d6b7"/>
-      <path d="M1020.54,71.4c.17-.77.88-1.17,1.51-1.6a12.71,12.71,0,0,1,1.5,2.94,14.83,14.83,0,0,1-3-1.34" fill="#81b0c4"/>
-      <path d="M1024.19,77.59c0,.63.06,1.65.09,2.31a2.5,2.5,0,0,0,.92-.19,13.94,13.94,0,0,0-.33-2.22C1024.7,77.44,1024.4,77.6,1024.19,77.59Zm-6.56-3.6a33.15,33.15,0,0,0,1.42,7,9.28,9.28,0,0,0,5.06.09c-.27-1.28-.15-2.83-.31-4.19-.11-1-.06-2-.22-3.1A17.49,17.49,0,0,0,1017.63,74Zm6.37-.22c0,1.09,0,2.18.13,3.27.42-.06.71-.1,1.1-.19a24.1,24.1,0,0,0-.37-3.18,2.81,2.81,0,0,0-.86.1Zm2.13-.18a3.21,3.21,0,0,0-.62,0c.09.9.31,1.88.39,2.82a2.39,2.39,0,0,0,.7-.18,5.55,5.55,0,0,0-.47-2.64Zm3.24,3a1.4,1.4,0,0,0,.84-1.71,8.21,8.21,0,0,0-.55-1.86c-.16-.25-.61-.58-1-.35-.58.37-1.61.48-2,.93a14.54,14.54,0,0,1,.37,2.58,7.8,7.8,0,0,1,2.23.06,9.05,9.05,0,0,0-1.34.34,2.75,2.75,0,0,0,1.46,0Zm-5.82-3.81a12.71,12.71,0,0,0-1.5-2.94c-.63.43-1.33.83-1.51,1.6a14.83,14.83,0,0,0,3,1.34Zm1.08-3.2a13,13,0,0,1-.44,3.2,24.86,24.86,0,0,0,1.75-2.76A1,1,0,0,0,1024.63,69.54Zm-1.23-.44c-.25,0-.46.29-.78.15-.08.08-.14.17-.22.25a18.84,18.84,0,0,1,1.59,3.1,13.64,13.64,0,0,0,.33-3.1C1023.91,69.53,1023.69,69.13,1023.4,69.1Zm-.79-1a2.5,2.5,0,0,0,.1.73c1,.3.8-1.33-.1-.73Zm-1.07-.35a5.73,5.73,0,0,0-1.59-.58c-.67-.13-.61.91-.58,1.53a5,5,0,0,0,.39,1.34c0,.15.06.31.19.34a3,3,0,0,0,1.21-.37,13.17,13.17,0,0,0,1.21-.91v-.39a2.05,2.05,0,0,0-.85-.21,8.13,8.13,0,0,0,.79-.26s0-.1,0-.15A1.6,1.6,0,0,1,1021.54,67.71Zm-4-.73c-.34.35,1,.83,1.4.86,0-.22.12-.43.1-.59-.5-.09-1.16,0-1.5-.27Zm4.28.17s-.05,0-.06,0a1.81,1.81,0,0,0,1.39.39c.27-.2.52-.43.8-.62-.66.06-1.48.47-2.13.18Zm3.92,1.19c0-.4-.12-1.2-.36-1.34-.51-.3-1.41.6-1.8.73a1.07,1.07,0,0,1,.12.37,1.13,1.13,0,0,1,.7.08,1.47,1.47,0,0,0-.63.13,3.74,3.74,0,0,0,0,.6,7.48,7.48,0,0,0,1.83.25A1.34,1.34,0,0,0,1025.74,68.34Zm-8.78-1c-.11-.08-.85-1-1-1a16.25,16.25,0,0,0-3.7,2.3,19.89,19.89,0,0,1,1.57,7.77c1.22.57,2.29,1.39,3.94,1.47-.19-1.35-.36-2.56-.47-3.83-.42-.17-1,0-1.4,0,0-.47.59-.21.64-.52s-.33-.26-.21-.63c.31.11.46.35.79.44.29-.65,0-1.79,0-2.33,0-.1,0-.57.28-.48s0,1.22,0,1.73a2.72,2.72,0,0,0,.13,1.23,45.48,45.48,0,0,1,4.94-.41,11.44,11.44,0,0,1-1.32-.59c-.27-.15-1.12-.47-1.19-.72-.13-.41.32-.63.4-1-.81.44-1-.43-1.16-1a7.71,7.71,0,0,1-.31-1.28,13.09,13.09,0,0,1-2-1.09Zm8.08-.88c1.11-.54,1.31,2,.87,2.84.07.24.3.34.4.56-.63,1.11-1.31,2.14-2,3.24.47-.29,1.15,0,1.7-.27.2-.08.35-.54.5-.91a19.49,19.49,0,0,0,1.06-3.28,3.8,3.8,0,0,0,.14-.91c0-.35-.53-.61-.77-.83-.45-.4-.73-.76-1.2-1.14-.19.28-.6.47-.75.7Zm-10.62-9.86a3.46,3.46,0,0,0-.36,2.45,1.43,1.43,0,0,1,2.22,1.08c.45,0,.17-.57.09-.93-.27-1.18.45-2.46,0-3.53a2.87,2.87,0,0,0-2,.93Zm3.79-3.38a5.34,5.34,0,0,0-3.23,2.29,9.6,9.6,0,0,1,1-.27,2.61,2.61,0,0,0,.49,0c.33-.08.6-.81.85-1.09s.53-.37.72-.62c.13-.06.32-.05.32-.24S1018.27,53.18,1018.21,53.2Zm6.24.32c-1.25-.7-3.35-1.23-4.68-.57a6.38,6.38,0,0,0-3,2.53c.46,1.08-.14,2.07-.18,3.16,0,.58.28,1.09.3,1.72-.16.26-.64.3-1,.28-.11-.56-.31-1.19-.89-1.26a1.35,1.35,0,0,0-1.45,1.3c0,.83.64,2.2,1.61,2.11.37,0,.46-.41.87-.41.22.44-.34.58-.4.89a3.31,3.31,0,0,0,.08.55,7.43,7.43,0,0,0,1,2.22c.49.7,1.45.81,2.48.87.18-.39.86-.36,1.31-.26a4.43,4.43,0,0,1-1.44-1.17,3,3,0,0,1-1-1.75,6.39,6.39,0,0,0,3.24,2.85,4.31,4.31,0,0,0,3.59-.85,4.05,4.05,0,0,0,.9-1.1,9.4,9.4,0,0,0,1.41-5.68,6.11,6.11,0,0,0-.33-2.27c-.3-.6-1.3-1.14-1.89-.59-.11-.59.49-1,1.19-.74A6.61,6.61,0,0,0,1024.45,53.52Zm2.31,19.19c1-.48,2.79-1.3,3.4,0a10.5,10.5,0,0,1,.61,1.79c.16.7-.18,2.17-.9,2.4a4.16,4.16,0,0,1-2.14,0,1.1,1.1,0,0,1-.26-.34,2.9,2.9,0,0,0-1.49.26c0,.4-.23.46-.49.55-.19.75.38,1.73.25,2.42-.1.49-.7.56-1.14.66a3.62,3.62,0,0,0,0,.73,1.09,1.09,0,0,1-1,.63,12.35,12.35,0,0,1-4.92-.24c-.38-.93-.68-2.06-1-3.13a6.44,6.44,0,0,1-3.41-1c-.35-.16-.83-.25-1-.53a4.52,4.52,0,0,1-.11-1.27,19.35,19.35,0,0,0-.48-3.73c-.14-.58-.4-1.08-.58-1.63a11,11,0,0,1-.53-1.66c-.12-.76.6-.8,1.05-1.13.71-.5,1.26-.78,2-1.24a4.71,4.71,0,0,0,1-.64c.15-.31-.27-.75-.38-1a2.81,2.81,0,0,1-.29-1.1,2.08,2.08,0,0,1-1.42-.91,3.48,3.48,0,0,1-.4-3c0-.08.19-.23.22-.35a3.82,3.82,0,0,0-.1-.81c-.05-1.3.22-2.42,1.09-2.81.36-1.42,1.63-1.89,2.83-2.59a9.44,9.44,0,0,1,1.45-.62,7.29,7.29,0,0,1,6.15.6,8.3,8.3,0,0,1,2,2.26c1,2,.9,5.25.23,7.64a9.68,9.68,0,0,1-.41,1.18c-.13.27-.53.8-.48,1s.91.9,1.09,1.08c.34.32,1,.75,1,1.16a4.09,4.09,0,0,1-.31,1.44c-.42,1.39-.82,2.68-1.29,3.92" fill="#231f20"/>
-      <path d="M1020.28,63.07c.05-.07.34-.17.75,0,0,0-.49.08-.45.88l-.2,0s-.2-.72-.1-.86" fill="#f7e4cd"/>
-      <path d="M1023.79,70a.22.22,0,1,1-.44,0,.22.22,0,0,1,.44,0h0" fill="#1d1919"/>
-      <path d="M1024,71a.22.22,0,1,1-.22-.22.22.22,0,0,1,.22.22h0" fill="#1d1919"/>
-    </g>
-    <path id="a91f0ca4-8fb7-4019-9c09-0a52e2c05754" d="M973,57.6V75.84L965.53,82l-11.61-4.23v4.19l-6.57-8.59,19.15,1.5V58.42Zm-6.39.92L955.89,52v4.29L946,59.17l-3,3.8v8.64l4.23,1.87V62.41Z" fill="url(#linear-gradient-34)"/>
-    <path d="M735.58,198.51a45.77,45.77,0,0,0-2-7.68,10.62,10.62,0,0,1-1.3,2.32A12.25,12.25,0,0,0,713,195.4a8.14,8.14,0,0,1,5,2.1,8.45,8.45,0,0,0-4.72-1.39,8.67,8.67,0,1,0,0,17.33h20a7.65,7.65,0,0,0,2.33-14.93Zm-18.66,12.25a1.06,1.06,0,0,1-1.48.16,1,1,0,1,1,1.48-.16Zm16.62-3.66c-3,4-9.48,2.66-13.62,2.86,0,0-.73,0-1.47.16,0,0,.28-.12.64-.24,2.9-1,4.28-1.21,6-2.12,3.31-1.7,6.62-5.4,7.29-9.25-1.26,3.7-5.11,6.89-8.6,8.18a58,58,0,0,1-6.73,1.75l-.18-.1c-2.94-1.43-3-7.81,2.32-9.86,2.35-.91,4.59-.41,7.13-1,2.7-.65,5.83-2.67,7.11-5.32C734.9,196.38,736.62,203,733.54,207.1Z" fill="#68bd45"/>
-    <path d="M801.53,198.51a47.79,47.79,0,0,0-2-7.68,11.08,11.08,0,0,1-1.31,2.32,12.25,12.25,0,0,0-19.29,2.25,8.15,8.15,0,0,1,5,2.1,8.51,8.51,0,0,0-4.73-1.39,8.67,8.67,0,1,0,0,17.33h20a7.65,7.65,0,0,0,2.33-14.93Zm-18.67,12.25a1,1,0,0,1-1.63-1.31,1.06,1.06,0,0,1,1.48-.16A1,1,0,0,1,782.86,210.76Zm16.63-3.66c-3,4-9.48,2.66-13.62,2.86,0,0-.74,0-1.47.16,0,0,.27-.12.63-.24,2.91-1,4.28-1.21,6.05-2.12,3.32-1.7,6.62-5.4,7.29-9.25-1.26,3.7-5.1,6.89-8.6,8.18a58,58,0,0,1-6.73,1.75l-.17-.1c-3-1.43-3-7.81,2.32-9.86,2.34-.91,4.59-.41,7.12-1,2.71-.65,5.84-2.67,7.11-5.32C800.85,196.38,802.56,203,799.49,207.1Z" fill="#68bd45"/>
-    <g>
-      <g>
-        <path d="M652.87,350.71l-6.38,6.35a.29.29,0,0,1-.4.06l-.05-.06-6.36-6.35a.34.34,0,0,1,0-.48.37.37,0,0,1,.2-.09h3.74a.31.31,0,0,0,.33-.3s0-.06,0-.1v-8.22a.3.3,0,0,1,.33-.28h4a.31.31,0,0,1,.31.31v8.19a.31.31,0,0,0,.31.32h3.77a.34.34,0,1,1,.23.65Z" fill="#68bd45"/>
-        <path d="M661.18,376.93l-6-10.38a3.63,3.63,0,0,0-2.84-1.64h-12a3.64,3.64,0,0,0-2.84,1.64l-6,10.38a3.64,3.64,0,0,0,0,3.28l6,10.39a3.63,3.63,0,0,0,2.84,1.63h12a3.62,3.62,0,0,0,2.84-1.63l6-10.39A3.64,3.64,0,0,0,661.18,376.93Zm-16.13-6.28a1.24,1.24,0,0,1,2.48,0V378a1.24,1.24,0,0,1-2.48,0Zm1.24,15.77a8.38,8.38,0,0,1-5-15.11,1.1,1.1,0,1,1,1.31,1.76,6.19,6.19,0,1,0,7.35,0,1.1,1.1,0,0,1,1.31-1.77,8.38,8.38,0,0,1-5,15.13Z" fill="#68bd45"/>
-      </g>
-      <g>
-        <circle cx="729.57" cy="377.13" r="2.49"/>
-        <circle cx="737.08" cy="377.13" r="2.49"/>
-        <circle cx="744.59" cy="377.13" r="2.49"/>
-      </g>
-      <g>
-        <path d="M698.64,350.71l-6.38,6.35a.29.29,0,0,1-.4.06l-.05-.06-6.35-6.35a.34.34,0,0,1,0-.48.4.4,0,0,1,.2-.09h3.75a.31.31,0,0,0,.32-.3.38.38,0,0,0,0-.1v-8.22a.3.3,0,0,1,.34-.28H694a.31.31,0,0,1,.31.31v8.19a.31.31,0,0,0,.31.32h3.78a.34.34,0,0,1,.44.21.35.35,0,0,1-.22.44Z" fill="#68bd45"/>
-        <path d="M707,376.93l-6-10.38a3.64,3.64,0,0,0-2.84-1.64h-12a3.63,3.63,0,0,0-2.84,1.64l-6,10.38a3.64,3.64,0,0,0,0,3.28l6,10.39a3.62,3.62,0,0,0,2.84,1.63h12A3.63,3.63,0,0,0,701,390.6l6-10.39A3.64,3.64,0,0,0,707,376.93Zm-16.12-6.28a1.24,1.24,0,0,1,2.47,0V378a1.24,1.24,0,0,1-2.47,0Zm1.23,15.77a8.38,8.38,0,0,1-5-15.11,1.1,1.1,0,0,1,1.32,1.76,6.18,6.18,0,1,0,9.86,5,6.21,6.21,0,0,0-2.51-5,1.1,1.1,0,1,1,1.3-1.77,8.38,8.38,0,0,1-5,15.13Z" fill="#68bd45"/>
-      </g>
-      <path d="M798.5,376.93l-6-10.38a3.64,3.64,0,0,0-2.84-1.64h-12a3.64,3.64,0,0,0-2.84,1.64l-6,10.38a3.58,3.58,0,0,0,0,3.28l6,10.39a3.63,3.63,0,0,0,2.84,1.63h12a3.63,3.63,0,0,0,2.84-1.63l6-10.39A3.64,3.64,0,0,0,798.5,376.93Zm-16.13-6.28a1.24,1.24,0,0,1,2.47,0V378a1.24,1.24,0,0,1-2.47,0Zm1.24,15.77a8.38,8.38,0,0,1-5-15.11,1.1,1.1,0,0,1,1.54.23,1.09,1.09,0,0,1-.23,1.53,6.13,6.13,0,0,0-2.5,5,6.19,6.19,0,1,0,9.85-5,1.1,1.1,0,0,1,1.3-1.77,8.38,8.38,0,0,1-5,15.13Z" fill="#68bd45"/>
-    </g>
-    <g>
-      <g>
-        <rect x="7.4" y="140.81" width="91" height="325.71" rx="4" fill="#fff"/>
-        <rect x="7.4" y="140.81" width="91" height="325.71" rx="4" fill="#505150" opacity="0.07"/>
-        <rect x="7.4" y="140.81" width="91" height="325.71" rx="4" fill="none" stroke="#505150" stroke-width="0.8" opacity="0.15"/>
-      </g>
-      <path d="M94.4,467.07h-.11V466h.11a2.56,2.56,0,0,0,.62-.07l.14,1.08A3.85,3.85,0,0,1,94.4,467.07Zm-2.1,0h-.8V466h.8Zm-2.8,0h-.8V466h.8Zm-2.79,0h-.8V466h.8Zm-2.8,0h-.79V466h.79Zm-2.79,0h-.8V466h.8Zm-2.79,0h-.8V466h.8Zm-2.8,0h-.8V466h.8Zm-2.79,0h-.8V466h.8Zm-2.8,0h-.8V466h.8Zm-2.79,0h-.8V466h.8Zm-2.8,0h-.8V466h.8Zm-2.79,0h-.8V466h.8Zm-2.8,0H58V466h.79Zm-2.79,0h-.8V466H56Zm-2.79,0h-.8V466h.8Zm-2.8,0h-.8V466h.8Zm-2.79,0h-.8V466h.8Zm-2.8,0H44V466h.8Zm-2.79,0h-.8V466H42Zm-2.8,0h-.79V466h.79Zm-2.79,0h-.8V466h.8Zm-2.79,0h-.8V466h.8Zm-2.8,0H30V466h.8Zm-2.79,0h-.8V466H28Zm-2.8,0h-.8V466h.8Zm-2.79,0h-.8V466h.8Zm-2.8,0h-.79V466h.79Zm-2.79,0h-.8V466h.8Zm-2.79,0h-.8V466h.8Zm-2.81,0a3.18,3.18,0,0,1-.87-.16l.18-1.06a3,3,0,0,0,.71.13Zm85.89-1.31-.5-.86a4.47,4.47,0,0,0,.51-.68l.61.7A6.09,6.09,0,0,1,97.14,465.75Zm-88.68-.24a5,5,0,0,1-.59-.88l.64-.66a4.19,4.19,0,0,0,.48.73Zm90.25-3.27-.78-.22a7.93,7.93,0,0,0,.07-1l.8-.06V461A7.88,7.88,0,0,1,98.71,462.24ZM7,461.88A7.63,7.63,0,0,1,7,461v-.33h.8V461c0,.24,0,.46,0,.69Zm91.76-3.63H98v-1.09h.8ZM7.8,458H7v-1.09h.8Zm91-3.56H98v-1.09h.8Zm-91-.26H7v-1.1h.8Zm91-3.56H98v-1.09h.8Zm-91-.27H7v-1.09h.8Zm91-3.55H98v-1.1h.8Zm-91-.27H7v-1.09h.8Zm91-3.56H98v-1.09h.8Zm-91-.27H7v-1.09h.8Zm91-3.55H98V438h.8Zm-91-.27H7v-1.09h.8Zm91-3.56H98v-1.09h.8ZM7.8,435H7v-1.1h.8Zm91-3.56H98v-1.09h.8Zm-91-.27H7v-1.09h.8Zm91-3.55H98v-1.1h.8Zm-91-.27H7V426.3h.8Zm91-3.56H98v-1.09h.8Zm-91-.27H7v-1.09h.8Zm91-3.55H98v-1.09h.8Zm-91-.27H7v-1.09h.8Zm91-3.56H98v-1.09h.8Zm-91-.26H7v-1.1h.8Zm91-3.56H98v-1.09h.8Zm-91-.27H7V411h.8Zm91-3.55H98v-1.1h.8Zm-91-.27H7v-1.1h.8Zm91-3.56H98v-1.09h.8Zm-91-.27H7v-1.09h.8Zm91-3.55H98V399.8h.8Zm-91-.27H7v-1.09h.8Zm91-3.56H98V396h.8Zm-91-.26H7v-1.1h.8Zm91-3.56H98v-1.09h.8ZM7.8,393H7v-1.09h.8Zm91-3.55H98v-1.1h.8Zm-91-.27H7v-1.1h.8Zm91-3.56H98V384.5h.8Zm-91-.27H7v-1.09h.8Zm91-3.55H98v-1.1h.8Zm-91-.27H7v-1.09h.8Zm91-3.56H98v-1.09h.8Zm-91-.26H7v-1.1h.8Zm91-3.56H98V373h.8Zm-91-.27H7v-1.09h.8Zm91-3.55H98v-1.1h.8ZM7.8,370H7v-1.1h.8Zm91-3.56H98v-1.09h.8Zm-91-.27H7v-1.09h.8Zm91-3.55H98v-1.1h.8Zm-91-.27H7v-1.09h.8Zm91-3.56H98v-1.09h.8Zm-91-.27H7v-1.09h.8Zm91-3.55H98v-1.09h.8Zm-91-.27H7v-1.09h.8Zm91-3.56H98v-1.09h.8Zm-91-.26H7v-1.1h.8Zm91-3.56H98v-1.09h.8Zm-91-.27H7V346h.8Zm91-3.55H98v-1.1h.8Zm-91-.27H7v-1.09h.8Zm91-3.56H98v-1.09h.8Zm-91-.27H7v-1.09h.8Zm91-3.55H98v-1.09h.8Zm-91-.27H7v-1.09h.8Zm91-3.56H98V331h.8Zm-91-.26H7v-1.1h.8Zm91-3.56H98v-1.09h.8ZM7.8,328H7v-1.09h.8Zm91-3.55H98v-1.1h.8Zm-91-.27H7v-1.09h.8Zm91-3.56H98v-1.09h.8Zm-91-.27H7v-1.09h.8Zm91-3.55H98v-1.09h.8Zm-91-.27H7V315.4h.8Zm91-3.56H98v-1.09h.8Zm-91-.26H7v-1.1h.8Zm91-3.56H98V308h.8Zm-91-.27H7v-1.09h.8Zm91-3.55H98v-1.1h.8ZM7.8,305H7v-1.09h.8Zm91-3.56H98v-1.09h.8Zm-91-.27H7V300.1h.8Zm91-3.55H98v-1.09h.8Zm-91-.27H7v-1.09h.8Zm91-3.56H98v-1.09h.8Zm-91-.26H7v-1.1h.8Zm91-3.56H98V288.9h.8Zm-91-.27H7v-1.09h.8Zm91-3.55H98v-1.1h.8Zm-91-.27H7v-1.1h.8Zm91-3.56H98v-1.09h.8Zm-91-.27H7V281h.8Zm91-3.55H98v-1.09h.8Zm-91-.27H7v-1.09h.8Zm91-3.56H98V273.6h.8Zm-91-.26H7v-1.1h.8Zm91-3.56H98v-1.09h.8Zm-91-.27H7v-1.09h.8Zm91-3.55H98V266h.8Zm-91-.27H7v-1.1h.8Zm91-3.56H98v-1.09h.8ZM7.8,263H7v-1.09h.8Zm91-3.55H98v-1.1h.8Zm-91-.27H7V258h.8Zm91-3.56H98v-1.09h.8Zm-91-.26H7v-1.1h.8Zm91-3.56H98v-1.09h.8Zm-91-.27H7v-1.09h.8Zm91-3.56H98v-1.09h.8Zm-91-.26H7v-1.1h.8Zm91-3.56H98V243h.8Zm-91-.27H7v-1.09h.8Zm91-3.55H98v-1.1h.8ZM7.8,240H7v-1.09h.8Zm91-3.56H98v-1.09h.8Zm-91-.27H7v-1.09h.8Zm91-3.55H98v-1.09h.8Zm-91-.27H7v-1.09h.8Zm91-3.56H98v-1.09h.8Zm-91-.26H7v-1.1h.8Zm91-3.56H98v-1.09h.8Zm-91-.27H7v-1.09h.8Zm91-3.55H98v-1.1h.8Zm-91-.27H7V219.8h.8Zm91-3.56H98v-1.09h.8Zm-91-.27H7V216h.8Zm91-3.55H98v-1.09h.8Zm-91-.27H7v-1.09h.8Zm91-3.56H98v-1.09h.8Zm-91-.26H7v-1.1h.8Zm91-3.56H98v-1.09h.8Zm-91-.27H7V204.5h.8Zm91-3.55H98v-1.1h.8Zm-91-.27H7v-1.09h.8Zm91-3.56H98v-1.09h.8Zm-91-.27H7v-1.09h.8Zm91-3.55H98V193.3h.8Zm-91-.27H7V193h.8Zm91-3.56H98v-1.09h.8Zm-91-.26H7v-1.1h.8Zm91-3.56H98v-1.09h.8Zm-91-.27H7v-1.09h.8Zm91-3.55H98v-1.1h.8Zm-91-.27H7v-1.09h.8Zm91-3.56H98V178h.8Zm-91-.27H7v-1.09h.8Zm91-3.55H98v-1.1h.8ZM7.8,175H7v-1.09h.8Zm91-3.56H98v-1.09h.8Zm-91-.26H7v-1.1h.8Zm91-3.56H98v-1.09h.8Zm-91-.27H7v-1.09h.8Zm91-3.55H98v-1.1h.8Zm-91-.27H7v-1.1h.8Zm91-3.56H98v-1.09h.8Zm-91-.27H7v-1.09h.8Zm91-3.55H98v-1.1h.8Zm-91-.27H7v-1.09h.8Zm91-3.56H98v-1.09h.8Zm-91-.27H7V151h.8Zm91-3.55H98v-1.09h.8Zm-91-.27H7v-1.09h.8Zm90-3.37a6.83,6.83,0,0,0-.27-.91l.7-.52a8,8,0,0,1,.34,1.11ZM8,144.63l-.75-.37a7.22,7.22,0,0,1,.37-1.08l.69.56A5.2,5.2,0,0,0,8,144.63Zm88.35-2.47a3.09,3.09,0,0,0-.64-.45l.3-1a4.15,4.15,0,0,1,.78.56ZM9.59,142l-.41-.94a4,4,0,0,1,.8-.5l.26,1A3.39,3.39,0,0,0,9.59,142Zm84.32-.67h-.8v-1.09h.8Zm-2.79,0h-.8v-1.09h.8Zm-2.8,0h-.79v-1.09h.79Zm-2.79,0h-.8v-1.09h.8Zm-2.79,0h-.8v-1.09h.8Zm-2.8,0h-.8v-1.09h.8Zm-2.79,0h-.8v-1.09h.8Zm-2.8,0h-.8v-1.09h.8Zm-2.79,0h-.8v-1.09h.8Zm-2.8,0H68v-1.09h.79Zm-2.79,0h-.8v-1.09H66Zm-2.79,0h-.8v-1.09h.8Zm-2.8,0h-.8v-1.09h.8Zm-2.79,0h-.8v-1.09h.8Zm-2.8,0H54v-1.09h.8Zm-2.79,0h-.8v-1.09H52Zm-2.8,0h-.79v-1.09h.79Zm-2.79,0h-.8v-1.09h.8Zm-2.79,0h-.8v-1.09h.8Zm-2.8,0H40v-1.09h.8Zm-2.79,0h-.8v-1.09H38Zm-2.8,0h-.8v-1.09h.8Zm-2.79,0h-.8v-1.09h.8Zm-2.8,0h-.8v-1.09h.8Zm-2.79,0h-.8v-1.09h.8Zm-2.8,0h-.79v-1.09h.79Zm-2.79,0h-.8v-1.09h.8Zm-2.79,0h-.8v-1.09h.8Zm-2.8,0h-.8v-1.09h.8Zm-2.79,0h-.8v-1.09h.8Z" fill="#505150" opacity="0.65"/>
-    </g>
-    <g>
-      <rect x="41.92" y="210.68" width="21.8" height="21.8" rx="1.01" transform="translate(-141.21 102.25) rotate(-45)" fill="url(#linear-gradient-35)"/>
-      <path d="M49.4,214l3.32-3.32a.16.16,0,0,1,.24,0L56.37,214a.16.16,0,0,1,0,.22.15.15,0,0,1-.15.06h-2a.18.18,0,0,0-.18.18h0v4.29a.16.16,0,0,1-.16.16H51.82a.17.17,0,0,1-.18-.14v-4.31a.18.18,0,0,0-.16-.18h-2a.17.17,0,0,1-.16-.19A.25.25,0,0,1,49.4,214Zm7,15.25L53,232.53a.16.16,0,0,1-.24,0l-3.32-3.32a.18.18,0,0,1,0-.25.16.16,0,0,1,.09,0h2a.18.18,0,0,0,.16-.18v-4.29a.16.16,0,0,1,.16-.16h2.08a.16.16,0,0,1,.16.16h0v4.29a.18.18,0,0,0,.18.18h1.94a.19.19,0,0,1,.25,0A.18.18,0,0,1,56.37,229.21Zm-10-4.38v-1.94a.2.2,0,0,0-.18-.18H41.91a.16.16,0,0,1-.17-.15v-2.07a.19.19,0,0,1,.17-.18H46.2a.17.17,0,0,0,.18-.15v-2a.16.16,0,0,1,.09-.21.17.17,0,0,1,.19.06L50,221.41a.16.16,0,0,1,0,.22h0L46.66,225a.16.16,0,0,1-.22,0A.17.17,0,0,1,46.38,224.83ZM59.3,218.2v2a.17.17,0,0,0,.18.15h4.29a.21.21,0,0,1,.18.18v2.07a.17.17,0,0,1-.18.15H59.48a.2.2,0,0,0-.18.18v1.94a.16.16,0,0,1-.13.19A.17.17,0,0,1,59,225l-3.32-3.37a.17.17,0,0,1,0-.23h0L59,218.05a.16.16,0,0,1,.22,0A.16.16,0,0,1,59.3,218.2Z" fill="#fff"/>
-    </g>
-    <g>
-      <path d="M20.64,448.57v23.32a.82.82,0,0,1-.81.84H6.77a.81.81,0,0,1-.83-.81V448.57a.83.83,0,0,1,.81-.84H19.8a.83.83,0,0,1,.84.81Z" fill="url(#linear-gradient-36)"/>
-      <path id="a1bc77ea-5288-41a0-8f9a-2d282cf54a86" d="M7.89,450.33h2.46a.21.21,0,0,1,.2.21v3.09a.2.2,0,0,1-.2.2H7.89a.23.23,0,0,1-.22-.2v-3.09A.23.23,0,0,1,7.89,450.33Zm4.21,0h2.38a.22.22,0,0,1,.21.21h0v3.09a.21.21,0,0,1-.21.2H12.1a.2.2,0,0,1-.21-.2h0v-3.09a.21.21,0,0,1,.21-.21Zm4.2,0h2.39a.23.23,0,0,1,.22.21v3.09a.23.23,0,0,1-.22.2H16.3a.2.2,0,0,1-.2-.2h0v-3.09a.21.21,0,0,1,.2-.21Zm-8.41,5.61h2.46a.2.2,0,0,1,.2.2v3.09a.22.22,0,0,1-.2.22H7.89a.22.22,0,0,1-.22-.22v-3.09A.23.23,0,0,1,7.89,455.94Zm4.21,0h2.38a.21.21,0,0,1,.21.2h0v3.09a.22.22,0,0,1-.21.22H12.1a.22.22,0,0,1-.21-.22v-3.09a.2.2,0,0,1,.21-.2Zm4.2,0h2.39a.23.23,0,0,1,.22.2v3.09a.22.22,0,0,1-.22.22H16.3a.22.22,0,0,1-.2-.22v-3.09a.2.2,0,0,1,.2-.2Zm-8.41,5.62h2.46a.2.2,0,0,1,.2.2h0v3.09a.21.21,0,0,1-.2.21H7.89a.23.23,0,0,1-.22-.21V461.7A.21.21,0,0,1,7.89,461.56Zm4.21,0h2.38a.2.2,0,0,1,.27.11v3.12a.21.21,0,0,1-.21.21H12.1a.21.21,0,0,1-.21-.21h0V461.7A.2.2,0,0,1,12.1,461.56Zm0,5.6h2.38a.21.21,0,0,1,.21.2h0V472a.21.21,0,0,1-.21.2H12.1a.2.2,0,0,1-.21-.2v-4.64A.2.2,0,0,1,12.1,467.16Zm4.2-5.6h2.39a.22.22,0,0,1,.22.2v3.09a.23.23,0,0,1-.22.21H16.3a.21.21,0,0,1-.2-.21h0V461.7A.19.19,0,0,1,16.3,461.56Z" fill="#f2f2f2"/>
-    </g>
-    <g>
-      <g>
-        <polygon points="56.17 325.97 69.71 334.75 83.49 325.93 85.21 327.95 69.71 337.93 54.44 327.95 56.17 325.97" fill="#74cfeb"/>
-        <polygon points="57.2 324.84 69.71 309.93 82.48 324.86 69.71 332.92 57.2 324.84" fill="#fff"/>
-        <polygon points="69.71 309.93 69.71 332.92 57.2 324.84 69.71 309.93" fill="#74cfeb"/>
-        <polygon points="69.71 309.93 69.71 332.92 82.48 324.86 69.71 309.93" fill="url(#linear-gradient-37)"/>
-        <polygon points="69.71 321.81 82.48 324.86 69.71 332.92 69.71 321.81" fill="#53b0de"/>
-        <polygon points="69.71 332.92 57.2 324.84 69.71 321.81 69.71 332.92" fill="#a5def3"/>
-        <polygon points="69.71 337.93 85.21 327.95 83.49 325.93 69.71 334.75 69.71 337.93" fill="url(#linear-gradient-38)"/>
-      </g>
-      <g>
-        <g>
-          <path d="M43.67,301.25a.84.84,0,0,1-.87.79H29.45a.84.84,0,0,1-.87-.79V279.6a.84.84,0,0,1,.87-.79H42.8a.84.84,0,0,1,.87.79Z" fill="url(#linear-gradient-39)"/>
-          <path d="M30.8,288.74a1.75,1.75,0,0,1,1.61-1.82H40a1.75,1.75,0,0,1,1.61,1.82h0A1.73,1.73,0,0,1,40,290.62H32.44a1.73,1.73,0,0,1-1.61-1.81Z" fill="#1e3465"/>
-          <path d="M30.8,283.37a1.73,1.73,0,0,1,1.61-1.81H40a1.73,1.73,0,0,1,1.61,1.81h0A1.73,1.73,0,0,1,40,285.18H32.44a1.73,1.73,0,0,1-1.61-1.81Z" fill="#1e3465"/>
-          <circle cx="32.91" cy="283.37" r="1.21" fill="#74cfeb"/>
-          <circle cx="32.91" cy="288.74" r="1.21" fill="#74cfeb"/>
-        </g>
-        <g>
-          <path d="M43.66,296.46c-2.94,0-5.4-.87-5.4-1.94v10.32c0,1.07,2.37,2,5.29,2h.11c3,0,5.37-.87,5.37-2V294.52C49,295.59,46.61,296.46,43.66,296.46Z" fill="url(#linear-gradient-40)"/>
-          <path d="M49,294.52c0,1.07-2.4,2-5.37,2s-5.36-.89-5.36-2,2.46-1.94,5.4-1.94,5.37.86,5.37,2" fill="#e8e8e8"/>
-          <path d="M47.74,294.36c0,.68-1.84,1.23-4.12,1.23s-4.11-.55-4.11-1.23,1.85-1.23,4.15-1.23,4.11.55,4.11,1.23" fill="#74cfeb"/>
-          <path d="M43.66,294.65a10,10,0,0,0-3.25.46,9.46,9.46,0,0,0,3.25.48,9.48,9.48,0,0,0,3.26-.48A10,10,0,0,0,43.66,294.65Z" fill="#1b8ab3"/>
-        </g>
-      </g>
-      <g>
-        <path d="M51.67,375.87a.86.86,0,0,1-.85.88H37a.87.87,0,0,1-.87-.87h0V351.2a.87.87,0,0,1,.85-.89H50.8a.87.87,0,0,1,.89.85v0Z" fill="url(#linear-gradient-41)"/>
-        <path d="M38.36,359.58A1.67,1.67,0,0,1,40,357.9h7.86a1.68,1.68,0,0,1,1.63,1.68h0a1.68,1.68,0,0,1-1.66,1.7H40.07a1.7,1.7,0,0,1-1.71-1.68Z" fill="#1e3465"/>
-        <path d="M38.36,354.57a1.7,1.7,0,0,1,1.69-1.7h7.84a1.67,1.67,0,0,1,1.63,1.69h0a1.68,1.68,0,0,1-1.68,1.68H40.07a1.67,1.67,0,0,1-1.71-1.65Z" fill="#1e3465"/>
-        <circle cx="40.18" cy="354.57" r="1.14" fill="#74cfeb"/>
-        <circle cx="40.18" cy="359.58" r="1.14" fill="#74cfeb"/>
-        <path d="M62.34,371.9a4.85,4.85,0,0,0-4.15-4.67A6.11,6.11,0,0,0,52,361.32a6.23,6.23,0,0,0-6,4.14,5.76,5.76,0,0,0-5,5.59,5.85,5.85,0,0,0,6,5.7H57.54A4.89,4.89,0,0,0,62.34,371.9Z" fill="url(#linear-gradient-42)"/>
-        <rect x="35.24" y="349.53" width="28" height="28" fill="none"/>
-      </g>
-    </g>
-    <path d="M1076.78,69.28a.61.61,0,0,1-.44-.19l-.93-.92a.63.63,0,0,1,0-.89.62.62,0,0,1,.88,0h0l.49.49,1.48-1.48a.63.63,0,0,1,.88,0,.64.64,0,0,1,0,.89h0l-1.92,1.91A.63.63,0,0,1,1076.78,69.28Zm11.69-.19,1.92-1.91a.63.63,0,0,0-.89-.89L1088,67.77l-.49-.49a.63.63,0,0,0-.9.87l0,0,.93.92a.62.62,0,0,0,.88,0Zm-19.76-7.79,3.19-2a1.26,1.26,0,0,0,.41-1.73,1.39,1.39,0,0,0-.4-.4l-3.19-2a1.26,1.26,0,0,0-1.73.39,1.3,1.3,0,0,0-.19.67v4a1.24,1.24,0,0,0,1.25,1.25A1.28,1.28,0,0,0,1068.71,61.3Zm2.54-3-3.2,2v-4Zm21.8,9.36a4.37,4.37,0,0,1-8.7.62h-2.6a4.37,4.37,0,0,1-8.65,0h-.7a4.35,4.35,0,0,1-3.1-1.3v6.3a3.75,3.75,0,0,0,3.75,3.75h0a4.38,4.38,0,1,1,0,1.25h0a5,5,0,0,1-5-5V64.36a6.28,6.28,0,1,1,1.31.12,3.1,3.1,0,0,0,3,2.5h.7a4.37,4.37,0,0,1,8.65,0h2.6a4.37,4.37,0,0,1,8.7.63Zm-18.75,10a3.13,3.13,0,1,0,3.12-3.13A3.12,3.12,0,0,0,1074.3,77.61Zm-5-14.38a5,5,0,1,0-5-5A5,5,0,0,0,1069.3,63.23Zm11.25,4.38a3.13,3.13,0,1,0-3.13,3.12A3.13,3.13,0,0,0,1080.55,67.61Zm11.25,0a3.13,3.13,0,1,0-3.13,3.12A3.13,3.13,0,0,0,1091.8,67.61Zm-16.25,10a.63.63,0,1,0,.62-.63A.62.62,0,0,0,1075.55,77.61Zm2.5,0a.63.63,0,1,0,.62-.63A.62.62,0,0,0,1078.05,77.61Zm15,0a4.37,4.37,0,0,1-8.7.62h0l-.63,0h0a.63.63,0,0,1,0-1.25l.63,0a.09.09,0,0,1,.07,0,4.37,4.37,0,0,1,8.7.61Zm-1.25,0a3.13,3.13,0,1,0-3.13,3.12A3.13,3.13,0,0,0,1091.8,77.61Z"/>
-    <g>
-      <path d="M972,358.59a.32.32,0,0,1-.3-.32h0a3.55,3.55,0,0,0-3.55-3.54.32.32,0,0,1-.32-.3h0a.32.32,0,0,1,.32-.32h0a3.55,3.55,0,0,0,3.55-3.55.31.31,0,0,1,.28-.35h0a.32.32,0,0,1,.32.32h0a3.54,3.54,0,0,0,3.54,3.54h0a.32.32,0,0,1,.32.32h0a.32.32,0,0,1-.32.3h0a3.55,3.55,0,0,0-3.54,3.55.32.32,0,0,1-.28.35Z" fill="#74cfeb"/>
-      <path d="M994.39,380.21a.25.25,0,0,1-.25-.25h0a2.86,2.86,0,0,0-2.86-2.86.24.24,0,0,1-.24-.24h0a.25.25,0,0,1,.24-.25h0a2.86,2.86,0,0,0,2.86-2.86.25.25,0,0,1,.25-.24h0a.24.24,0,0,1,.24.24h0a2.86,2.86,0,0,0,2.86,2.86h0a.25.25,0,1,1,0,.49h0a2.86,2.86,0,0,0-2.86,2.86h0a.25.25,0,0,1-.24.25Z" fill="#74cfeb"/>
-      <path d="M993.3,362.6a10.89,10.89,0,1,1-13.17-8,10.88,10.88,0,0,1,13.17,8Z" fill="url(#radial-gradient-8)"/>
-      <g clip-path="url(#clip-path)">
-        <g>
-          <path d="M976.83,372.51a2.91,2.91,0,1,0,0-5.81h0a1,1,0,0,0,0-.25,2.92,2.92,0,0,0-2.92-2.91h-2.18a11,11,0,0,0,.3,4,11.18,11.18,0,0,0,2.62,4.93Z" fill="#f2f2f3"/>
-          <path d="M993.3,363.1h0a10.55,10.55,0,0,0-2.5-5.11,2.76,2.76,0,0,0-.51-.16,3.2,3.2,0,0,0-4,2.17,4.27,4.27,0,0,0-.12.7h-.37a3.07,3.07,0,0,0-3,3.07,3,3,0,0,0,2,2.89,2.66,2.66,0,0,0,1,.2h3.55A22.82,22.82,0,0,0,993.3,363.1Z" fill="#f2f2f3"/>
-        </g>
-      </g>
-      <path d="M997.19,356c-1.12-1.86-3.73-2.57-7.36-2a30,30,0,0,0-3.62.8,12.18,12.18,0,0,1,2.72,1.37l1.27-.27a12.82,12.82,0,0,1,1.95-.16c1.78,0,3,.44,3.55,1.29h0c.67,1.12.1,3.07-1.56,5.32a32.67,32.67,0,0,1-18.92,11.17c-2.77.43-4.75,0-5.43-1.11s-.1-3.07,1.56-5.32c.22-.27.27-.41.5-.69a11.81,11.81,0,0,1,0-3,20,20,0,0,0-2.07,2.52c-2.2,2.95-2.8,5.59-1.68,7.43a5.61,5.61,0,0,0,5.14,2.22,14.5,14.5,0,0,0,2.28-.18,34.1,34.1,0,0,0,19.93-12C997.7,360.54,998.3,357.9,997.19,356Z" fill="#74cfeb"/>
-    </g>
-    <g>
-      <path d="M1064.41,400.3c-.08,0-.17.2-.17.31,0,.68,0,2.49,0,3.72,0,0,0,.11.1.11.26,0,.87,0,1.4,0a3.52,3.52,0,0,0,1.41-.21,1.81,1.81,0,0,0,.9-1.71c0-1.65-1.16-2.29-2.89-2.29a3.26,3.26,0,0,0-.72,0Zm4.42,7.64c0-1.69-1.25-2.63-3.51-2.63-.1,0-.82,0-1,0s-.12.06-.12.11c0,1.21,0,3.14,0,3.9a1.33,1.33,0,0,0,.57.92,4,4,0,0,0,1.49.2,2.33,2.33,0,0,0,2.53-2.51Zm-7.9-8.58c.17,0,.68.05,2,.05s2.24,0,3.45,0c1.49,0,3.54.53,3.54,2.76a2.68,2.68,0,0,1-1.78,2.39c-.05,0-.05.05,0,.07,1.44.36,2.7,1.25,2.7,2.92a3.58,3.58,0,0,1-2.51,3.34,8.23,8.23,0,0,1-3.18.53c-.87,0-3.21-.1-4.51-.07-.14-.05.12-.67.23-.77a3.1,3.1,0,0,0,.88-.14c.46-.12.51-.25.58-.95s0-2.72,0-4.23c0-2.07,0-3.47,0-4.15,0-.53-.2-.7-.58-.81l-1.16-.17c-.09-.08.2-.66.31-.73ZM1051.06,410a3.39,3.39,0,0,0,1.93.46,3.8,3.8,0,0,0,2.74-1,5.22,5.22,0,0,0,1.54-4.1A4.9,4.9,0,0,0,1055,401a6.07,6.07,0,0,0-3.22-.75,2.7,2.7,0,0,0-1,.11.53.53,0,0,0-.17.28c0,.34,0,3,0,4.51s0,3.82,0,4.07a1,1,0,0,0,.38.82Zm-3.88-10.63c.32,0,1.57.05,2.17.05,1.08,0,1.85-.05,3.88-.05a6.32,6.32,0,0,1,4.17,1.33,5.55,5.55,0,0,1,1.9,4.38,5.72,5.72,0,0,1-2.36,4.92,7.86,7.86,0,0,1-4.91,1.39c-1.16,0-3.16,0-4.82-.05h0c-.09-.16.13-.76.27-.77a2.6,2.6,0,0,0,.79-.16c.35-.13.42-.32.47-.95.06-1.18,0-2.6,0-4.21,0-1.15,0-3.39,0-4.1s-.31-.76-.82-.86c-.26,0-.6-.12-1.08-.17-.07-.12.24-.65.33-.75Z" fill="#8e714e" fill-rule="evenodd"/>
-      <path d="M1026.49,410.66a3.37,3.37,0,0,1-1.11-.29.59.59,0,0,1-.14-.27c0-.6,0-2.31,0-3.46a4.05,4.05,0,0,0-.55-2.29,2.34,2.34,0,0,0-2-1,4.54,4.54,0,0,0-2.59,1.24s-.16.13-.14-.06,0-.56,0-.82a.43.43,0,0,0-.12-.36,11.14,11.14,0,0,1-2.65.69c-.41.08-.51.48-.09.61h0a3.74,3.74,0,0,1,1,.45.53.53,0,0,1,.15.48c0,1.28,0,3.25,0,4.32,0,.43-.14.58-.44.65h0a6.24,6.24,0,0,1-.72.13,1,1,0,0,0,0,.77c.19,0,1.18-.05,2-.05,1.13,0,1.71.05,2,.05a1.1,1.1,0,0,0,.09-.77,2.8,2.8,0,0,1-.79-.12c-.31-.07-.39-.22-.41-.58,0-.9,0-2.82,0-4.12a.82.82,0,0,1,.2-.63,2.62,2.62,0,0,1,1.59-.58,1.77,1.77,0,0,1,1.18.39,1.66,1.66,0,0,1,.55,1.08c.09.73.05,2.19.05,3.45,0,.69-.05.86-.31.94a3.48,3.48,0,0,1-.78.16,1,1,0,0,0,0,.77c.49,0,1.07-.06,1.93-.06,1.06,0,1.74.06,2,.06a1.24,1.24,0,0,0,0-.74Zm4.73-6.53c-.9,0-1.47.7-1.47,1.79s.5,2.4,1.9,2.4a1.36,1.36,0,0,0,.89-.34,2.26,2.26,0,0,0,.55-1.58c0-1.42-.7-2.27-1.87-2.27Zm-.12,7.56a1.51,1.51,0,0,0-.73.18c-.72.47-1,.91-1,1.44a1.48,1.48,0,0,0,.6,1.23,3,3,0,0,0,2,.63c1.74,0,2.51-.94,2.51-1.86a1.31,1.31,0,0,0-1-1.32,7.09,7.09,0,0,0-2.4-.3Zm.12,4.44a3.75,3.75,0,0,1-2.44-.72,2.26,2.26,0,0,1-.91-1.69,1.3,1.3,0,0,1,.35-.85,8.31,8.31,0,0,1,1.57-1.27s0,0,0-.07a.09.09,0,0,0-.07-.08,1.65,1.65,0,0,1-1.11-1.08v0a.23.23,0,0,1,.1-.3c.12-.09.29-.19.48-.31a7.84,7.84,0,0,0,.79-.51.15.15,0,0,0,0-.11s0-.06-.07-.08a2.49,2.49,0,0,1-1.79-2.62,2.58,2.58,0,0,1,1.09-2.15,5,5,0,0,1,2.46-.84h.06a5.41,5.41,0,0,1,1.88.41,3.12,3.12,0,0,0,1.11.17,1.48,1.48,0,0,0,1.2-.44,1,1,0,0,1,.06.34,1.29,1.29,0,0,1-.22.79,1,1,0,0,1-.75.32H1035a2.81,2.81,0,0,1-.44-.07l-.07,0s0,.06,0,.12v0a5.31,5.31,0,0,1,.11.74,2.75,2.75,0,0,1-1.17,2.47,3.81,3.81,0,0,1-2,.77l-.24,0-.22,0h0c-.14,0-.48.2-.48.49s.15.57.89.62c.15,0,.3,0,.47,0a15,15,0,0,1,2.76.35,1.92,1.92,0,0,1,1.28,1.83,3.77,3.77,0,0,1-2.41,3.18,5.6,5.6,0,0,1-2.28.49Zm9.75-11.92a1.59,1.59,0,0,0-.92.26,2.64,2.64,0,0,0-1,2.43c0,2.24,1.13,3.81,2.73,3.81a1.75,1.75,0,0,0,1.18-.41,3,3,0,0,0,.76-2.38c0-2.22-1.11-3.71-2.74-3.71Zm.31,7.32c-2.91,0-4-2.14-4-4.14a3.7,3.7,0,0,1,1.69-3.25,5.21,5.21,0,0,1,2.62-.76,3.67,3.67,0,0,1,3.78,3.88,4,4,0,0,1-1.8,3.54,4.79,4.79,0,0,1-2.34.73Zm-30.47-7.32a1.62,1.62,0,0,0-.93.26,2.66,2.66,0,0,0-1,2.43c0,2.24,1.12,3.81,2.73,3.81a1.75,1.75,0,0,0,1.18-.41,3,3,0,0,0,.75-2.38c0-2.22-1.09-3.71-2.73-3.71Zm.31,7.32c-2.91,0-4-2.14-4-4.14a3.7,3.7,0,0,1,1.69-3.25,5.17,5.17,0,0,1,2.61-.76,3.66,3.66,0,0,1,3.78,3.88,4,4,0,0,1-1.79,3.54,4.69,4.69,0,0,1-2.34.73Zm-19.55-.17a.73.73,0,0,1-.05-.39.57.57,0,0,1,.05-.26,6.07,6.07,0,0,0,.75-.15c.35-.09.48-.28.5-.7,0-1,0-3,0-4.33v0a.52.52,0,0,0-.18-.48,4,4,0,0,0-1-.45c-.15-.05-.26-.13-.24-.24s.1-.22.32-.25a12.16,12.16,0,0,0,2.62-.67.38.38,0,0,1,.09.27l0,.19a6.19,6.19,0,0,0,0,.63.12.12,0,0,0,.13.12.17.17,0,0,0,.1,0,4.8,4.8,0,0,1,2.6-1.16,2.22,2.22,0,0,1,2,1.21.13.13,0,0,0,.12.07.14.14,0,0,0,.1,0,5.2,5.2,0,0,1,2.68-1.23c1.59,0,2.53,1.18,2.53,3.18,0,.56,0,1.3,0,2s0,1.15,0,1.54a.53.53,0,0,0,.31.41,3.66,3.66,0,0,0,1,.24h0a1.39,1.39,0,0,1-.11.65h-.42c-.33,0-.79,0-1.3,0-1.06,0-1.61,0-2.14.05a1.77,1.77,0,0,1,0-.65,5.41,5.41,0,0,0,.65-.15c.34-.1.43-.26.44-.7s.07-3.1,0-3.76a1.68,1.68,0,0,0-1.74-1.49,3.07,3.07,0,0,0-1.75.66.36.36,0,0,0-.07.18h0a7.77,7.77,0,0,1,.07,1.41V408c0,.77,0,1.48,0,2a.5.5,0,0,0,.41.53l.26.05.55.12a1,1,0,0,1,0,.48.3.3,0,0,1-.07.17c-.58,0-1.18,0-2,0l-1.08,0h-.77a.82.82,0,0,1,0-.34.52.52,0,0,1,.07-.31,1.75,1.75,0,0,1,.24,0l.55-.1c.29-.09.39-.24.41-.62a29.9,29.9,0,0,0,0-3.92,1.61,1.61,0,0,0-1.68-1.48,3.13,3.13,0,0,0-1.74.66.54.54,0,0,0-.15.4v1c0,1.23,0,2.77,0,3.43a.53.53,0,0,0,.48.53,3.62,3.62,0,0,0,.39.07l.31.05a1.33,1.33,0,0,1-.05.65h-.61c-.36,0-.83,0-1.34,0s-1,0-1.37,0a3.5,3.5,0,0,0-.63,0Z" fill="#442d22" fill-rule="evenodd"/>
-      <g>
-        <path d="M982.58,415.46l-.7-.23s.08-3.58-1.2-3.83c-.86-1,.14-42.07,3.21-.14a2.47,2.47,0,0,0-1.24,1.43,12.89,12.89,0,0,0-.07,2.77Z" fill="#fff" fill-rule="evenodd"/>
-        <path d="M982.58,415.46l-.7-.23s.08-3.58-1.2-3.83c-.86-1,.14-42.07,3.21-.14a2.47,2.47,0,0,0-1.24,1.43,12.89,12.89,0,0,0-.07,2.77Z" fill="#a6a385" fill-rule="evenodd"/>
-        <path d="M983,412a12.42,12.42,0,0,0,4.71-12.43c-1.39-6.11-4.66-8.11-5-8.88a7.94,7.94,0,0,1-.77-1.5l.25,17s-.53,5.2.82,5.83" fill="#fff" fill-rule="evenodd"/>
-        <path d="M983,412a12.42,12.42,0,0,0,4.71-12.43c-1.39-6.11-4.66-8.11-5-8.88a7.94,7.94,0,0,1-.77-1.5l.25,17s-.53,5.2.82,5.83" fill="#499d4a" fill-rule="evenodd"/>
-        <path d="M981.52,412.23s-5.77-3.93-5.42-10.86a14.57,14.57,0,0,1,5.18-10.94,1.58,1.58,0,0,0,.56-1.3c.36.77.29,11.51.34,12.77.16,4.88-.27,9.41-.66,10.33Z" fill="#fff" fill-rule="evenodd"/>
-        <path d="M981.52,412.23s-5.77-3.93-5.42-10.86a14.57,14.57,0,0,1,5.18-10.94,1.58,1.58,0,0,0,.56-1.3c.36.77.29,11.51.34,12.77.16,4.88-.27,9.41-.66,10.33Z" fill="#58aa50" fill-rule="evenodd"/>
-      </g>
-    </g>
-  </g>
-  <g id="Text">
-    <g>
-      <path d="M191.83,489.89h-1.12v-4c0-1.46-.54-2.19-1.63-2.19a1.79,1.79,0,0,0-1.38.63,2.37,2.37,0,0,0-.56,1.63v4H186V479.53h1.12v4.52h0a2.55,2.55,0,0,1,2.3-1.32c1.57,0,2.36.95,2.36,2.85Z" fill="#2f2f2f"/>
-      <path d="M199.55,489.89h-1.13v-1.11h0a2.31,2.31,0,0,1-2.16,1.27c-1.67,0-2.5-1-2.5-3v-4.18h1.11v4c0,1.47.56,2.21,1.69,2.21a1.71,1.71,0,0,0,1.35-.6,2.3,2.3,0,0,0,.53-1.59v-4h1.13Z" fill="#2f2f2f"/>
-      <path d="M202.8,488.88h0v1h-1.12V479.53h1.12v4.59h0a2.65,2.65,0,0,1,2.42-1.39,2.56,2.56,0,0,1,2.11.94,3.85,3.85,0,0,1,.76,2.52,4.34,4.34,0,0,1-.85,2.81,2.86,2.86,0,0,1-2.34,1.05A2.31,2.31,0,0,1,202.8,488.88Zm0-2.82v1a2.09,2.09,0,0,0,.57,1.48,1.86,1.86,0,0,0,1.43.6,1.89,1.89,0,0,0,1.6-.78,3.61,3.61,0,0,0,.57-2.17,2.83,2.83,0,0,0-.54-1.83,1.78,1.78,0,0,0-1.46-.66,2,2,0,0,0-1.57.68A2.48,2.48,0,0,0,202.77,486.06Z" fill="#2f2f2f"/>
-      <path d="M213.49,486.43h-3.73v-.88h3.73Z" fill="#2f2f2f"/>
-      <path d="M220.86,482.89l-2.79,7H217l-2.66-7h1.23l1.78,5.09a4.63,4.63,0,0,1,.25,1h0a4.42,4.42,0,0,1,.21-.95l1.86-5.11Z" fill="#2f2f2f"/>
-      <path d="M222.67,481.11a.73.73,0,0,1-.51-.2.7.7,0,0,1-.21-.52.69.69,0,0,1,.21-.52.74.74,0,0,1,1,0,.66.66,0,0,1,.22.52.67.67,0,0,1-.22.51A.7.7,0,0,1,222.67,481.11Zm.55,8.78H222.1v-7h1.12Z" fill="#2f2f2f"/>
-      <path d="M229,484a1.32,1.32,0,0,0-.85-.23,1.43,1.43,0,0,0-1.2.68,3.12,3.12,0,0,0-.48,1.84v3.57h-1.12v-7h1.12v1.44h0a2.47,2.47,0,0,1,.74-1.15,1.67,1.67,0,0,1,1.1-.41,2,2,0,0,1,.67.09Z" fill="#2f2f2f"/>
-      <path d="M233.91,489.82a2.15,2.15,0,0,1-1,.22c-1.23,0-1.84-.68-1.84-2.05v-4.14h-1.2v-1H231v-1.71l1.12-.36v2.07h1.77v1h-1.77v3.94a1.65,1.65,0,0,0,.24,1,1,1,0,0,0,.79.3,1.23,1.23,0,0,0,.74-.23Z" fill="#2f2f2f"/>
-      <path d="M241,489.89H239.9v-1.11h0a2.31,2.31,0,0,1-2.16,1.27c-1.67,0-2.51-1-2.51-3v-4.18h1.12v4c0,1.47.56,2.21,1.69,2.21a1.71,1.71,0,0,0,1.35-.6,2.3,2.3,0,0,0,.53-1.59v-4H241Z" fill="#2f2f2f"/>
-      <path d="M248.18,489.89h-1.12V488.8h0a2.35,2.35,0,0,1-2.15,1.25,2.29,2.29,0,0,1-1.64-.55,1.94,1.94,0,0,1-.59-1.47q0-2,2.31-2.28l2.1-.3c0-1.19-.48-1.78-1.44-1.78a3.47,3.47,0,0,0-2.29.86v-1.15a4.4,4.4,0,0,1,2.38-.65c1.65,0,2.47.87,2.47,2.61Zm-1.12-3.54-1.69.23a2.67,2.67,0,0,0-1.18.39,1.11,1.11,0,0,0-.39,1,1.09,1.09,0,0,0,.36.84,1.46,1.46,0,0,0,1,.32,1.78,1.78,0,0,0,1.37-.58,2.07,2.07,0,0,0,.55-1.48Z" fill="#2f2f2f"/>
-      <path d="M251.32,489.89H250.2V479.53h1.12Z" fill="#2f2f2f"/>
-      <path d="M257,486.43h-3.74v-.88H257Z" fill="#2f2f2f"/>
-      <path d="M264.75,489.89h-1.12v-4c0-1.49-.55-2.23-1.63-2.23a1.76,1.76,0,0,0-1.39.63,2.34,2.34,0,0,0-.55,1.6v4h-1.12v-7h1.12v1.16h0a2.54,2.54,0,0,1,2.3-1.32,2.13,2.13,0,0,1,1.76.74,3.33,3.33,0,0,1,.61,2.14Z" fill="#2f2f2f"/>
-      <path d="M272.45,486.67h-4.94a2.56,2.56,0,0,0,.63,1.81,2.17,2.17,0,0,0,1.65.63,3.42,3.42,0,0,0,2.17-.78v1.05a4,4,0,0,1-2.44.67,3,3,0,0,1-2.33-.95,3.93,3.93,0,0,1-.85-2.68,3.84,3.84,0,0,1,.93-2.67,3,3,0,0,1,2.3-1,2.61,2.61,0,0,1,2.13.89,3.69,3.69,0,0,1,.75,2.46Zm-1.15-.95a2.24,2.24,0,0,0-.47-1.51,1.59,1.59,0,0,0-1.28-.54,1.81,1.81,0,0,0-1.35.57,2.65,2.65,0,0,0-.68,1.48Z" fill="#2f2f2f"/>
-      <path d="M277.37,489.82a2.09,2.09,0,0,1-1,.22c-1.23,0-1.84-.68-1.84-2.05v-4.14h-1.2v-1h1.2v-1.71l1.12-.36v2.07h1.76v1h-1.76v3.94a1.65,1.65,0,0,0,.24,1,1,1,0,0,0,.79.3,1.2,1.2,0,0,0,.73-.23Z" fill="#2f2f2f"/>
-      <path d="M288.06,482.89l-2.09,7H284.8l-1.44-5a3.82,3.82,0,0,1-.11-.65h0a3,3,0,0,1-.14.64l-1.57,5h-1.12l-2.12-7h1.18l1.45,5.26a3,3,0,0,1,.1.63h.05a2.65,2.65,0,0,1,.12-.64l1.62-5.25h1l1.45,5.28a3.2,3.2,0,0,1,.1.63h.06a3.49,3.49,0,0,1,.11-.63l1.43-5.28Z" fill="#2f2f2f"/>
-      <path d="M292.14,490.05a3.22,3.22,0,0,1-2.48-1,3.62,3.62,0,0,1-.93-2.6,3.79,3.79,0,0,1,1-2.75,3.46,3.46,0,0,1,2.6-1,3.16,3.16,0,0,1,2.45,1,3.84,3.84,0,0,1,.88,2.67,3.79,3.79,0,0,1-.95,2.69A3.32,3.32,0,0,1,292.14,490.05Zm.08-6.38a2.13,2.13,0,0,0-1.71.73,3,3,0,0,0-.63,2,2.82,2.82,0,0,0,.64,2,2.15,2.15,0,0,0,1.7.72,2,2,0,0,0,1.67-.7,3.74,3.74,0,0,0,0-4A2,2,0,0,0,292.22,483.67Z" fill="#2f2f2f"/>
-      <path d="M301,484a1.31,1.31,0,0,0-.85-.23,1.45,1.45,0,0,0-1.2.68,3.12,3.12,0,0,0-.48,1.84v3.57h-1.12v-7h1.12v1.44h0a2.46,2.46,0,0,1,.73-1.15,1.71,1.71,0,0,1,1.1-.41,1.92,1.92,0,0,1,.67.09Z" fill="#2f2f2f"/>
-      <path d="M308.05,489.89h-1.58l-3.09-3.36h0v3.36h-1.13V479.53h1.13v6.57h0l2.94-3.21h1.47l-3.24,3.38Z" fill="#2f2f2f"/>
-    </g>
-    <g>
-      <path d="M566,489.64v-1.21a3.25,3.25,0,0,0,2,.68c1,0,1.48-.33,1.48-1a.82.82,0,0,0-.13-.48,1.22,1.22,0,0,0-.34-.34,2.43,2.43,0,0,0-.51-.27l-.62-.25c-.31-.13-.58-.25-.82-.38a2.4,2.4,0,0,1-.59-.42,1.73,1.73,0,0,1-.35-.54,1.86,1.86,0,0,1-.12-.7,1.66,1.66,0,0,1,.22-.87,2,2,0,0,1,.61-.64,2.63,2.63,0,0,1,.85-.38,3.71,3.71,0,0,1,1-.13,4.05,4.05,0,0,1,1.63.31v1.14a3.17,3.17,0,0,0-1.78-.51,2,2,0,0,0-.57.07,1.56,1.56,0,0,0-.43.2.91.91,0,0,0-.28.31.79.79,0,0,0-.1.4.91.91,0,0,0,.39.79,2,2,0,0,0,.46.26l.62.25a8.42,8.42,0,0,1,.84.37,2.88,2.88,0,0,1,.63.42,1.81,1.81,0,0,1,.4.55,1.92,1.92,0,0,1-.09,1.63,2.07,2.07,0,0,1-.61.64,3,3,0,0,1-.89.37,4.42,4.42,0,0,1-1,.12A4,4,0,0,1,566,489.64Z" fill="#2f2f2f"/>
-      <path d="M573.33,488.88h0v4.23h-1.12V482.89h1.12v1.23h0a2.65,2.65,0,0,1,2.42-1.39,2.54,2.54,0,0,1,2.11.94,3.85,3.85,0,0,1,.76,2.52,4.34,4.34,0,0,1-.85,2.81,2.86,2.86,0,0,1-2.34,1.05A2.34,2.34,0,0,1,573.33,488.88Zm0-2.82v1a2.09,2.09,0,0,0,.57,1.48,2,2,0,0,0,3-.18,3.54,3.54,0,0,0,.58-2.17,2.83,2.83,0,0,0-.54-1.83,1.79,1.79,0,0,0-1.46-.66,2,2,0,0,0-1.57.68A2.48,2.48,0,0,0,573.3,486.06Z" fill="#2f2f2f"/>
-      <path d="M583.33,490.05a3.22,3.22,0,0,1-2.48-1,3.62,3.62,0,0,1-.93-2.6,3.79,3.79,0,0,1,1-2.75,3.5,3.5,0,0,1,2.61-1,3.13,3.13,0,0,1,2.44,1,4.4,4.4,0,0,1-.06,5.36A3.34,3.34,0,0,1,583.33,490.05Zm.08-6.38a2.13,2.13,0,0,0-1.71.73,3,3,0,0,0-.63,2,2.82,2.82,0,0,0,.64,2,2.15,2.15,0,0,0,1.7.72,2,2,0,0,0,1.67-.7,3.79,3.79,0,0,0,0-4A2.06,2.06,0,0,0,583.41,483.67Z" fill="#2f2f2f"/>
-      <path d="M594.34,489.89h-1.57l-3.09-3.36h0v3.36h-1.12V479.53h1.12v6.57h0l2.94-3.21h1.47l-3.25,3.38Z" fill="#2f2f2f"/>
-      <path d="M600.76,486.67h-4.94a2.66,2.66,0,0,0,.63,1.81,2.17,2.17,0,0,0,1.65.63,3.45,3.45,0,0,0,2.18-.78v1.05a4.05,4.05,0,0,1-2.44.67,2.93,2.93,0,0,1-2.33-.95,4.49,4.49,0,0,1,.07-5.35,3,3,0,0,1,2.3-1,2.61,2.61,0,0,1,2.13.89,3.69,3.69,0,0,1,.75,2.46Zm-1.15-.95a2.29,2.29,0,0,0-.46-1.51,1.61,1.61,0,0,0-1.29-.54,1.81,1.81,0,0,0-1.34.57,2.59,2.59,0,0,0-.69,1.48Z" fill="#2f2f2f"/>
-      <path d="M606.11,486.43h-3.73v-.88h3.73Z" fill="#2f2f2f"/>
-      <path d="M613.47,482.89l-2.79,7h-1.1l-2.65-7h1.23l1.78,5.09a4.53,4.53,0,0,1,.24,1h0a5.1,5.1,0,0,1,.22-.95l1.86-5.11Z" fill="#2f2f2f"/>
-      <path d="M615.29,481.11a.77.77,0,0,1-.52-.2.7.7,0,0,1-.21-.52.69.69,0,0,1,.21-.52.73.73,0,0,1,.52-.21.72.72,0,0,1,.52.21.69.69,0,0,1,.22.52.7.7,0,0,1-.22.51A.72.72,0,0,1,615.29,481.11Zm.54,8.78h-1.12v-7h1.12Z" fill="#2f2f2f"/>
-      <path d="M621.6,484a1.28,1.28,0,0,0-.84-.23,1.43,1.43,0,0,0-1.2.68,3,3,0,0,0-.49,1.84v3.57H618v-7h1.12v1.44h0a2.54,2.54,0,0,1,.73-1.15,1.71,1.71,0,0,1,1.1-.41,1.92,1.92,0,0,1,.67.09Z" fill="#2f2f2f"/>
-      <path d="M626.52,489.82a2.09,2.09,0,0,1-1,.22c-1.23,0-1.84-.68-1.84-2.05v-4.14h-1.21v-1h1.21v-1.71l1.12-.36v2.07h1.76v1h-1.76v3.94a1.65,1.65,0,0,0,.24,1,1,1,0,0,0,.79.3,1.2,1.2,0,0,0,.73-.23Z" fill="#2f2f2f"/>
-      <path d="M633.64,489.89h-1.12v-1.11h0a2.29,2.29,0,0,1-2.16,1.27c-1.67,0-2.5-1-2.5-3v-4.18h1.11v4c0,1.47.57,2.21,1.7,2.21a1.71,1.71,0,0,0,1.35-.6,2.35,2.35,0,0,0,.53-1.59v-4h1.12Z" fill="#2f2f2f"/>
-      <path d="M640.8,489.89h-1.13V488.8h0a2.37,2.37,0,0,1-2.16,1.25,2.28,2.28,0,0,1-1.63-.55,1.9,1.9,0,0,1-.59-1.47q0-2,2.31-2.28l2.09-.3c0-1.19-.48-1.78-1.44-1.78a3.47,3.47,0,0,0-2.28.86v-1.15a4.4,4.4,0,0,1,2.38-.65c1.64,0,2.47.87,2.47,2.61Zm-1.13-3.54-1.68.23a2.63,2.63,0,0,0-1.18.39,1.12,1.12,0,0,0-.4,1,1.1,1.1,0,0,0,.37.84,1.44,1.44,0,0,0,1,.32,1.79,1.79,0,0,0,1.38-.58,2.11,2.11,0,0,0,.54-1.48Z" fill="#2f2f2f"/>
-      <path d="M643.94,489.89h-1.12V479.53h1.12Z" fill="#2f2f2f"/>
-      <path d="M649.64,486.43h-3.73v-.88h3.73Z" fill="#2f2f2f"/>
-      <path d="M657.36,489.89h-1.12v-4c0-1.49-.54-2.23-1.63-2.23a1.77,1.77,0,0,0-1.39.63,2.39,2.39,0,0,0-.55,1.6v4h-1.12v-7h1.12v1.16h0a2.53,2.53,0,0,1,2.3-1.32,2.11,2.11,0,0,1,1.75.74,3.27,3.27,0,0,1,.61,2.14Z" fill="#2f2f2f"/>
-      <path d="M665.07,486.67h-5a2.66,2.66,0,0,0,.63,1.81,2.18,2.18,0,0,0,1.66.63,3.44,3.44,0,0,0,2.17-.78v1.05a4,4,0,0,1-2.44.67,2.93,2.93,0,0,1-2.33-.95,3.88,3.88,0,0,1-.85-2.68,3.84,3.84,0,0,1,.93-2.67,3,3,0,0,1,2.3-1,2.6,2.6,0,0,1,2.12.89,3.69,3.69,0,0,1,.76,2.46Zm-1.15-.95a2.29,2.29,0,0,0-.47-1.51,1.6,1.6,0,0,0-1.28-.54,1.81,1.81,0,0,0-1.35.57,2.52,2.52,0,0,0-.68,1.48Z" fill="#2f2f2f"/>
-      <path d="M670,489.82a2.1,2.1,0,0,1-1,.22c-1.22,0-1.84-.68-1.84-2.05v-4.14h-1.2v-1h1.2v-1.71l1.13-.36v2.07H670v1h-1.76v3.94a1.65,1.65,0,0,0,.24,1,1,1,0,0,0,.79.3,1.22,1.22,0,0,0,.73-.23Z" fill="#2f2f2f"/>
-      <path d="M680.68,482.89l-2.1,7h-1.16l-1.44-5a3,3,0,0,1-.11-.65h0a3,3,0,0,1-.14.64l-1.57,5H673l-2.12-7h1.18l1.45,5.26a3.93,3.93,0,0,1,.09.63h.06a2.65,2.65,0,0,1,.12-.64l1.61-5.25h1l1.45,5.28a4.17,4.17,0,0,1,.1.63H678a2.32,2.32,0,0,1,.11-.63l1.42-5.28Z" fill="#2f2f2f"/>
-      <path d="M684.76,490.05a3.21,3.21,0,0,1-2.48-1,3.62,3.62,0,0,1-.93-2.6,3.79,3.79,0,0,1,1-2.75,3.5,3.5,0,0,1,2.61-1,3.13,3.13,0,0,1,2.44,1,4.4,4.4,0,0,1-.06,5.36A3.34,3.34,0,0,1,684.76,490.05Zm.08-6.38a2.13,2.13,0,0,0-1.71.73,3,3,0,0,0-.63,2,2.87,2.87,0,0,0,.63,2,2.18,2.18,0,0,0,1.71.72,2,2,0,0,0,1.67-.7,3.79,3.79,0,0,0,0-4A2.06,2.06,0,0,0,684.84,483.67Z" fill="#2f2f2f"/>
-      <path d="M693.61,484a1.32,1.32,0,0,0-.85-.23,1.43,1.43,0,0,0-1.2.68,3.12,3.12,0,0,0-.48,1.84v3.57H690v-7h1.12v1.44h0a2.38,2.38,0,0,1,.73-1.15,1.69,1.69,0,0,1,1.1-.41,2,2,0,0,1,.67.09Z" fill="#2f2f2f"/>
-      <path d="M700.66,489.89h-1.57L696,486.53h0v3.36h-1.12V479.53H696v6.57h0l2.94-3.21h1.47l-3.25,3.38Z" fill="#2f2f2f"/>
-    </g>
-    <g>
-      <path d="M433,101.69l-3.63,9.8h-1.27l-3.55-9.8h1.28l2.71,7.77a4.66,4.66,0,0,1,.2.87h0a3.91,3.91,0,0,1,.22-.88l2.77-7.76Z" fill="#2f2f2f"/>
-      <path d="M442.22,111.49h-1.41l-5-7.81a3.64,3.64,0,0,1-.32-.62h0a9.25,9.25,0,0,1,.06,1.35v7.08h-1.15v-9.8h1.49l4.91,7.69c.2.32.34.54.39.65h0a11.18,11.18,0,0,1-.07-1.44v-6.9h1.15Z" fill="#2f2f2f"/>
-      <path d="M450.2,108.27h-4.94a2.66,2.66,0,0,0,.63,1.81,2.17,2.17,0,0,0,1.65.63,3.47,3.47,0,0,0,2.18-.78v1a4.05,4.05,0,0,1-2.44.67,3,3,0,0,1-2.34-1,3.91,3.91,0,0,1-.84-2.68,3.84,3.84,0,0,1,.92-2.66,3,3,0,0,1,2.3-1,2.61,2.61,0,0,1,2.13.89,3.69,3.69,0,0,1,.75,2.46Zm-1.15-1a2.24,2.24,0,0,0-.47-1.51,1.58,1.58,0,0,0-1.28-.54,1.79,1.79,0,0,0-1.34.57,2.59,2.59,0,0,0-.69,1.48Z" fill="#2f2f2f"/>
-      <path d="M455.13,111.42a2.15,2.15,0,0,1-1.05.22c-1.23,0-1.84-.68-1.84-2v-4.14H451v-1h1.2v-1.71l1.12-.36v2.07h1.77v1h-1.77v3.94a1.65,1.65,0,0,0,.24,1,1,1,0,0,0,.79.3,1.23,1.23,0,0,0,.74-.23Z" fill="#2f2f2f"/>
-      <path d="M436.48,128.29h-1.12V117.93h1.12Z" fill="#2f2f2f"/>
-      <path d="M439.16,119.51a.73.73,0,0,1-.51-.2.7.7,0,0,1-.21-.52.69.69,0,0,1,.21-.52.69.69,0,0,1,.51-.21.74.74,0,0,1,.53.21.69.69,0,0,1,.21.52.69.69,0,0,1-.21.51A.74.74,0,0,1,439.16,119.51Zm.55,8.78h-1.12v-7h1.12Z" fill="#2f2f2f"/>
-      <path d="M447.64,128.29h-1.12v-4c0-1.49-.54-2.23-1.63-2.23a1.77,1.77,0,0,0-1.39.63,2.34,2.34,0,0,0-.55,1.6v4h-1.12v-7H443v1.16h0a2.52,2.52,0,0,1,2.29-1.32,2.12,2.12,0,0,1,1.76.74,3.27,3.27,0,0,1,.61,2.14Z" fill="#2f2f2f"/>
-      <path d="M455.47,128.29H453.9l-3.09-3.36h0v3.36h-1.12V117.93h1.12v6.57h0l2.94-3.21h1.47L452,124.67Z" fill="#2f2f2f"/>
-    </g>
-    <g>
-      <path d="M538.59,101.69l-3.63,9.8h-1.27l-3.55-9.8h1.28l2.71,7.77a4.66,4.66,0,0,1,.2.87h0a3.91,3.91,0,0,1,.22-.88l2.77-7.76Z" fill="#2f2f2f"/>
-      <path d="M547.82,111.49h-1.41l-5-7.81a3.64,3.64,0,0,1-.32-.62h0a9.25,9.25,0,0,1,.06,1.35v7.08h-1.15v-9.8h1.49l4.91,7.69c.2.32.34.54.4.65h0a11.18,11.18,0,0,1-.07-1.44v-6.9h1.15Z" fill="#2f2f2f"/>
-      <path d="M555.8,108.27h-4.94a2.66,2.66,0,0,0,.63,1.81,2.17,2.17,0,0,0,1.65.63,3.45,3.45,0,0,0,2.18-.78v1a4.05,4.05,0,0,1-2.44.67,3,3,0,0,1-2.34-1,3.91,3.91,0,0,1-.84-2.68,3.84,3.84,0,0,1,.92-2.66,3,3,0,0,1,2.3-1,2.61,2.61,0,0,1,2.13.89,3.69,3.69,0,0,1,.75,2.46Zm-1.15-1a2.24,2.24,0,0,0-.47-1.51,1.58,1.58,0,0,0-1.28-.54,1.78,1.78,0,0,0-1.34.57,2.59,2.59,0,0,0-.69,1.48Z" fill="#2f2f2f"/>
-      <path d="M560.72,111.42a2.09,2.09,0,0,1-1,.22c-1.23,0-1.84-.68-1.84-2v-4.14h-1.2v-1h1.2v-1.71l1.12-.36v2.07h1.76v1H559v3.94a1.65,1.65,0,0,0,.24,1,1,1,0,0,0,.79.3,1.18,1.18,0,0,0,.73-.23Z" fill="#2f2f2f"/>
-      <path d="M542.08,128.29H541V117.93h1.12Z" fill="#2f2f2f"/>
-      <path d="M544.76,119.51a.73.73,0,0,1-.51-.2.7.7,0,0,1-.21-.52.69.69,0,0,1,.21-.52.69.69,0,0,1,.51-.21.74.74,0,0,1,.53.21.69.69,0,0,1,.21.52.69.69,0,0,1-.21.51A.74.74,0,0,1,544.76,119.51Zm.55,8.78h-1.12v-7h1.12Z" fill="#2f2f2f"/>
-      <path d="M553.24,128.29h-1.12v-4c0-1.49-.54-2.23-1.63-2.23a1.77,1.77,0,0,0-1.39.63,2.34,2.34,0,0,0-.55,1.6v4h-1.12v-7h1.12v1.16h0a2.53,2.53,0,0,1,2.3-1.32,2.11,2.11,0,0,1,1.75.74,3.27,3.27,0,0,1,.61,2.14Z" fill="#2f2f2f"/>
-      <path d="M561.07,128.29H559.5l-3.09-3.36h0v3.36h-1.12V117.93h1.12v6.57h0l2.94-3.21h1.47l-3.25,3.38Z" fill="#2f2f2f"/>
-    </g>
-    <g>
-      <path d="M104.22,114.33H99v-9.81h5v1h-3.83v3.26h3.54v1h-3.54v3.43h4Z" fill="#2f2f2f"/>
-      <path d="M111.31,107.33,109,110.87l2.31,3.46H110l-1.37-2.27c-.09-.14-.19-.32-.31-.54h0s-.13.22-.32.54l-1.4,2.27h-1.29l2.38-3.43-2.28-3.57h1.31l1.35,2.39c.1.18.2.36.29.55h0l1.75-2.94Z" fill="#2f2f2f"/>
-      <path d="M113.75,113.32h0v4.23H112.6V107.33h1.12v1.23h0a2.66,2.66,0,0,1,2.42-1.4,2.57,2.57,0,0,1,2.11.94,3.88,3.88,0,0,1,.76,2.52,4.37,4.37,0,0,1-.85,2.82,2.86,2.86,0,0,1-2.34,1A2.34,2.34,0,0,1,113.75,113.32Zm0-2.83v1a2.05,2.05,0,0,0,.57,1.47,1.84,1.84,0,0,0,1.43.61,1.89,1.89,0,0,0,1.6-.78,3.61,3.61,0,0,0,.57-2.17,2.81,2.81,0,0,0-.54-1.83,1.78,1.78,0,0,0-1.46-.66,2,2,0,0,0-1.57.68A2.47,2.47,0,0,0,113.72,110.49Z" fill="#2f2f2f"/>
-      <path d="M124.41,108.46a1.39,1.39,0,0,0-.85-.22,1.42,1.42,0,0,0-1.2.67,3.15,3.15,0,0,0-.48,1.85v3.57h-1.12v-7h1.12v1.44h0a2.41,2.41,0,0,1,.73-1.15,1.65,1.65,0,0,1,1.1-.42,1.89,1.89,0,0,1,.67.1Z" fill="#2f2f2f"/>
-      <path d="M131.25,111.11h-4.94a2.61,2.61,0,0,0,.63,1.8,2.14,2.14,0,0,0,1.65.64,3.45,3.45,0,0,0,2.18-.78v1a4.05,4.05,0,0,1-2.44.67,3,3,0,0,1-2.33-.95,4.49,4.49,0,0,1,.07-5.35,3,3,0,0,1,2.31-1,2.63,2.63,0,0,1,2.12.89,3.72,3.72,0,0,1,.75,2.47Zm-1.15-1a2.29,2.29,0,0,0-.46-1.51,1.61,1.61,0,0,0-1.29-.54,1.84,1.84,0,0,0-1.34.56,2.62,2.62,0,0,0-.69,1.49Z" fill="#2f2f2f"/>
-      <path d="M132.5,114.07v-1.2a3.32,3.32,0,0,0,2,.68c1,0,1.48-.33,1.48-1a.81.81,0,0,0-.13-.47,1.25,1.25,0,0,0-.34-.35,2.43,2.43,0,0,0-.51-.27l-.62-.25a7.11,7.11,0,0,1-.82-.37,2.7,2.7,0,0,1-.59-.42,1.73,1.73,0,0,1-.35-.54,1.86,1.86,0,0,1-.12-.7,1.66,1.66,0,0,1,.22-.87,2,2,0,0,1,.61-.64,2.88,2.88,0,0,1,.85-.39,4.22,4.22,0,0,1,1-.13,4.05,4.05,0,0,1,1.63.32v1.13a3.25,3.25,0,0,0-1.78-.5,2,2,0,0,0-.57.07,1.32,1.32,0,0,0-.43.2.91.91,0,0,0-.28.31.79.79,0,0,0-.1.4.92.92,0,0,0,.1.46,1,1,0,0,0,.29.33,2.43,2.43,0,0,0,.46.26l.62.25a8.42,8.42,0,0,1,.84.37,2.88,2.88,0,0,1,.63.42,1.9,1.9,0,0,1,.4.54,1.83,1.83,0,0,1,.14.73,1.78,1.78,0,0,1-.23.91,2,2,0,0,1-.61.63,2.75,2.75,0,0,1-.89.38,4.42,4.42,0,0,1-1,.12A3.91,3.91,0,0,1,132.5,114.07Z" fill="#2f2f2f"/>
-      <path d="M138.42,114.07v-1.2a3.32,3.32,0,0,0,2,.68q1.47,0,1.47-1a.89.89,0,0,0-.12-.47,1.41,1.41,0,0,0-.34-.35,3.05,3.05,0,0,0-.51-.27l-.62-.25a6.41,6.41,0,0,1-.82-.37,2.48,2.48,0,0,1-.59-.42,1.6,1.6,0,0,1-.36-.54,2.1,2.1,0,0,1-.11-.7,1.66,1.66,0,0,1,.22-.87,1.93,1.93,0,0,1,.6-.64,2.94,2.94,0,0,1,.86-.39,4.07,4.07,0,0,1,1-.13,4,4,0,0,1,1.63.32v1.13a3.22,3.22,0,0,0-1.78-.5,2,2,0,0,0-.56.07,1.37,1.37,0,0,0-.44.2,1,1,0,0,0-.28.31.91.91,0,0,0-.1.4,1,1,0,0,0,.1.46,1.28,1.28,0,0,0,.29.33,2.92,2.92,0,0,0,.47.26l.62.25a7.3,7.3,0,0,1,.83.37,2.47,2.47,0,0,1,.63.42,1.58,1.58,0,0,1,.4.54,1.67,1.67,0,0,1,.14.73,1.69,1.69,0,0,1-.23.91,1.93,1.93,0,0,1-.61.63,2.7,2.7,0,0,1-.88.38,4.44,4.44,0,0,1-1.05.12A3.94,3.94,0,0,1,138.42,114.07Z" fill="#2f2f2f"/>
-      <path d="M151.83,114.33h-1.36l-1.64-2.75a7.23,7.23,0,0,0-.44-.65,2.29,2.29,0,0,0-.44-.44,1.26,1.26,0,0,0-.47-.25,1.81,1.81,0,0,0-.58-.08h-1v4.17h-1.14v-9.81h2.92a4.07,4.07,0,0,1,1.19.17,2.7,2.7,0,0,1,.94.48,2.31,2.31,0,0,1,.63.82,2.74,2.74,0,0,1,.22,1.15,2.85,2.85,0,0,1-.15.94,2.4,2.4,0,0,1-.44.76,2.9,2.9,0,0,1-.68.57,3.26,3.26,0,0,1-.9.36v0a2.55,2.55,0,0,1,.43.25,2.63,2.63,0,0,1,.34.33c.11.13.22.28.33.44l.35.56ZM146,105.56v3.56h1.56a2.28,2.28,0,0,0,.8-.13,2,2,0,0,0,.63-.37,1.71,1.71,0,0,0,.42-.6,2,2,0,0,0,.15-.79A1.56,1.56,0,0,0,149,106a2.21,2.21,0,0,0-1.47-.44Z" fill="#2f2f2f"/>
-      <path d="M155.75,114.49a3.25,3.25,0,0,1-2.48-1,3.62,3.62,0,0,1-.93-2.6,3.82,3.82,0,0,1,1-2.76,3.5,3.5,0,0,1,2.61-1,3.11,3.11,0,0,1,2.44,1,3.79,3.79,0,0,1,.88,2.67,3.71,3.71,0,0,1-.95,2.68A3.27,3.27,0,0,1,155.75,114.49Zm.08-6.38a2.13,2.13,0,0,0-1.71.73,3,3,0,0,0-.63,2,2.82,2.82,0,0,0,.64,2,2.15,2.15,0,0,0,1.7.72,2.06,2.06,0,0,0,1.67-.71,3,3,0,0,0,.58-2,3.1,3.1,0,0,0-.58-2A2,2,0,0,0,155.83,108.11Z" fill="#2f2f2f"/>
-      <path d="M166.64,114.33h-1.12v-1.11h0a2.29,2.29,0,0,1-2.16,1.27c-1.67,0-2.5-1-2.5-3v-4.18h1.11v4c0,1.48.57,2.22,1.7,2.22a1.69,1.69,0,0,0,1.35-.61,2.32,2.32,0,0,0,.53-1.58v-4h1.12Z" fill="#2f2f2f"/>
-      <path d="M172.08,114.26a2.09,2.09,0,0,1-1,.22c-1.23,0-1.84-.69-1.84-2v-4.15H168v-1h1.2v-1.71l1.12-.36v2.07h1.76v1h-1.76v4a1.61,1.61,0,0,0,.24,1,1,1,0,0,0,.79.3,1.14,1.14,0,0,0,.73-.23Z" fill="#2f2f2f"/>
-      <path d="M179.08,111.11h-5a2.61,2.61,0,0,0,.63,1.8,2.16,2.16,0,0,0,1.66.64,3.42,3.42,0,0,0,2.17-.78v1a4,4,0,0,1-2.44.67,3,3,0,0,1-2.33-.95,3.89,3.89,0,0,1-.85-2.69,3.83,3.83,0,0,1,.93-2.66,3,3,0,0,1,2.3-1,2.63,2.63,0,0,1,2.12.89,3.67,3.67,0,0,1,.76,2.47Zm-1.15-1a2.29,2.29,0,0,0-.47-1.51,1.6,1.6,0,0,0-1.28-.54,1.84,1.84,0,0,0-1.35.56,2.55,2.55,0,0,0-.68,1.49Z" fill="#2f2f2f"/>
-      <path d="M126.34,130.81a3.7,3.7,0,0,1-1.92.48,3.14,3.14,0,0,1-2.41-1,3.5,3.5,0,0,1-.92-2.53,3.89,3.89,0,0,1,1-2.78,3.46,3.46,0,0,1,2.64-1.05,3.8,3.8,0,0,1,1.63.34v1.15a2.89,2.89,0,0,0-1.67-.54,2.24,2.24,0,0,0-1.76.77,2.89,2.89,0,0,0-.68,2,2.79,2.79,0,0,0,.64,1.94,2.24,2.24,0,0,0,1.73.71,2.81,2.81,0,0,0,1.73-.61Z" fill="#2f2f2f"/>
-      <path d="M128.4,122.35a.69.69,0,0,1-.51-.21.69.69,0,0,1-.22-.51.73.73,0,0,1,.22-.53.69.69,0,0,1,.51-.21.72.72,0,0,1,.52.21.69.69,0,0,1,.22.53.67.67,0,0,1-.22.51A.72.72,0,0,1,128.4,122.35Zm.55,8.78h-1.13v-7H129Z" fill="#2f2f2f"/>
-      <path d="M134.71,125.26a1.34,1.34,0,0,0-.84-.22,1.42,1.42,0,0,0-1.2.67,3.15,3.15,0,0,0-.48,1.85v3.57h-1.13v-7h1.13v1.44h0a2.48,2.48,0,0,1,.73-1.15A1.67,1.67,0,0,1,134,124a1.85,1.85,0,0,1,.67.1Z" fill="#2f2f2f"/>
-      <path d="M140.67,130.81a3.66,3.66,0,0,1-1.91.48,3.16,3.16,0,0,1-2.42-1,3.55,3.55,0,0,1-.92-2.53,3.89,3.89,0,0,1,1-2.78,3.48,3.48,0,0,1,2.65-1.05,3.83,3.83,0,0,1,1.63.34v1.15a2.89,2.89,0,0,0-1.67-.54,2.23,2.23,0,0,0-1.76.77,2.9,2.9,0,0,0-.69,2,2.79,2.79,0,0,0,.65,1.94,2.22,2.22,0,0,0,1.73.71,2.78,2.78,0,0,0,1.72-.61Z" fill="#2f2f2f"/>
-      <path d="M147.9,131.13h-1.12V130h0a2.31,2.31,0,0,1-2.16,1.27c-1.67,0-2.5-1-2.5-3v-4.18h1.11v4c0,1.48.57,2.22,1.7,2.22a1.72,1.72,0,0,0,1.35-.61,2.32,2.32,0,0,0,.53-1.58v-4h1.12Z" fill="#2f2f2f"/>
-      <path d="M150.59,122.35a.7.7,0,0,1-.52-.21.68.68,0,0,1-.21-.51.72.72,0,0,1,.21-.53.7.7,0,0,1,.52-.21.72.72,0,0,1,.73.74.69.69,0,0,1-.21.51A.72.72,0,0,1,150.59,122.35Zm.54,8.78H150v-7h1.12Z" fill="#2f2f2f"/>
-      <path d="M156.58,131.06a2.22,2.22,0,0,1-1.05.22c-1.22,0-1.83-.69-1.83-2.05v-4.15h-1.21v-1h1.21v-1.71l1.12-.36v2.07h1.76v1h-1.76v4a1.61,1.61,0,0,0,.24,1,1,1,0,0,0,.79.3,1.14,1.14,0,0,0,.73-.23Z" fill="#2f2f2f"/>
-    </g>
-    <g>
-      <path d="M503.3,426.1l-3.63,9.8h-1.26l-3.56-9.8h1.28l2.71,7.77a4,4,0,0,1,.2.87h0a4,4,0,0,1,.23-.88l2.76-7.76Z" fill="#2f2f2f"/>
-      <path d="M505.21,427.12a.73.73,0,0,1-.51-.2.7.7,0,0,1-.21-.52.7.7,0,0,1,.72-.73.78.78,0,0,1,.53.2.72.72,0,0,1,.21.53.69.69,0,0,1-.21.51A.74.74,0,0,1,505.21,427.12Zm.55,8.78h-1.12v-7h1.12Z" fill="#2f2f2f"/>
-      <path d="M511.53,430a1.39,1.39,0,0,0-.85-.22,1.41,1.41,0,0,0-1.2.68,3.12,3.12,0,0,0-.48,1.84v3.57h-1.12v-7H509v1.44h0a2.46,2.46,0,0,1,.73-1.15,1.64,1.64,0,0,1,1.1-.41,1.92,1.92,0,0,1,.67.09Z" fill="#2f2f2f"/>
-      <path d="M516.45,435.83a2.13,2.13,0,0,1-1.05.22c-1.22,0-1.84-.68-1.84-2.05v-4.14h-1.2v-1h1.2v-1.71l1.12-.36v2.07h1.77v1h-1.77v3.94a1.65,1.65,0,0,0,.24,1,1,1,0,0,0,.8.3,1.16,1.16,0,0,0,.73-.24Z" fill="#2f2f2f"/>
-      <path d="M523.57,435.9h-1.12v-1.11h0a2.31,2.31,0,0,1-2.16,1.27c-1.67,0-2.5-1-2.5-3V428.9h1.11v4c0,1.47.56,2.21,1.7,2.21a1.74,1.74,0,0,0,1.35-.6,2.37,2.37,0,0,0,.53-1.59v-4h1.12Z" fill="#2f2f2f"/>
-      <path d="M530.72,435.9H529.6v-1.09h0a2.34,2.34,0,0,1-2.15,1.25,2.31,2.31,0,0,1-1.64-.55,1.94,1.94,0,0,1-.59-1.47q0-2,2.31-2.28l2.1-.3c0-1.19-.48-1.78-1.44-1.78a3.45,3.45,0,0,0-2.28.86v-1.15a4.28,4.28,0,0,1,2.37-.65c1.65,0,2.47.87,2.47,2.61Zm-1.12-3.54-1.69.23a2.58,2.58,0,0,0-1.17.39,1.09,1.09,0,0,0-.4,1,1.07,1.07,0,0,0,.37.84,1.42,1.42,0,0,0,1,.32,1.79,1.79,0,0,0,1.38-.58,2.11,2.11,0,0,0,.54-1.48Z" fill="#2f2f2f"/>
-      <path d="M533.86,435.9h-1.12V425.54h1.12Z" fill="#2f2f2f"/>
-      <path d="M497.66,452.7h-1.4l-5.05-7.81a3,3,0,0,1-.31-.62h0a11.85,11.85,0,0,1,.05,1.35v7.08h-1.15v-9.8h1.49l4.91,7.69c.21.32.34.53.4.65h0a11.72,11.72,0,0,1-.06-1.44v-6.9h1.14Z" fill="#2f2f2f"/>
-      <path d="M505.64,449.48H500.7a2.61,2.61,0,0,0,.63,1.8,2.14,2.14,0,0,0,1.65.64,3.45,3.45,0,0,0,2.18-.78v1.05a4.05,4.05,0,0,1-2.44.67,2.93,2.93,0,0,1-2.33-.95,4.49,4.49,0,0,1,.07-5.35,3,3,0,0,1,2.3-1,2.64,2.64,0,0,1,2.13.89,3.74,3.74,0,0,1,.75,2.47Zm-1.15-1A2.29,2.29,0,0,0,504,447a1.61,1.61,0,0,0-1.29-.54,1.81,1.81,0,0,0-1.34.57,2.56,2.56,0,0,0-.69,1.48Z" fill="#2f2f2f"/>
-      <path d="M510.57,452.63a2.15,2.15,0,0,1-1.05.22c-1.22,0-1.84-.68-1.84-2.05v-4.14h-1.2v-1h1.2V444l1.12-.36v2.07h1.77v1H508.8v3.94a1.65,1.65,0,0,0,.24,1,1,1,0,0,0,.8.3,1.16,1.16,0,0,0,.73-.24Z" fill="#2f2f2f"/>
-      <path d="M521.26,445.7l-2.1,7H518l-1.45-5a3.06,3.06,0,0,1-.1-.65h0a3.07,3.07,0,0,1-.15.63l-1.56,5h-1.12l-2.12-7h1.17l1.45,5.26a3,3,0,0,1,.1.63h0a3.31,3.31,0,0,1,.13-.64L516,445.7h1l1.45,5.28a6,6,0,0,1,.1.63h.05a2.86,2.86,0,0,1,.12-.63l1.42-5.28Z" fill="#2f2f2f"/>
-      <path d="M525.33,452.86a3.24,3.24,0,0,1-2.48-1,3.65,3.65,0,0,1-.92-2.6,3.79,3.79,0,0,1,1-2.75,3.47,3.47,0,0,1,2.61-1,3.16,3.16,0,0,1,2.44,1,4.38,4.38,0,0,1-.07,5.36A3.32,3.32,0,0,1,525.33,452.86Zm.08-6.38a2.11,2.11,0,0,0-1.7.73,3,3,0,0,0-.63,2,2.87,2.87,0,0,0,.63,2,2.16,2.16,0,0,0,1.7.72,2.06,2.06,0,0,0,1.68-.7,3.79,3.79,0,0,0,0-4A2.06,2.06,0,0,0,525.41,446.48Z" fill="#2f2f2f"/>
-      <path d="M534.18,446.83a1.34,1.34,0,0,0-.84-.22,1.42,1.42,0,0,0-1.2.67,3.17,3.17,0,0,0-.48,1.85v3.57h-1.13v-7h1.13v1.44h0a2.54,2.54,0,0,1,.73-1.15,1.65,1.65,0,0,1,1.1-.41,1.89,1.89,0,0,1,.67.09Z" fill="#2f2f2f"/>
-      <path d="M541.24,452.7h-1.57l-3.09-3.36h0v3.36h-1.12V442.34h1.12v6.57h0l2.94-3.21H541l-3.25,3.38Z" fill="#2f2f2f"/>
-      <path d="M493.56,468.49h0v4.23h-1.12V462.5h1.12v1.23h0a2.65,2.65,0,0,1,2.42-1.39,2.56,2.56,0,0,1,2.12.94,3.89,3.89,0,0,1,.75,2.51,4.35,4.35,0,0,1-.85,2.82,2.86,2.86,0,0,1-2.34,1.05A2.36,2.36,0,0,1,493.56,468.49Zm0-2.83v1a2.09,2.09,0,0,0,.56,1.48,2,2,0,0,0,3-.18,3.61,3.61,0,0,0,.58-2.17,2.81,2.81,0,0,0-.54-1.83,1.8,1.8,0,0,0-1.47-.66,2,2,0,0,0-1.57.68A2.46,2.46,0,0,0,493.54,465.66Z" fill="#2f2f2f"/>
-      <path d="M506.26,466.28h-4.94a2.61,2.61,0,0,0,.63,1.8,2.14,2.14,0,0,0,1.65.64,3.42,3.42,0,0,0,2.17-.78V469a4,4,0,0,1-2.44.67,3,3,0,0,1-2.33-1,3.93,3.93,0,0,1-.84-2.68,3.84,3.84,0,0,1,.92-2.67,3,3,0,0,1,2.3-1,2.63,2.63,0,0,1,2.13.88,3.74,3.74,0,0,1,.75,2.47Zm-1.15-.95a2.24,2.24,0,0,0-.47-1.51,1.58,1.58,0,0,0-1.28-.54,1.81,1.81,0,0,0-1.35.57,2.62,2.62,0,0,0-.68,1.48Z" fill="#2f2f2f"/>
-      <path d="M513.61,466.28h-4.94a2.61,2.61,0,0,0,.63,1.8,2.14,2.14,0,0,0,1.65.64,3.45,3.45,0,0,0,2.18-.78V469a4.05,4.05,0,0,1-2.44.67,2.93,2.93,0,0,1-2.33-1,4.49,4.49,0,0,1,.07-5.35,3,3,0,0,1,2.3-1,2.63,2.63,0,0,1,2.13.88,3.74,3.74,0,0,1,.75,2.47Zm-1.15-.95a2.29,2.29,0,0,0-.46-1.51,1.61,1.61,0,0,0-1.29-.54,1.79,1.79,0,0,0-1.34.57,2.56,2.56,0,0,0-.69,1.48Z" fill="#2f2f2f"/>
-      <path d="M519,463.63a1.39,1.39,0,0,0-.85-.22,1.41,1.41,0,0,0-1.2.68,3.12,3.12,0,0,0-.48,1.84v3.57H515.3v-7h1.12v1.44h0a2.54,2.54,0,0,1,.73-1.15,1.66,1.66,0,0,1,1.11-.41,2,2,0,0,1,.67.09Z" fill="#2f2f2f"/>
-      <path d="M520.76,460.72a.73.73,0,0,1-.51-.2A.7.7,0,0,1,520,460a.7.7,0,0,1,.72-.73.78.78,0,0,1,.53.2.72.72,0,0,1,.21.53.69.69,0,0,1-.21.51A.74.74,0,0,1,520.76,460.72Zm.55,8.78h-1.12v-7h1.12Z" fill="#2f2f2f"/>
-      <path d="M529.24,469.5h-1.12v-4c0-1.49-.54-2.23-1.63-2.23a1.77,1.77,0,0,0-1.39.63,2.34,2.34,0,0,0-.55,1.6v4h-1.12v-7h1.12v1.16h0a2.52,2.52,0,0,1,2.29-1.32,2.13,2.13,0,0,1,1.76.74,3.27,3.27,0,0,1,.61,2.14Z" fill="#2f2f2f"/>
-      <path d="M537.31,468.94q0,3.85-3.69,3.85a5,5,0,0,1-2.27-.49v-1.12a4.65,4.65,0,0,0,2.26.66c1.72,0,2.58-.92,2.58-2.75v-.77h0a2.6,2.6,0,0,1-2.4,1.34,2.63,2.63,0,0,1-2.1-.93,3.73,3.73,0,0,1-.8-2.5,4.37,4.37,0,0,1,.86-2.84,2.86,2.86,0,0,1,2.35-1.05,2.26,2.26,0,0,1,2.09,1.13h0v-1h1.12Zm-1.12-2.61v-1a2,2,0,0,0-.56-1.43,1.89,1.89,0,0,0-1.41-.59,1.94,1.94,0,0,0-1.62.75,3.34,3.34,0,0,0-.59,2.12,2.93,2.93,0,0,0,.56,1.87,1.83,1.83,0,0,0,1.5.7,1.94,1.94,0,0,0,1.53-.67A2.53,2.53,0,0,0,536.19,466.33Z" fill="#2f2f2f"/>
-    </g>
-    <g>
-      <path d="M220.33,176.83h-1.27l-1-2.75h-4.16l-1,2.75h-1.28l3.76-9.81h1.19Zm-2.69-3.78-1.53-4.18a4.18,4.18,0,0,1-.15-.66h0a4,4,0,0,1-.16.66l-1.52,4.18Z" fill="#2f2f2f"/>
-      <path d="M226.94,170.15l-4.14,5.72h4.1v1h-5.75v-.35l4.14-5.7h-3.75v-.95h5.4Z" fill="#2f2f2f"/>
-      <path d="M234,176.83h-1.12v-1.11h0a2.29,2.29,0,0,1-2.16,1.27c-1.67,0-2.5-1-2.5-3v-4.18h1.11v4c0,1.48.57,2.22,1.7,2.22a1.69,1.69,0,0,0,1.35-.61,2.32,2.32,0,0,0,.53-1.58v-4H234Z" fill="#2f2f2f"/>
-      <path d="M239.8,171a1.39,1.39,0,0,0-.85-.22,1.42,1.42,0,0,0-1.2.67,3.15,3.15,0,0,0-.48,1.85v3.57h-1.12v-7h1.12v1.44h0a2.42,2.42,0,0,1,.74-1.15,1.63,1.63,0,0,1,1.1-.42,1.93,1.93,0,0,1,.67.1Z" fill="#2f2f2f"/>
-      <path d="M246.64,173.61H241.7a2.56,2.56,0,0,0,.63,1.8,2.14,2.14,0,0,0,1.65.64,3.42,3.42,0,0,0,2.17-.78v1a4,4,0,0,1-2.44.67,3,3,0,0,1-2.33-1,3.94,3.94,0,0,1-.85-2.69,3.83,3.83,0,0,1,.93-2.66,3,3,0,0,1,2.3-1,2.64,2.64,0,0,1,2.13.89,3.72,3.72,0,0,1,.75,2.47Zm-1.15-1a2.24,2.24,0,0,0-.47-1.51,1.58,1.58,0,0,0-1.28-.54,1.84,1.84,0,0,0-1.35.56,2.61,2.61,0,0,0-.68,1.49Z" fill="#2f2f2f"/>
-      <path d="M257.3,168.06h-3.83v3.39H257v1h-3.54v4.34h-1.15V167h5Z" fill="#2f2f2f"/>
-      <path d="M259.43,168.05a.69.69,0,0,1-.51-.21.68.68,0,0,1-.21-.51.72.72,0,0,1,.21-.53.69.69,0,0,1,.51-.21.74.74,0,0,1,.53.21.72.72,0,0,1,.21.53.69.69,0,0,1-.21.51A.74.74,0,0,1,259.43,168.05Zm.55,8.78h-1.12v-7H260Z" fill="#2f2f2f"/>
-      <path d="M265.75,171a1.37,1.37,0,0,0-.85-.22,1.42,1.42,0,0,0-1.19.67,3.08,3.08,0,0,0-.49,1.85v3.57H262.1v-7h1.12v1.44h0a2.41,2.41,0,0,1,.73-1.15,1.67,1.67,0,0,1,1.1-.42,1.89,1.89,0,0,1,.67.1Z" fill="#2f2f2f"/>
-      <path d="M272.59,173.61h-4.94a2.61,2.61,0,0,0,.63,1.8,2.15,2.15,0,0,0,1.66.64,3.44,3.44,0,0,0,2.17-.78v1a4.05,4.05,0,0,1-2.44.67,3,3,0,0,1-2.33-1,3.89,3.89,0,0,1-.85-2.69,3.83,3.83,0,0,1,.93-2.66,3,3,0,0,1,2.3-1,2.63,2.63,0,0,1,2.12.89,3.72,3.72,0,0,1,.75,2.47Zm-1.14-1a2.29,2.29,0,0,0-.47-1.51,1.6,1.6,0,0,0-1.28-.54,1.84,1.84,0,0,0-1.35.56,2.55,2.55,0,0,0-.68,1.49Z" fill="#2f2f2f"/>
-      <path d="M283.07,169.83l-2.1,7h-1.16l-1.44-5a3.15,3.15,0,0,1-.11-.65h0a2.93,2.93,0,0,1-.14.63l-1.57,5H275.4l-2.12-7h1.18l1.45,5.26a3.93,3.93,0,0,1,.09.63h.06a2.65,2.65,0,0,1,.12-.64l1.61-5.25h1l1.45,5.27a4.17,4.17,0,0,1,.1.63h.05a3.09,3.09,0,0,1,.12-.63l1.42-5.27Z" fill="#2f2f2f"/>
-      <path d="M289.24,176.83h-1.12v-1.1h0a2.33,2.33,0,0,1-2.15,1.26,2.31,2.31,0,0,1-1.64-.55,1.94,1.94,0,0,1-.59-1.47c0-1.31.77-2.07,2.31-2.29l2.1-.29c0-1.19-.48-1.78-1.44-1.78a3.42,3.42,0,0,0-2.28.86v-1.15a4.32,4.32,0,0,1,2.38-.66q2.46,0,2.46,2.61Zm-1.12-3.54-1.69.23a2.58,2.58,0,0,0-1.17.39,1.09,1.09,0,0,0-.4,1,1,1,0,0,0,.37.83,1.39,1.39,0,0,0,1,.33,1.8,1.8,0,0,0,1.38-.59,2.09,2.09,0,0,0,.54-1.48Z" fill="#2f2f2f"/>
-      <path d="M292.38,176.83h-1.12V166.46h1.12Z" fill="#2f2f2f"/>
-      <path d="M295.62,176.83h-1.13V166.46h1.13Z" fill="#2f2f2f"/>
-      <path d="M234,193.37v-1.2a3.34,3.34,0,0,0,2,.68c1,0,1.48-.33,1.48-1a.89.89,0,0,0-.13-.47A1.25,1.25,0,0,0,237,191a2.7,2.7,0,0,0-.51-.27l-.62-.25a7.11,7.11,0,0,1-.82-.37,2.7,2.7,0,0,1-.59-.42,1.57,1.57,0,0,1-.35-.54,1.86,1.86,0,0,1-.12-.7,1.66,1.66,0,0,1,.22-.87,1.93,1.93,0,0,1,.6-.64,2.94,2.94,0,0,1,.86-.39,4.15,4.15,0,0,1,1-.13,4,4,0,0,1,1.62.32v1.13a3.19,3.19,0,0,0-1.77-.5,2,2,0,0,0-.57.07,1.48,1.48,0,0,0-.44.2,1,1,0,0,0-.28.31.87.87,0,0,0-.09.4,1,1,0,0,0,.09.46,1.15,1.15,0,0,0,.3.33,2.43,2.43,0,0,0,.46.26l.62.25a8.42,8.42,0,0,1,.84.37,2.88,2.88,0,0,1,.63.42,1.69,1.69,0,0,1,.39.54,1.67,1.67,0,0,1,.15.73,1.78,1.78,0,0,1-.23.91,2.07,2.07,0,0,1-.62.63,2.7,2.7,0,0,1-.88.38,4.42,4.42,0,0,1-1,.12A4,4,0,0,1,234,193.37Z" fill="#2f2f2f"/>
-      <path d="M245.88,193.63h-1.12v-1.11h0a2.29,2.29,0,0,1-2.16,1.27c-1.66,0-2.5-1-2.5-3v-4.18h1.12v4c0,1.48.56,2.22,1.69,2.22a1.69,1.69,0,0,0,1.35-.61,2.32,2.32,0,0,0,.53-1.58v-4h1.12Z" fill="#2f2f2f"/>
-      <path d="M249.14,192.62h0v1H248V183.26h1.12v4.6h0a2.66,2.66,0,0,1,2.42-1.4,2.59,2.59,0,0,1,2.11.94,3.94,3.94,0,0,1,.76,2.52,4.37,4.37,0,0,1-.86,2.82,2.85,2.85,0,0,1-2.33,1A2.3,2.3,0,0,1,249.14,192.62Zm0-2.83v1a2.09,2.09,0,0,0,.56,1.47,2,2,0,0,0,3-.17,3.54,3.54,0,0,0,.58-2.17,2.81,2.81,0,0,0-.54-1.83,1.79,1.79,0,0,0-1.46-.66,2,2,0,0,0-1.57.68A2.47,2.47,0,0,0,249.11,189.79Z" fill="#2f2f2f"/>
-      <path d="M262,193.63h-1.13v-4q0-2.22-1.62-2.22a1.76,1.76,0,0,0-1.39.63,2.31,2.31,0,0,0-.55,1.59v4h-1.13v-7h1.13v1.16h0a2.55,2.55,0,0,1,2.3-1.33,2.16,2.16,0,0,1,1.76.74,3.36,3.36,0,0,1,.61,2.15Z" fill="#2f2f2f"/>
-      <path d="M269.66,190.41h-4.94a2.56,2.56,0,0,0,.63,1.8,2.14,2.14,0,0,0,1.65.64,3.42,3.42,0,0,0,2.17-.78v1.05a4,4,0,0,1-2.44.67,3,3,0,0,1-2.33-.95,3.94,3.94,0,0,1-.85-2.69,3.83,3.83,0,0,1,.93-2.66,3,3,0,0,1,2.3-1,2.64,2.64,0,0,1,2.13.89,3.72,3.72,0,0,1,.75,2.47Zm-1.15-.95A2.24,2.24,0,0,0,268,188a1.59,1.59,0,0,0-1.28-.54,1.84,1.84,0,0,0-1.35.56,2.68,2.68,0,0,0-.68,1.49Z" fill="#2f2f2f"/>
-      <path d="M274.58,193.56a2.2,2.2,0,0,1-1,.22c-1.23,0-1.84-.69-1.84-2.05v-4.15h-1.2v-1h1.2v-1.71l1.12-.36v2.07h1.76v1h-1.76v3.95a1.61,1.61,0,0,0,.24,1,1,1,0,0,0,.79.3,1.14,1.14,0,0,0,.73-.23Z" fill="#2f2f2f"/>
-    </g>
-    <g>
-      <path d="M222.44,260a5.81,5.81,0,0,1-2.71.57,4.37,4.37,0,0,1-3.35-1.35,4.94,4.94,0,0,1-1.26-3.53,5.19,5.19,0,0,1,1.42-3.8,4.79,4.79,0,0,1,3.59-1.45,5.73,5.73,0,0,1,2.31.4v1.23a4.72,4.72,0,0,0-2.33-.59,3.53,3.53,0,0,0-2.73,1.13,4.23,4.23,0,0,0-1,3,4,4,0,0,0,1,2.86,3.35,3.35,0,0,0,2.57,1.06,4.81,4.81,0,0,0,2.56-.66Z" fill="#2f2f2f"/>
-      <path d="M227,260.59a3.26,3.26,0,0,1-2.48-1,3.62,3.62,0,0,1-.93-2.6,3.76,3.76,0,0,1,1-2.76,3.46,3.46,0,0,1,2.6-1,3.11,3.11,0,0,1,2.44,1,3.79,3.79,0,0,1,.88,2.67,3.75,3.75,0,0,1-.94,2.68A3.34,3.34,0,0,1,227,260.59Zm.08-6.38a2.13,2.13,0,0,0-1.71.73,3,3,0,0,0-.63,2,2.82,2.82,0,0,0,.64,2,2.15,2.15,0,0,0,1.7.72,2.06,2.06,0,0,0,1.67-.71,3,3,0,0,0,.58-2,3.1,3.1,0,0,0-.58-2A2,2,0,0,0,227.07,254.21Z" fill="#2f2f2f"/>
-      <path d="M235.84,254.56a1.39,1.39,0,0,0-.85-.22,1.42,1.42,0,0,0-1.2.67,3.15,3.15,0,0,0-.48,1.85v3.57h-1.12v-7h1.12v1.44h0a2.41,2.41,0,0,1,.73-1.15,1.65,1.65,0,0,1,1.1-.42,1.93,1.93,0,0,1,.67.1Z" fill="#2f2f2f"/>
-      <path d="M238.23,259.41h0v4.24h-1.12V253.43h1.12v1.23h0a2.66,2.66,0,0,1,2.42-1.4,2.57,2.57,0,0,1,2.11.94,3.88,3.88,0,0,1,.76,2.52,4.32,4.32,0,0,1-.85,2.81,2.83,2.83,0,0,1-2.34,1.06A2.33,2.33,0,0,1,238.23,259.41Zm0-2.82v1a2.05,2.05,0,0,0,.57,1.47,1.84,1.84,0,0,0,1.43.61,1.89,1.89,0,0,0,1.6-.78,3.61,3.61,0,0,0,.57-2.17,2.81,2.81,0,0,0-.54-1.83,1.78,1.78,0,0,0-1.46-.66,2,2,0,0,0-1.57.68A2.47,2.47,0,0,0,238.2,256.59Z" fill="#2f2f2f"/>
-      <path d="M254.27,251.66h-3.82v3.39H254v1h-3.54v4.34H249.3v-9.81h5Z" fill="#2f2f2f"/>
-      <path d="M256.41,251.65a.69.69,0,0,1-.51-.21.69.69,0,0,1-.21-.52.72.72,0,0,1,.21-.52.74.74,0,0,1,1.25.52.67.67,0,0,1-.22.52A.7.7,0,0,1,256.41,251.65Zm.55,8.78h-1.12v-7H257Z" fill="#2f2f2f"/>
-      <path d="M262.73,254.56a1.39,1.39,0,0,0-.85-.22,1.42,1.42,0,0,0-1.2.67,3.15,3.15,0,0,0-.48,1.85v3.57h-1.12v-7h1.12v1.44h0a2.41,2.41,0,0,1,.73-1.15,1.67,1.67,0,0,1,1.1-.42,1.89,1.89,0,0,1,.67.1Z" fill="#2f2f2f"/>
-      <path d="M269.57,257.21h-4.94a2.61,2.61,0,0,0,.63,1.8,2.14,2.14,0,0,0,1.65.64,3.45,3.45,0,0,0,2.18-.78v1.05a4.05,4.05,0,0,1-2.44.67,3,3,0,0,1-2.33-.95,4.49,4.49,0,0,1,.07-5.35,3,3,0,0,1,2.31-1,2.63,2.63,0,0,1,2.12.89,3.72,3.72,0,0,1,.75,2.47Zm-1.15-.95a2.29,2.29,0,0,0-.46-1.51,1.61,1.61,0,0,0-1.29-.54,1.84,1.84,0,0,0-1.34.56,2.62,2.62,0,0,0-.69,1.49Z" fill="#2f2f2f"/>
-      <path d="M280.05,253.43l-2.1,7h-1.16l-1.45-5a3.16,3.16,0,0,1-.1-.65h0a3.07,3.07,0,0,1-.15.63l-1.56,5h-1.12l-2.12-7h1.17l1.45,5.26a3,3,0,0,1,.1.63h0a3.31,3.31,0,0,1,.13-.64l1.61-5.25h1l1.45,5.27a4.17,4.17,0,0,1,.1.63h0a3.09,3.09,0,0,1,.12-.63l1.42-5.27Z" fill="#2f2f2f"/>
-      <path d="M286.22,260.43H285.1v-1.1h0a2.33,2.33,0,0,1-2.15,1.26,2.31,2.31,0,0,1-1.64-.55,1.94,1.94,0,0,1-.59-1.47c0-1.31.77-2.07,2.31-2.29l2.1-.29c0-1.19-.48-1.78-1.44-1.78a3.4,3.4,0,0,0-2.28.86v-1.15a4.29,4.29,0,0,1,2.37-.66c1.65,0,2.47.87,2.47,2.61Zm-1.12-3.54-1.69.23a2.72,2.72,0,0,0-1.17.38,1.12,1.12,0,0,0-.4,1,1,1,0,0,0,.37.83,1.37,1.37,0,0,0,1,.33,1.8,1.8,0,0,0,1.38-.59,2.09,2.09,0,0,0,.54-1.48Z" fill="#2f2f2f"/>
-      <path d="M289.36,260.43h-1.12V250.06h1.12Z" fill="#2f2f2f"/>
-      <path d="M292.59,260.43h-1.12V250.06h1.12Z" fill="#2f2f2f"/>
-    </g>
-    <g>
-      <path d="M363,176.83h-1.27l-1-2.75h-4.15l-1,2.75h-1.28L358,167h1.19Zm-2.68-3.78-1.54-4.18a4.18,4.18,0,0,1-.15-.66h0a3.18,3.18,0,0,1-.16.66l-1.52,4.18Z" fill="#2f2f2f"/>
-      <path d="M365.4,175.82h0v4.23h-1.12V169.83h1.12v1.23h0a2.67,2.67,0,0,1,2.42-1.4,2.59,2.59,0,0,1,2.12.94,3.94,3.94,0,0,1,.76,2.52,4.37,4.37,0,0,1-.86,2.82A2.86,2.86,0,0,1,367.5,177,2.36,2.36,0,0,1,365.4,175.82Zm0-2.83v1a2,2,0,0,0,.56,1.47,1.85,1.85,0,0,0,1.43.61,1.89,1.89,0,0,0,1.6-.78,3.61,3.61,0,0,0,.58-2.17,2.81,2.81,0,0,0-.54-1.83,1.8,1.8,0,0,0-1.47-.66,2,2,0,0,0-1.57.68A2.51,2.51,0,0,0,365.38,173Z" fill="#2f2f2f"/>
-      <path d="M373.56,175.82h0v4.23h-1.12V169.83h1.12v1.23h0a2.66,2.66,0,0,1,2.42-1.4,2.57,2.57,0,0,1,2.11.94,3.88,3.88,0,0,1,.76,2.52,4.37,4.37,0,0,1-.85,2.82,2.86,2.86,0,0,1-2.34,1.05A2.34,2.34,0,0,1,373.56,175.82Zm0-2.83v1a2.05,2.05,0,0,0,.57,1.47,1.84,1.84,0,0,0,1.43.61,1.89,1.89,0,0,0,1.6-.78,3.61,3.61,0,0,0,.57-2.17,2.81,2.81,0,0,0-.54-1.83,1.78,1.78,0,0,0-1.46-.66,2,2,0,0,0-1.57.68A2.47,2.47,0,0,0,373.53,173Z" fill="#2f2f2f"/>
-      <path d="M392,176.16a6.64,6.64,0,0,1-3.29.83,4.49,4.49,0,0,1-3.39-1.35,5,5,0,0,1-1.29-3.58,5.13,5.13,0,0,1,1.43-3.74,4.93,4.93,0,0,1,3.65-1.46,6.17,6.17,0,0,1,2.69.52v1.27a5.16,5.16,0,0,0-2.82-.75,3.53,3.53,0,0,0-2.7,1.13,4.75,4.75,0,0,0-.07,5.87,3.44,3.44,0,0,0,2.65,1.06,4.06,4.06,0,0,0,2-.46v-2.75h-2.15v-1H392Z" fill="#2f2f2f"/>
-      <path d="M399,176.83h-1.12v-1.1h0a2.33,2.33,0,0,1-2.15,1.26,2.31,2.31,0,0,1-1.64-.55,1.94,1.94,0,0,1-.59-1.47c0-1.31.77-2.07,2.31-2.29l2.1-.29c0-1.19-.48-1.78-1.44-1.78a3.42,3.42,0,0,0-2.28.86v-1.15a4.29,4.29,0,0,1,2.37-.66c1.65,0,2.47.87,2.47,2.61Zm-1.12-3.54-1.69.23a2.58,2.58,0,0,0-1.17.39,1.09,1.09,0,0,0-.4,1,1,1,0,0,0,.37.83,1.37,1.37,0,0,0,1,.33,1.8,1.8,0,0,0,1.38-.59,2.09,2.09,0,0,0,.54-1.48Z" fill="#2f2f2f"/>
-      <path d="M404.3,176.76a2.09,2.09,0,0,1-1,.22c-1.23,0-1.84-.69-1.84-2v-4.15h-1.21v-.95h1.21v-1.71l1.12-.36v2.07h1.76v.95h-1.76v3.95a1.61,1.61,0,0,0,.24,1,1,1,0,0,0,.79.3,1.14,1.14,0,0,0,.73-.23Z" fill="#2f2f2f"/>
-      <path d="M411.29,173.61h-4.94a2.61,2.61,0,0,0,.63,1.8,2.14,2.14,0,0,0,1.65.64,3.45,3.45,0,0,0,2.18-.78v1a4.05,4.05,0,0,1-2.44.67,3,3,0,0,1-2.33-1,4.49,4.49,0,0,1,.07-5.35,3,3,0,0,1,2.31-1,2.63,2.63,0,0,1,2.12.89,3.72,3.72,0,0,1,.75,2.47Zm-1.15-1a2.29,2.29,0,0,0-.46-1.51,1.61,1.61,0,0,0-1.29-.54,1.84,1.84,0,0,0-1.34.56,2.62,2.62,0,0,0-.69,1.49Z" fill="#2f2f2f"/>
-      <path d="M421.77,169.83l-2.1,7h-1.16l-1.45-5a3.16,3.16,0,0,1-.1-.65h0a3.07,3.07,0,0,1-.15.63l-1.56,5H414.1l-2.12-7h1.17l1.45,5.26a3,3,0,0,1,.1.63h.05a3.31,3.31,0,0,1,.13-.64l1.61-5.25h1L419,175.1a4.17,4.17,0,0,1,.1.63h.05a3.09,3.09,0,0,1,.12-.63l1.42-5.27Z" fill="#2f2f2f"/>
-      <path d="M427.94,176.83h-1.12v-1.1h0a2.33,2.33,0,0,1-2.15,1.26,2.31,2.31,0,0,1-1.64-.55,1.94,1.94,0,0,1-.59-1.47c0-1.31.77-2.07,2.31-2.29l2.1-.29c0-1.19-.48-1.78-1.44-1.78a3.44,3.44,0,0,0-2.29.86v-1.15a4.35,4.35,0,0,1,2.38-.66c1.65,0,2.47.87,2.47,2.61Zm-1.12-3.54-1.69.23a2.58,2.58,0,0,0-1.17.39,1.09,1.09,0,0,0-.4,1,1.05,1.05,0,0,0,.36.83,1.42,1.42,0,0,0,1,.33,1.8,1.8,0,0,0,1.38-.59,2.09,2.09,0,0,0,.54-1.48Z" fill="#2f2f2f"/>
-      <path d="M435.45,169.83,432.23,178c-.57,1.45-1.38,2.17-2.42,2.17a2.55,2.55,0,0,1-.73-.09v-1a2.16,2.16,0,0,0,.67.12,1.39,1.39,0,0,0,1.27-1l.56-1.33-2.74-7h1.25l1.89,5.38c0,.07.07.25.14.54h.05a4.78,4.78,0,0,1,.13-.52l2-5.4Z" fill="#2f2f2f"/>
-      <path d="M376.6,193.37v-1.2a3.34,3.34,0,0,0,2,.68c1,0,1.48-.33,1.48-1a.89.89,0,0,0-.13-.47,1.41,1.41,0,0,0-.34-.35,2.7,2.7,0,0,0-.51-.27l-.62-.25a6.41,6.41,0,0,1-.82-.37,2.48,2.48,0,0,1-.59-.42,1.57,1.57,0,0,1-.35-.54,1.86,1.86,0,0,1-.12-.7,1.66,1.66,0,0,1,.22-.87,1.93,1.93,0,0,1,.6-.64,2.94,2.94,0,0,1,.86-.39,4.09,4.09,0,0,1,1-.13,4,4,0,0,1,1.62.32v1.13a3.19,3.19,0,0,0-1.77-.5,2,2,0,0,0-.57.07,1.37,1.37,0,0,0-.44.2,1,1,0,0,0-.28.31.88.88,0,0,0-.1.4,1,1,0,0,0,.1.46,1.28,1.28,0,0,0,.29.33,2.92,2.92,0,0,0,.47.26l.62.25a8.42,8.42,0,0,1,.84.37,2.59,2.59,0,0,1,.62.42,1.58,1.58,0,0,1,.4.54,1.67,1.67,0,0,1,.14.73,1.78,1.78,0,0,1-.22.91,2.07,2.07,0,0,1-.62.63,2.7,2.7,0,0,1-.88.38,4.42,4.42,0,0,1-1,.12A4,4,0,0,1,376.6,193.37Z" fill="#2f2f2f"/>
-      <path d="M388.51,193.63h-1.12v-1.11h0a2.29,2.29,0,0,1-2.16,1.27c-1.67,0-2.5-1-2.5-3v-4.18h1.11v4c0,1.48.57,2.22,1.7,2.22a1.69,1.69,0,0,0,1.35-.61,2.32,2.32,0,0,0,.53-1.58v-4h1.12Z" fill="#2f2f2f"/>
-      <path d="M391.77,192.62h0v1h-1.12V183.26h1.12v4.6h0a2.66,2.66,0,0,1,2.42-1.4,2.6,2.6,0,0,1,2.11.94,3.94,3.94,0,0,1,.76,2.52,4.37,4.37,0,0,1-.86,2.82,2.85,2.85,0,0,1-2.33,1A2.3,2.3,0,0,1,391.77,192.62Zm0-2.83v1a2.09,2.09,0,0,0,.56,1.47,2,2,0,0,0,3-.17,3.54,3.54,0,0,0,.58-2.17,2.81,2.81,0,0,0-.54-1.83,1.79,1.79,0,0,0-1.46-.66,2,2,0,0,0-1.58.68A2.51,2.51,0,0,0,391.74,189.79Z" fill="#2f2f2f"/>
-      <path d="M404.59,193.63h-1.13v-4q0-2.22-1.62-2.22a1.76,1.76,0,0,0-1.39.63,2.31,2.31,0,0,0-.55,1.59v4h-1.13v-7h1.13v1.16h0a2.55,2.55,0,0,1,2.3-1.33,2.16,2.16,0,0,1,1.76.74,3.36,3.36,0,0,1,.61,2.15Z" fill="#2f2f2f"/>
-      <path d="M412.29,190.41h-4.94a2.56,2.56,0,0,0,.62,1.8,2.18,2.18,0,0,0,1.66.64,3.42,3.42,0,0,0,2.17-.78v1.05a4,4,0,0,1-2.44.67,3,3,0,0,1-2.33-.95,3.94,3.94,0,0,1-.85-2.69,3.83,3.83,0,0,1,.93-2.66,3,3,0,0,1,2.3-1,2.64,2.64,0,0,1,2.13.89,3.72,3.72,0,0,1,.75,2.47Zm-1.15-.95a2.29,2.29,0,0,0-.47-1.51,1.59,1.59,0,0,0-1.28-.54A1.84,1.84,0,0,0,408,188a2.61,2.61,0,0,0-.68,1.49Z" fill="#2f2f2f"/>
-      <path d="M417.21,193.56a2.2,2.2,0,0,1-1,.22c-1.23,0-1.84-.69-1.84-2.05v-4.15h-1.21v-1h1.21v-1.71l1.12-.36v2.07h1.76v1h-1.76v3.95a1.61,1.61,0,0,0,.24,1,1,1,0,0,0,.79.3,1.14,1.14,0,0,0,.73-.23Z" fill="#2f2f2f"/>
-    </g>
-    <g>
-      <path d="M579.51,171.19v-1.35a2.86,2.86,0,0,0,.56.37,5.24,5.24,0,0,0,.69.28,5.8,5.8,0,0,0,.72.17,4.06,4.06,0,0,0,.67.06,2.65,2.65,0,0,0,1.58-.39,1.32,1.32,0,0,0,.52-1.13,1.36,1.36,0,0,0-.17-.69,2,2,0,0,0-.48-.54,5.42,5.42,0,0,0-.73-.47L582,167c-.34-.18-.66-.35-1-.53a4,4,0,0,1-.78-.59,2.29,2.29,0,0,1-.51-.73,2.15,2.15,0,0,1-.19-.95,2.27,2.27,0,0,1,.29-1.16,2.52,2.52,0,0,1,.77-.82,3.31,3.31,0,0,1,1.1-.48,4.69,4.69,0,0,1,1.24-.16,4.86,4.86,0,0,1,2.12.35v1.29a3.86,3.86,0,0,0-2.23-.6,4,4,0,0,0-.76.08,2.08,2.08,0,0,0-.67.26,1.56,1.56,0,0,0-.47.45,1.19,1.19,0,0,0-.19.69,1.45,1.45,0,0,0,.14.65,1.63,1.63,0,0,0,.42.5,4,4,0,0,0,.66.43c.26.15.57.3.91.47a10.66,10.66,0,0,1,1,.55,4.44,4.44,0,0,1,.82.63,2.8,2.8,0,0,1,.57.77,2.19,2.19,0,0,1,.21,1,2.43,2.43,0,0,1-.29,1.23,2.3,2.3,0,0,1-.76.82,3.41,3.41,0,0,1-1.11.45,5.77,5.77,0,0,1-1.33.14l-.58,0-.69-.11a6.75,6.75,0,0,1-.68-.18A2,2,0,0,1,579.51,171.19Z" fill="#2f2f2f"/>
-      <path d="M592.84,168.37h-5a2.61,2.61,0,0,0,.63,1.8,2.16,2.16,0,0,0,1.66.64,3.42,3.42,0,0,0,2.17-.78v1.05a4,4,0,0,1-2.44.67,3,3,0,0,1-2.33-.95,3.88,3.88,0,0,1-.85-2.68,3.84,3.84,0,0,1,.93-2.67,3,3,0,0,1,2.3-1,2.65,2.65,0,0,1,2.13.89,3.74,3.74,0,0,1,.75,2.47Zm-1.15-1a2.29,2.29,0,0,0-.47-1.51,1.59,1.59,0,0,0-1.28-.54,1.81,1.81,0,0,0-1.35.57,2.55,2.55,0,0,0-.68,1.48Z" fill="#2f2f2f"/>
-      <path d="M598.17,165.72a1.39,1.39,0,0,0-.85-.22,1.42,1.42,0,0,0-1.2.67,3.17,3.17,0,0,0-.48,1.85v3.57h-1.12v-7h1.12V166h0a2.46,2.46,0,0,1,.73-1.15,1.64,1.64,0,0,1,1.1-.41,2,2,0,0,1,.67.09Z" fill="#2f2f2f"/>
-      <path d="M605.44,164.59l-2.79,7h-1.1l-2.65-7h1.23l1.78,5.08a4.6,4.6,0,0,1,.24,1h0a5.1,5.1,0,0,1,.22-1l1.86-5.11Z" fill="#2f2f2f"/>
-      <path d="M607.26,162.81a.73.73,0,0,1-.51-.2.67.67,0,0,1-.22-.52.69.69,0,0,1,.22-.53.69.69,0,0,1,.51-.2.71.71,0,0,1,.52.2.73.73,0,0,1,.22.53.7.7,0,0,1-.22.51A.72.72,0,0,1,607.26,162.81Zm.54,8.78h-1.12v-7h1.12Z" fill="#2f2f2f"/>
-      <path d="M614.72,171.27a3.7,3.7,0,0,1-1.92.48,3.14,3.14,0,0,1-2.41-1,3.5,3.5,0,0,1-.92-2.53,3.89,3.89,0,0,1,1-2.78,3.46,3.46,0,0,1,2.64-1.05,3.66,3.66,0,0,1,1.63.35v1.14a2.87,2.87,0,0,0-1.67-.54,2.24,2.24,0,0,0-1.76.77,2.89,2.89,0,0,0-.68,2,2.79,2.79,0,0,0,.64,1.94,2.24,2.24,0,0,0,1.73.71,2.81,2.81,0,0,0,1.73-.61Z" fill="#2f2f2f"/>
-      <path d="M621.89,168.37h-4.95a2.61,2.61,0,0,0,.63,1.8,2.16,2.16,0,0,0,1.66.64,3.42,3.42,0,0,0,2.17-.78v1.05a4,4,0,0,1-2.44.67,3,3,0,0,1-2.33-.95,3.88,3.88,0,0,1-.85-2.68,3.84,3.84,0,0,1,.93-2.67,3,3,0,0,1,2.3-1,2.63,2.63,0,0,1,2.12.89,3.69,3.69,0,0,1,.76,2.47Zm-1.15-1a2.29,2.29,0,0,0-.47-1.51,1.59,1.59,0,0,0-1.28-.54,1.81,1.81,0,0,0-1.35.57,2.55,2.55,0,0,0-.68,1.48Z" fill="#2f2f2f"/>
-      <path d="M634.59,171.59h-1.36l-1.64-2.75a6.61,6.61,0,0,0-.44-.65,2.58,2.58,0,0,0-.43-.44,1.38,1.38,0,0,0-.48-.25,2.08,2.08,0,0,0-.58-.08h-.94v4.17h-1.15v-9.8h2.92a4.08,4.08,0,0,1,1.19.16,2.48,2.48,0,0,1,.94.49,2.19,2.19,0,0,1,.63.81,2.74,2.74,0,0,1,.22,1.15,2.85,2.85,0,0,1-.15.94,2.4,2.4,0,0,1-.44.76,2.71,2.71,0,0,1-.68.57,3.62,3.62,0,0,1-.9.37v0a2.87,2.87,0,0,1,.43.25,3.51,3.51,0,0,1,.34.33c.11.13.22.28.33.44l.36.56Zm-5.87-8.76v3.55h1.55a2.28,2.28,0,0,0,.8-.13,1.87,1.87,0,0,0,.63-.37,1.63,1.63,0,0,0,.42-.6,2,2,0,0,0,.15-.79,1.52,1.52,0,0,0-.51-1.22,2.15,2.15,0,0,0-1.47-.44Z" fill="#2f2f2f"/>
-      <path d="M641.26,171.59h-1.12v-1.11h0a2.31,2.31,0,0,1-2.16,1.27c-1.67,0-2.51-1-2.51-3v-4.18h1.12v4c0,1.48.56,2.22,1.69,2.22a1.69,1.69,0,0,0,1.35-.61,2.27,2.27,0,0,0,.53-1.58v-4h1.12Z" fill="#2f2f2f"/>
-      <path d="M649.18,171.59h-1.12v-4c0-1.49-.54-2.23-1.63-2.23A1.77,1.77,0,0,0,645,166a2.37,2.37,0,0,0-.55,1.6v4h-1.12v-7h1.12v1.16h0a2.54,2.54,0,0,1,2.3-1.33,2.12,2.12,0,0,1,1.75.75,3.27,3.27,0,0,1,.61,2.14Z" fill="#2f2f2f"/>
-      <path d="M654.41,171.52a2.09,2.09,0,0,1-1,.22c-1.23,0-1.84-.68-1.84-2.05v-4.14h-1.21v-1h1.21v-1.71l1.12-.36v2.07h1.76v1h-1.76v3.94a1.61,1.61,0,0,0,.24,1,.92.92,0,0,0,.79.31,1.14,1.14,0,0,0,.73-.24Z" fill="#2f2f2f"/>
-      <path d="M656.37,162.81a.77.77,0,0,1-.52-.2.7.7,0,0,1-.21-.52.7.7,0,0,1,.73-.73.71.71,0,0,1,.52.2.72.72,0,0,1,.21.53.69.69,0,0,1-.21.51A.72.72,0,0,1,656.37,162.81Zm.54,8.78h-1.12v-7h1.12Z" fill="#2f2f2f"/>
-      <path d="M669,171.59h-1.12v-4a3,3,0,0,0-.36-1.68,1.35,1.35,0,0,0-1.21-.52,1.53,1.53,0,0,0-1.22.65,2.57,2.57,0,0,0-.5,1.58v4h-1.12v-4.16c0-1.37-.53-2.06-1.59-2.06a1.47,1.47,0,0,0-1.22.62,2.55,2.55,0,0,0-.48,1.61v4H659v-7h1.12v1.11h0a2.38,2.38,0,0,1,2.17-1.28,2.07,2.07,0,0,1,2,1.45,2.5,2.5,0,0,1,2.32-1.45c1.54,0,2.31,1,2.31,2.86Z" fill="#2f2f2f"/>
-      <path d="M676.68,168.37h-4.94a2.56,2.56,0,0,0,.62,1.8,2.18,2.18,0,0,0,1.66.64,3.42,3.42,0,0,0,2.17-.78v1.05a4,4,0,0,1-2.44.67,3,3,0,0,1-2.33-.95,3.93,3.93,0,0,1-.85-2.68,3.84,3.84,0,0,1,.93-2.67,3,3,0,0,1,2.3-1,2.65,2.65,0,0,1,2.13.89,3.74,3.74,0,0,1,.75,2.47Zm-1.15-1a2.29,2.29,0,0,0-.47-1.51,1.59,1.59,0,0,0-1.28-.54,1.81,1.81,0,0,0-1.35.57,2.55,2.55,0,0,0-.68,1.48Z" fill="#2f2f2f"/>
-      <path d="M681.78,171.34v-1.21a3.34,3.34,0,0,0,2,.68c1,0,1.48-.33,1.48-1a.82.82,0,0,0-.13-.48,1.4,1.4,0,0,0-.34-.35,2.42,2.42,0,0,0-.51-.26l-.62-.25c-.31-.13-.58-.25-.82-.38a2.4,2.4,0,0,1-.59-.42,1.73,1.73,0,0,1-.35-.54,1.86,1.86,0,0,1-.12-.7,1.66,1.66,0,0,1,.22-.87,1.87,1.87,0,0,1,.61-.64,2.88,2.88,0,0,1,.85-.39,4.15,4.15,0,0,1,1-.13,4,4,0,0,1,1.62.32v1.13a3.19,3.19,0,0,0-1.77-.5,2,2,0,0,0-.57.07,1.56,1.56,0,0,0-.43.2.91.91,0,0,0-.28.31.79.79,0,0,0-.1.4.92.92,0,0,0,.1.46,1,1,0,0,0,.29.33,2.43,2.43,0,0,0,.46.26l.62.25a8.42,8.42,0,0,1,.84.37,2.88,2.88,0,0,1,.63.42,1.9,1.9,0,0,1,.4.54,1.84,1.84,0,0,1,.14.74,1.77,1.77,0,0,1-.23.9,2,2,0,0,1-.61.63,2.75,2.75,0,0,1-.89.38,4.42,4.42,0,0,1-1,.12A4.1,4.1,0,0,1,681.78,171.34Z" fill="#2f2f2f"/>
-      <path d="M693.69,171.59h-1.12v-1.11h0a2.29,2.29,0,0,1-2.16,1.27c-1.66,0-2.5-1-2.5-3v-4.18H689v4c0,1.48.56,2.22,1.69,2.22a1.69,1.69,0,0,0,1.35-.61,2.32,2.32,0,0,0,.53-1.58v-4h1.12Z" fill="#2f2f2f"/>
-      <path d="M697,170.58h0v1H695.8V161.23h1.12v4.59h0a2.66,2.66,0,0,1,2.42-1.4,2.57,2.57,0,0,1,2.11,1,3.84,3.84,0,0,1,.76,2.51,4.35,4.35,0,0,1-.86,2.82,2.82,2.82,0,0,1-2.33,1.05A2.3,2.3,0,0,1,697,170.58Zm0-2.83v1a2.05,2.05,0,0,0,.57,1.47,2,2,0,0,0,3-.17,3.54,3.54,0,0,0,.58-2.17,2.81,2.81,0,0,0-.54-1.83,1.79,1.79,0,0,0-1.46-.66,2,2,0,0,0-1.57.68A2.47,2.47,0,0,0,696.92,167.75Z" fill="#2f2f2f"/>
-      <path d="M709.77,171.59h-1.12v-4c0-1.49-.55-2.23-1.63-2.23a1.76,1.76,0,0,0-1.39.63,2.32,2.32,0,0,0-.55,1.6v4H704v-7h1.12v1.16h0a2.55,2.55,0,0,1,2.3-1.33,2.14,2.14,0,0,1,1.76.75,3.33,3.33,0,0,1,.61,2.14Z" fill="#2f2f2f"/>
-      <path d="M717.47,168.37h-4.94a2.61,2.61,0,0,0,.63,1.8,2.14,2.14,0,0,0,1.65.64A3.42,3.42,0,0,0,717,170v1.05a4,4,0,0,1-2.44.67,3,3,0,0,1-2.33-.95,3.93,3.93,0,0,1-.84-2.68,3.84,3.84,0,0,1,.92-2.67,3,3,0,0,1,2.3-1,2.64,2.64,0,0,1,2.13.89,3.74,3.74,0,0,1,.75,2.47Zm-1.15-1a2.24,2.24,0,0,0-.47-1.51,1.58,1.58,0,0,0-1.28-.54,1.81,1.81,0,0,0-1.35.57,2.62,2.62,0,0,0-.68,1.48Z" fill="#2f2f2f"/>
-      <path d="M722.39,171.52a2.09,2.09,0,0,1-1,.22c-1.23,0-1.84-.68-1.84-2.05v-4.14h-1.2v-1h1.2v-1.71l1.12-.36v2.07h1.76v1h-1.76v3.94a1.61,1.61,0,0,0,.24,1,.92.92,0,0,0,.79.31,1.13,1.13,0,0,0,.73-.24Z" fill="#2f2f2f"/>
-    </g>
-    <g>
-      <path d="M587.56,327.69h-1.27l-1-2.75h-4.16l-1,2.75h-1.28l3.76-9.8h1.19Zm-2.69-3.78-1.53-4.18a4,4,0,0,1-.15-.65h0a4.1,4.1,0,0,1-.16.65l-1.52,4.18Z" fill="#2f2f2f"/>
-      <path d="M590,326.68h0v4.23h-1.12V320.69H590v1.23h0a2.66,2.66,0,0,1,2.42-1.4,2.57,2.57,0,0,1,2.11.94,3.88,3.88,0,0,1,.76,2.52,4.35,4.35,0,0,1-.85,2.82,2.86,2.86,0,0,1-2.34,1.05A2.34,2.34,0,0,1,590,326.68Zm0-2.83v1a2.05,2.05,0,0,0,.57,1.47,1.84,1.84,0,0,0,1.43.61,1.89,1.89,0,0,0,1.6-.78,3.61,3.61,0,0,0,.57-2.17,2.81,2.81,0,0,0-.54-1.83,1.78,1.78,0,0,0-1.46-.66,2,2,0,0,0-1.57.68A2.47,2.47,0,0,0,590,323.85Z" fill="#2f2f2f"/>
-      <path d="M598.14,326.68h0v4.23H597V320.69h1.12v1.23h0a2.66,2.66,0,0,1,2.42-1.4,2.59,2.59,0,0,1,2.11.94,3.88,3.88,0,0,1,.76,2.52,4.35,4.35,0,0,1-.86,2.82,2.82,2.82,0,0,1-2.33,1.05A2.34,2.34,0,0,1,598.14,326.68Zm0-2.83v1a2.09,2.09,0,0,0,.56,1.47,2,2,0,0,0,3-.17,3.54,3.54,0,0,0,.58-2.17,2.81,2.81,0,0,0-.54-1.83,1.79,1.79,0,0,0-1.46-.66,2,2,0,0,0-1.57.68A2.47,2.47,0,0,0,598.11,323.85Z" fill="#2f2f2f"/>
-      <path d="M604.71,327.44v-1.21a3.32,3.32,0,0,0,2,.68c1,0,1.48-.33,1.48-1a.89.89,0,0,0-.12-.47,1.29,1.29,0,0,0-.35-.35,2.61,2.61,0,0,0-.5-.27l-.63-.25a7.11,7.11,0,0,1-.82-.37,2.17,2.17,0,0,1-.58-.42,1.6,1.6,0,0,1-.36-.54,1.86,1.86,0,0,1-.12-.7,1.66,1.66,0,0,1,.23-.87,1.93,1.93,0,0,1,.6-.64,2.94,2.94,0,0,1,.86-.39,4.07,4.07,0,0,1,1-.13,4,4,0,0,1,1.63.32V322a3.25,3.25,0,0,0-1.78-.5,2,2,0,0,0-.57.07,1.56,1.56,0,0,0-.43.2,1,1,0,0,0-.28.31.79.79,0,0,0-.1.4.92.92,0,0,0,.1.46,1.11,1.11,0,0,0,.29.33,2.79,2.79,0,0,0,.46.26l.63.25a8.19,8.19,0,0,1,.83.37,2.47,2.47,0,0,1,.63.42,1.72,1.72,0,0,1,.4.54,1.84,1.84,0,0,1,.14.74,1.77,1.77,0,0,1-.23.9,1.93,1.93,0,0,1-.61.63,2.79,2.79,0,0,1-.88.38,4.51,4.51,0,0,1-1,.12A4.06,4.06,0,0,1,604.71,327.44Z" fill="#2f2f2f"/>
-      <path d="M614.48,327.44v-1.21a3.34,3.34,0,0,0,2,.68c1,0,1.48-.33,1.48-1a.89.89,0,0,0-.13-.47,1.25,1.25,0,0,0-.34-.35,2.7,2.7,0,0,0-.51-.27l-.62-.25a7.11,7.11,0,0,1-.82-.37,2.4,2.4,0,0,1-.59-.42,1.73,1.73,0,0,1-.35-.54,1.86,1.86,0,0,1-.12-.7,1.66,1.66,0,0,1,.22-.87,1.93,1.93,0,0,1,.6-.64,3.06,3.06,0,0,1,.86-.39,4.15,4.15,0,0,1,1-.13,4,4,0,0,1,1.62.32V322a3.19,3.19,0,0,0-1.77-.5,2,2,0,0,0-.57.07,1.78,1.78,0,0,0-.44.2.88.88,0,0,0-.27.31.79.79,0,0,0-.1.4.92.92,0,0,0,.1.46,1,1,0,0,0,.29.33,2.43,2.43,0,0,0,.46.26l.62.25a8.42,8.42,0,0,1,.84.37,2.88,2.88,0,0,1,.63.42,1.9,1.9,0,0,1,.4.54,1.84,1.84,0,0,1,.14.74,1.77,1.77,0,0,1-.23.9,2,2,0,0,1-.62.63,2.61,2.61,0,0,1-.88.38,4.42,4.42,0,0,1-1,.12A4.1,4.1,0,0,1,614.48,327.44Z" fill="#2f2f2f"/>
-      <path d="M626.39,327.69h-1.12v-1.11h0a2.29,2.29,0,0,1-2.16,1.27c-1.66,0-2.5-1-2.5-3v-4.18h1.12v4c0,1.48.56,2.22,1.69,2.22a1.69,1.69,0,0,0,1.35-.61,2.32,2.32,0,0,0,.53-1.58v-4h1.12Z" fill="#2f2f2f"/>
-      <path d="M629.65,326.68h0v1H628.5V317.33h1.12v4.59h0a2.66,2.66,0,0,1,2.42-1.4,2.59,2.59,0,0,1,2.11.94,3.94,3.94,0,0,1,.76,2.52,4.35,4.35,0,0,1-.86,2.82,2.84,2.84,0,0,1-2.33,1.05A2.3,2.3,0,0,1,629.65,326.68Zm0-2.83v1a2.09,2.09,0,0,0,.56,1.47,2,2,0,0,0,3-.17,3.54,3.54,0,0,0,.58-2.17,2.81,2.81,0,0,0-.54-1.83,1.79,1.79,0,0,0-1.46-.66,2,2,0,0,0-1.57.68A2.47,2.47,0,0,0,629.62,323.85Z" fill="#2f2f2f"/>
-      <path d="M642.47,327.69h-1.13v-4c0-1.49-.54-2.23-1.62-2.23a1.76,1.76,0,0,0-1.39.63,2.32,2.32,0,0,0-.55,1.6v4h-1.12v-7h1.12v1.16h0a2.55,2.55,0,0,1,2.3-1.33,2.14,2.14,0,0,1,1.76.75,3.33,3.33,0,0,1,.61,2.14Z" fill="#2f2f2f"/>
-      <path d="M650.17,324.47h-4.94a2.56,2.56,0,0,0,.63,1.8,2.14,2.14,0,0,0,1.65.64,3.42,3.42,0,0,0,2.17-.78v1.05a4,4,0,0,1-2.44.67,3,3,0,0,1-2.33-1,3.93,3.93,0,0,1-.85-2.68,3.84,3.84,0,0,1,.93-2.67,3,3,0,0,1,2.3-1,2.64,2.64,0,0,1,2.13.89,3.74,3.74,0,0,1,.75,2.47Zm-1.15-1a2.24,2.24,0,0,0-.47-1.51,1.59,1.59,0,0,0-1.28-.54,1.84,1.84,0,0,0-1.35.56,2.61,2.61,0,0,0-.68,1.49Z" fill="#2f2f2f"/>
-      <path d="M655.09,327.62a2.09,2.09,0,0,1-1,.22c-1.23,0-1.84-.68-1.84-2v-4.14H651v-1h1.2V319l1.12-.36v2.07h1.76v1h-1.76v3.94a1.61,1.61,0,0,0,.24,1,.92.92,0,0,0,.79.31,1.14,1.14,0,0,0,.73-.24Z" fill="#2f2f2f"/>
-    </g>
-    <g>
-      <path d="M889.05,329.79V320h2.71q5.18,0,5.18,4.77a4.81,4.81,0,0,1-1.44,3.65,5.33,5.33,0,0,1-3.85,1.38ZM890.2,321v7.72h1.46a4.12,4.12,0,0,0,3-1,3.87,3.87,0,0,0,1.07-2.93q0-3.77-4-3.76Z" fill="#2f2f2f"/>
-      <path d="M903.57,329.79h-1.12V328.7h0a2.35,2.35,0,0,1-2.15,1.25,2.29,2.29,0,0,1-1.64-.55,1.94,1.94,0,0,1-.59-1.47q0-2,2.31-2.28l2.1-.3c0-1.19-.48-1.78-1.44-1.78a3.47,3.47,0,0,0-2.29.86v-1.15a4.32,4.32,0,0,1,2.38-.66c1.65,0,2.47.87,2.47,2.62Zm-1.12-3.54-1.69.23a2.67,2.67,0,0,0-1.18.39,1.11,1.11,0,0,0-.39,1,1.05,1.05,0,0,0,.36.83,1.42,1.42,0,0,0,1,.33,1.79,1.79,0,0,0,1.37-.59,2,2,0,0,0,.55-1.47Z" fill="#2f2f2f"/>
-      <path d="M908.83,329.72a2.13,2.13,0,0,1-1.05.22c-1.23,0-1.84-.68-1.84-2.05v-4.14h-1.2v-1h1.2v-1.71l1.12-.36v2.07h1.77v1h-1.77v3.94a1.67,1.67,0,0,0,.24,1,1,1,0,0,0,.8.3,1.16,1.16,0,0,0,.73-.24Z" fill="#2f2f2f"/>
-      <path d="M915.44,329.79h-1.12V328.7h0a2.37,2.37,0,0,1-2.16,1.25,2.28,2.28,0,0,1-1.63-.55,1.91,1.91,0,0,1-.6-1.47q0-2,2.31-2.28l2.1-.3c0-1.19-.48-1.78-1.44-1.78a3.47,3.47,0,0,0-2.28.86v-1.15a4.32,4.32,0,0,1,2.38-.66c1.64,0,2.46.87,2.46,2.62Zm-1.12-3.54-1.69.23a2.63,2.63,0,0,0-1.17.39,1.12,1.12,0,0,0-.4,1,1,1,0,0,0,.37.83,1.39,1.39,0,0,0,1,.33,1.8,1.8,0,0,0,1.38-.59,2.08,2.08,0,0,0,.54-1.47Z" fill="#2f2f2f"/>
-      <path d="M921.08,329.39V328a2.59,2.59,0,0,0,.56.37,4.37,4.37,0,0,0,.68.27,4.58,4.58,0,0,0,.73.18,4.06,4.06,0,0,0,.67.06,2.65,2.65,0,0,0,1.58-.39,1.32,1.32,0,0,0,.52-1.13,1.36,1.36,0,0,0-.17-.69,2,2,0,0,0-.48-.54,5.42,5.42,0,0,0-.73-.47l-.91-.46c-.34-.18-.66-.35-1-.53a4.23,4.23,0,0,1-.77-.59,2.29,2.29,0,0,1-.51-.73,2.18,2.18,0,0,1-.19-.95,2.33,2.33,0,0,1,.29-1.17,2.59,2.59,0,0,1,.77-.81,3.35,3.35,0,0,1,1.09-.48,5.85,5.85,0,0,1,3.36.19v1.29a3.8,3.8,0,0,0-2.22-.6,3.84,3.84,0,0,0-.76.08,2.08,2.08,0,0,0-.67.26,1.44,1.44,0,0,0-.47.45,1.19,1.19,0,0,0-.19.69,1.48,1.48,0,0,0,.14.65,1.59,1.59,0,0,0,.41.5,4.57,4.57,0,0,0,.67.43l.91.47a9.37,9.37,0,0,1,1,.55,4.21,4.21,0,0,1,.83.63,2.8,2.8,0,0,1,.57.77,2.19,2.19,0,0,1,.2,1,2.43,2.43,0,0,1-.28,1.23,2.24,2.24,0,0,1-.77.82,3.24,3.24,0,0,1-1.11.45,5.63,5.63,0,0,1-1.32.14,4.45,4.45,0,0,1-.58,0c-.22,0-.46-.06-.69-.1a6.11,6.11,0,0,1-.68-.18A2,2,0,0,1,921.08,329.39Z" fill="#2f2f2f"/>
-      <path d="M934.41,326.57h-4.95a2.61,2.61,0,0,0,.63,1.8,2.16,2.16,0,0,0,1.66.64,3.42,3.42,0,0,0,2.17-.78v1a4.05,4.05,0,0,1-2.44.67,3,3,0,0,1-2.33-.95,3.88,3.88,0,0,1-.85-2.68,3.84,3.84,0,0,1,.93-2.67,3,3,0,0,1,2.3-1,2.63,2.63,0,0,1,2.12.89,3.74,3.74,0,0,1,.76,2.47Zm-1.15-.95a2.29,2.29,0,0,0-.47-1.51,1.6,1.6,0,0,0-1.28-.54,1.81,1.81,0,0,0-1.35.57,2.49,2.49,0,0,0-.68,1.48Z" fill="#2f2f2f"/>
-      <path d="M939.74,323.92a1.39,1.39,0,0,0-.85-.22,1.42,1.42,0,0,0-1.2.67,3.17,3.17,0,0,0-.48,1.85v3.57h-1.12v-7h1.12v1.44h0a2.46,2.46,0,0,1,.73-1.15,1.64,1.64,0,0,1,1.1-.41,2,2,0,0,1,.67.09Z" fill="#2f2f2f"/>
-      <path d="M947,322.79l-2.79,7h-1.1l-2.65-7h1.23l1.78,5.08a4.6,4.6,0,0,1,.24,1h0a4.92,4.92,0,0,1,.22-1l1.86-5.11Z" fill="#2f2f2f"/>
-      <path d="M948.83,321a.77.77,0,0,1-.52-.2.7.7,0,0,1-.21-.52.7.7,0,0,1,.73-.73.71.71,0,0,1,.52.2.73.73,0,0,1,.22.53.7.7,0,0,1-.22.51A.72.72,0,0,1,948.83,321Zm.55,8.78h-1.13v-7h1.13Z" fill="#2f2f2f"/>
-      <path d="M956.29,329.47a3.7,3.7,0,0,1-1.92.48,3.16,3.16,0,0,1-2.41-1,3.5,3.5,0,0,1-.92-2.53,3.89,3.89,0,0,1,1-2.78,3.46,3.46,0,0,1,2.64-1.05,3.66,3.66,0,0,1,1.63.35v1.15a2.83,2.83,0,0,0-1.67-.55,2.24,2.24,0,0,0-1.76.77,2.89,2.89,0,0,0-.68,2,2.79,2.79,0,0,0,.64,1.94,2.24,2.24,0,0,0,1.73.71,2.81,2.81,0,0,0,1.73-.61Z" fill="#2f2f2f"/>
-      <path d="M963.46,326.57h-5a2.61,2.61,0,0,0,.63,1.8,2.18,2.18,0,0,0,1.66.64,3.42,3.42,0,0,0,2.17-.78v1a4,4,0,0,1-2.44.67,3,3,0,0,1-2.33-.95,3.88,3.88,0,0,1-.85-2.68,3.84,3.84,0,0,1,.93-2.67,3,3,0,0,1,2.3-1,2.67,2.67,0,0,1,2.13.89,3.74,3.74,0,0,1,.75,2.47Zm-1.15-.95a2.29,2.29,0,0,0-.47-1.51,1.59,1.59,0,0,0-1.28-.54,1.81,1.81,0,0,0-1.35.57,2.55,2.55,0,0,0-.68,1.48Z" fill="#2f2f2f"/>
-      <path d="M964.7,329.54v-1.21a3.32,3.32,0,0,0,2,.68c1,0,1.47-.33,1.47-1a.9.9,0,0,0-.12-.48,1.29,1.29,0,0,0-.35-.35,2.61,2.61,0,0,0-.5-.27l-.63-.24a7.83,7.83,0,0,1-.81-.38,2.22,2.22,0,0,1-.59-.42,1.6,1.6,0,0,1-.36-.54,1.86,1.86,0,0,1-.12-.7,1.66,1.66,0,0,1,.23-.87,1.93,1.93,0,0,1,.6-.64,2.94,2.94,0,0,1,.86-.39,4.07,4.07,0,0,1,1-.13,4,4,0,0,1,1.63.32v1.13a3.25,3.25,0,0,0-1.78-.5,2,2,0,0,0-.57.07,1.42,1.42,0,0,0-.43.2,1,1,0,0,0-.28.31.79.79,0,0,0-.1.4.92.92,0,0,0,.1.46,1.11,1.11,0,0,0,.29.33,2.54,2.54,0,0,0,.47.26l.62.25a7.3,7.3,0,0,1,.83.37,2.47,2.47,0,0,1,.63.42,1.72,1.72,0,0,1,.4.54,1.84,1.84,0,0,1,.14.74,1.77,1.77,0,0,1-.23.9,2,2,0,0,1-.61.63,2.79,2.79,0,0,1-.88.38,4.44,4.44,0,0,1-1,.12A4.06,4.06,0,0,1,964.7,329.54Z" fill="#2f2f2f"/>
-      <path d="M974.47,329.54v-1.21a3.34,3.34,0,0,0,2,.68c1,0,1.48-.33,1.48-1a.82.82,0,0,0-.13-.48,1.25,1.25,0,0,0-.34-.35,2.43,2.43,0,0,0-.51-.27l-.62-.24c-.31-.13-.58-.25-.82-.38a2.4,2.4,0,0,1-.59-.42,1.73,1.73,0,0,1-.35-.54,1.86,1.86,0,0,1-.12-.7,1.66,1.66,0,0,1,.22-.87,1.93,1.93,0,0,1,.6-.64,3.06,3.06,0,0,1,.86-.39,4.15,4.15,0,0,1,1-.13,4.05,4.05,0,0,1,1.63.32v1.13a3.25,3.25,0,0,0-1.78-.5,2,2,0,0,0-.57.07,1.32,1.32,0,0,0-.43.2.82.82,0,0,0-.28.31.79.79,0,0,0-.1.4.92.92,0,0,0,.1.46,1,1,0,0,0,.29.33,2.43,2.43,0,0,0,.46.26l.62.25a8.42,8.42,0,0,1,.84.37,2.88,2.88,0,0,1,.63.42,1.9,1.9,0,0,1,.4.54,1.84,1.84,0,0,1,.14.74,1.77,1.77,0,0,1-.23.9,2.15,2.15,0,0,1-.61.63,2.75,2.75,0,0,1-.89.38,4.42,4.42,0,0,1-1,.12A4.1,4.1,0,0,1,974.47,329.54Z" fill="#2f2f2f"/>
-      <path d="M986.38,329.79h-1.12v-1.11h0a2.29,2.29,0,0,1-2.16,1.27c-1.66,0-2.5-1-2.5-3v-4.18h1.12v4c0,1.48.56,2.22,1.69,2.22a1.69,1.69,0,0,0,1.35-.61,2.32,2.32,0,0,0,.53-1.58v-4h1.12Z" fill="#2f2f2f"/>
-      <path d="M989.64,328.78h0v1h-1.12V319.43h1.12V324h0a2.66,2.66,0,0,1,2.42-1.4,2.59,2.59,0,0,1,2.11.94,3.88,3.88,0,0,1,.76,2.52,4.37,4.37,0,0,1-.86,2.82,2.82,2.82,0,0,1-2.33,1.05A2.3,2.3,0,0,1,989.64,328.78Zm0-2.83v1a2.05,2.05,0,0,0,.57,1.47,2,2,0,0,0,3-.17,3.54,3.54,0,0,0,.58-2.17,2.81,2.81,0,0,0-.54-1.83,1.79,1.79,0,0,0-1.46-.66,2,2,0,0,0-1.57.68A2.47,2.47,0,0,0,989.61,326Z" fill="#2f2f2f"/>
-      <path d="M1002.46,329.79h-1.12v-4c0-1.49-.55-2.23-1.63-2.23a1.76,1.76,0,0,0-1.39.63,2.32,2.32,0,0,0-.55,1.6v4h-1.12v-7h1.12V324h0a2.52,2.52,0,0,1,2.29-1.33,2.14,2.14,0,0,1,1.76.75,3.33,3.33,0,0,1,.61,2.14Z" fill="#2f2f2f"/>
-      <path d="M1010.16,326.57h-4.94a2.61,2.61,0,0,0,.63,1.8,2.14,2.14,0,0,0,1.65.64,3.42,3.42,0,0,0,2.17-.78v1a4,4,0,0,1-2.44.67,3,3,0,0,1-2.33-.95,3.93,3.93,0,0,1-.85-2.68,3.84,3.84,0,0,1,.93-2.67,3,3,0,0,1,2.3-1,2.64,2.64,0,0,1,2.13.89,3.74,3.74,0,0,1,.75,2.47Zm-1.15-.95a2.24,2.24,0,0,0-.47-1.51,1.59,1.59,0,0,0-1.28-.54,1.81,1.81,0,0,0-1.35.57,2.62,2.62,0,0,0-.68,1.48Z" fill="#2f2f2f"/>
-      <path d="M1015.08,329.72a2.09,2.09,0,0,1-1,.22c-1.23,0-1.84-.68-1.84-2.05v-4.14H1011v-1h1.2v-1.71l1.12-.36v2.07h1.76v1h-1.76v3.94a1.67,1.67,0,0,0,.24,1,1,1,0,0,0,.79.3,1.14,1.14,0,0,0,.73-.24Z" fill="#2f2f2f"/>
-    </g>
-    <g>
-      <path d="M911.3,401.31v-9.8H914q5.19,0,5.19,4.77a4.81,4.81,0,0,1-1.44,3.65,5.35,5.35,0,0,1-3.86,1.38Zm1.15-8.76v7.72h1.46a4.16,4.16,0,0,0,3-1,3.87,3.87,0,0,0,1.07-2.93q0-3.76-4-3.76Z" fill="#2f2f2f"/>
-      <path d="M925.82,401.31H924.7v-1.09h0a2.36,2.36,0,0,1-2.15,1.25,2.29,2.29,0,0,1-1.64-.55,1.9,1.9,0,0,1-.59-1.47q0-2,2.31-2.28l2.1-.3c0-1.19-.48-1.78-1.45-1.78A3.47,3.47,0,0,0,921,396V394.8a4.32,4.32,0,0,1,2.38-.65c1.64,0,2.47.87,2.47,2.61Zm-1.12-3.54L923,398a2.67,2.67,0,0,0-1.18.39,1.11,1.11,0,0,0-.39,1,1.05,1.05,0,0,0,.36.83,1.42,1.42,0,0,0,1,.33,1.82,1.82,0,0,0,1.37-.58,2.12,2.12,0,0,0,.55-1.48Z" fill="#2f2f2f"/>
-      <path d="M931.08,401.24a2.15,2.15,0,0,1-1.05.22c-1.23,0-1.84-.68-1.84-2v-4.14H927v-1h1.2V392.6l1.12-.36v2.07h1.77v1h-1.77v3.94a1.67,1.67,0,0,0,.24,1,1,1,0,0,0,.79.3,1.17,1.17,0,0,0,.74-.24Z" fill="#2f2f2f"/>
-      <path d="M937.69,401.31h-1.12v-1.09h0a2.34,2.34,0,0,1-2.15,1.25,2.31,2.31,0,0,1-1.64-.55,1.94,1.94,0,0,1-.59-1.47q0-2,2.31-2.28l2.1-.3c0-1.19-.48-1.78-1.44-1.78a3.45,3.45,0,0,0-2.28.86V394.8a4.28,4.28,0,0,1,2.37-.65c1.65,0,2.47.87,2.47,2.61Zm-1.12-3.54-1.69.23a2.58,2.58,0,0,0-1.17.39,1.09,1.09,0,0,0-.4,1,1,1,0,0,0,.37.83,1.39,1.39,0,0,0,1,.33A1.83,1.83,0,0,0,936,400a2.11,2.11,0,0,0,.54-1.48Z" fill="#2f2f2f"/>
-      <path d="M901,417.86v-1.21a3.32,3.32,0,0,0,2,.68c1,0,1.48-.33,1.48-1a.9.9,0,0,0-.12-.48,1.14,1.14,0,0,0-.35-.34,2.17,2.17,0,0,0-.5-.28l-.63-.24a7.83,7.83,0,0,1-.81-.38,2.07,2.07,0,0,1-.59-.42,1.6,1.6,0,0,1-.36-.54,1.86,1.86,0,0,1-.12-.7,1.66,1.66,0,0,1,.23-.87,1.93,1.93,0,0,1,.6-.64,2.68,2.68,0,0,1,.86-.38,3.64,3.64,0,0,1,1-.13,4,4,0,0,1,1.63.31v1.13a3.25,3.25,0,0,0-1.78-.5,2,2,0,0,0-.57.07,1.71,1.71,0,0,0-.43.2,1,1,0,0,0-.28.31.79.79,0,0,0-.1.4.92.92,0,0,0,.1.46,1.11,1.11,0,0,0,.29.33,2.79,2.79,0,0,0,.46.26l.63.25a8.19,8.19,0,0,1,.83.37,2.47,2.47,0,0,1,.63.42,1.72,1.72,0,0,1,.4.54,1.84,1.84,0,0,1,.14.74,1.77,1.77,0,0,1-.23.9,1.93,1.93,0,0,1-.61.63,2.79,2.79,0,0,1-.88.38,4.44,4.44,0,0,1-1,.12A4.06,4.06,0,0,1,901,417.86Z" fill="#2f2f2f"/>
-      <path d="M912.91,414.89H908a2.61,2.61,0,0,0,.63,1.8,2.14,2.14,0,0,0,1.65.64,3.45,3.45,0,0,0,2.18-.78v1.05a4.05,4.05,0,0,1-2.44.67,3,3,0,0,1-2.33-.95,3.88,3.88,0,0,1-.85-2.68,3.84,3.84,0,0,1,.93-2.67,3,3,0,0,1,2.3-1,2.63,2.63,0,0,1,2.12.88,3.74,3.74,0,0,1,.75,2.47Zm-1.15-.95a2.29,2.29,0,0,0-.46-1.51,1.61,1.61,0,0,0-1.29-.54,1.81,1.81,0,0,0-1.34.57,2.56,2.56,0,0,0-.69,1.48Z" fill="#2f2f2f"/>
-      <path d="M918.25,412.24a1.39,1.39,0,0,0-.85-.22,1.41,1.41,0,0,0-1.2.68,3.12,3.12,0,0,0-.48,1.84v3.57H914.6v-7h1.12v1.44h0a2.38,2.38,0,0,1,.73-1.15,1.62,1.62,0,0,1,1.1-.41,2,2,0,0,1,.67.09Z" fill="#2f2f2f"/>
-      <path d="M925.52,411.11l-2.79,7h-1.1l-2.65-7h1.23L922,416.2a4.39,4.39,0,0,1,.24,1h0a4.28,4.28,0,0,1,.22-.95l1.86-5.11Z" fill="#2f2f2f"/>
-      <path d="M927.33,409.33a.73.73,0,0,1-.51-.2.7.7,0,0,1-.21-.52.7.7,0,0,1,.72-.73.78.78,0,0,1,.53.2.72.72,0,0,1,.21.53.69.69,0,0,1-.21.51A.74.74,0,0,1,927.33,409.33Zm.55,8.78h-1.12v-7h1.12Z" fill="#2f2f2f"/>
-      <path d="M934.79,417.79a3.64,3.64,0,0,1-1.91.48,3.18,3.18,0,0,1-2.42-1,3.55,3.55,0,0,1-.92-2.53,3.89,3.89,0,0,1,1-2.78,3.49,3.49,0,0,1,2.65-1,3.65,3.65,0,0,1,1.63.34v1.15a2.83,2.83,0,0,0-1.67-.55,2.23,2.23,0,0,0-1.76.77,2.9,2.9,0,0,0-.69,2,2.79,2.79,0,0,0,.65,1.94,2.24,2.24,0,0,0,1.73.71,2.76,2.76,0,0,0,1.72-.61Z" fill="#2f2f2f"/>
-      <path d="M942,414.89H937a2.61,2.61,0,0,0,.63,1.8,2.14,2.14,0,0,0,1.65.64,3.45,3.45,0,0,0,2.18-.78v1.05a4.05,4.05,0,0,1-2.44.67,3,3,0,0,1-2.33-.95,3.88,3.88,0,0,1-.85-2.68,3.84,3.84,0,0,1,.93-2.67,3,3,0,0,1,2.3-1,2.63,2.63,0,0,1,2.12.88,3.74,3.74,0,0,1,.75,2.47Zm-1.14-.95a2.35,2.35,0,0,0-.47-1.51,1.6,1.6,0,0,0-1.28-.54,1.81,1.81,0,0,0-1.35.57,2.49,2.49,0,0,0-.68,1.48Z" fill="#2f2f2f"/>
-      <path d="M943.21,417.86v-1.21a3.32,3.32,0,0,0,2,.68c1,0,1.48-.33,1.48-1a.82.82,0,0,0-.13-.48,1.1,1.1,0,0,0-.34-.34,2.05,2.05,0,0,0-.51-.28l-.62-.24c-.31-.13-.58-.25-.82-.38a2.4,2.4,0,0,1-.59-.42,1.73,1.73,0,0,1-.35-.54,1.86,1.86,0,0,1-.12-.7,1.66,1.66,0,0,1,.22-.87,2,2,0,0,1,.61-.64,2.63,2.63,0,0,1,.85-.38,3.71,3.71,0,0,1,1-.13,4,4,0,0,1,1.63.31v1.13a3.25,3.25,0,0,0-1.78-.5,2,2,0,0,0-.57.07,1.56,1.56,0,0,0-.43.2.91.91,0,0,0-.28.31.79.79,0,0,0-.1.4.92.92,0,0,0,.1.46,1,1,0,0,0,.29.33,2.43,2.43,0,0,0,.46.26l.62.25a8.42,8.42,0,0,1,.84.37,2.88,2.88,0,0,1,.63.42,1.9,1.9,0,0,1,.4.54,1.84,1.84,0,0,1,.14.74,1.77,1.77,0,0,1-.23.9,1.93,1.93,0,0,1-.61.63,2.75,2.75,0,0,1-.89.38,4.42,4.42,0,0,1-1,.12A4,4,0,0,1,943.21,417.86Z" fill="#2f2f2f"/>
-    </g>
-    <g>
-      <path d="M1018.12,361.71h-1.28l-1-2.75h-4.16l-1,2.75h-1.28l3.76-9.8h1.19Zm-2.69-3.78-1.54-4.18a3.75,3.75,0,0,1-.15-.65h0a3.32,3.32,0,0,1-.15.65l-1.53,4.18Z" fill="#2f2f2f"/>
-      <path d="M1024.73,355l-4.14,5.72h4.1v1h-5.75v-.35l4.14-5.69h-3.75v-1h5.4Z" fill="#2f2f2f"/>
-      <path d="M1031.82,361.71h-1.12V360.6h0a2.31,2.31,0,0,1-2.16,1.27c-1.67,0-2.51-1-2.51-3v-4.18h1.12v4c0,1.48.56,2.22,1.69,2.22a1.71,1.71,0,0,0,1.35-.6,2.32,2.32,0,0,0,.53-1.59v-4h1.12Z" fill="#2f2f2f"/>
-      <path d="M1037.58,355.84a1.37,1.37,0,0,0-.85-.22,1.45,1.45,0,0,0-1.2.67,3.17,3.17,0,0,0-.48,1.85v3.57h-1.12v-7h1.12v1.44h0a2.46,2.46,0,0,1,.73-1.15,1.65,1.65,0,0,1,1.1-.41,1.92,1.92,0,0,1,.67.09Z" fill="#2f2f2f"/>
-      <path d="M1044.42,358.49h-4.94a2.61,2.61,0,0,0,.63,1.8,2.15,2.15,0,0,0,1.66.64,3.44,3.44,0,0,0,2.17-.78v1.05a4.05,4.05,0,0,1-2.44.67,2.93,2.93,0,0,1-2.33-.95,3.88,3.88,0,0,1-.85-2.68,3.84,3.84,0,0,1,.93-2.67,3,3,0,0,1,2.3-1,2.63,2.63,0,0,1,2.12.89,3.74,3.74,0,0,1,.75,2.47Zm-1.14-.95a2.29,2.29,0,0,0-.47-1.51,1.6,1.6,0,0,0-1.28-.54,1.81,1.81,0,0,0-1.35.57,2.49,2.49,0,0,0-.68,1.48Z" fill="#2f2f2f"/>
-      <path d="M1017.2,378.1a5.79,5.79,0,0,1-2.71.57,4.4,4.4,0,0,1-3.35-1.34,5,5,0,0,1-1.25-3.54,5.22,5.22,0,0,1,1.41-3.8,4.82,4.82,0,0,1,3.59-1.45,5.72,5.72,0,0,1,2.31.41v1.22a4.71,4.71,0,0,0-2.32-.59,3.57,3.57,0,0,0-2.74,1.13,4.25,4.25,0,0,0-1,3,4.07,4.07,0,0,0,1,2.86,3.32,3.32,0,0,0,2.57,1.06,4.81,4.81,0,0,0,2.56-.66Z" fill="#2f2f2f"/>
-      <path d="M1021.75,378.67a3.24,3.24,0,0,1-2.48-1,3.62,3.62,0,0,1-.93-2.6,3.78,3.78,0,0,1,1-2.75,3.47,3.47,0,0,1,2.6-1,3.16,3.16,0,0,1,2.45,1,3.84,3.84,0,0,1,.88,2.67,3.75,3.75,0,0,1-1,2.68A3.29,3.29,0,0,1,1021.75,378.67Zm.08-6.38a2.13,2.13,0,0,0-1.71.73,3,3,0,0,0-.63,2,2.87,2.87,0,0,0,.64,2,2.15,2.15,0,0,0,1.7.72,2.07,2.07,0,0,0,1.67-.7,3.74,3.74,0,0,0,0-4A2,2,0,0,0,1021.83,372.29Z" fill="#2f2f2f"/>
-      <path d="M1026.5,378.26v-1.21a3.32,3.32,0,0,0,2,.68q1.47,0,1.47-1a.89.89,0,0,0-.12-.47,1.6,1.6,0,0,0-.34-.35,3,3,0,0,0-.51-.26c-.19-.08-.4-.17-.63-.25a7.83,7.83,0,0,1-.81-.38,2.22,2.22,0,0,1-.59-.42,1.6,1.6,0,0,1-.36-.54,1.86,1.86,0,0,1-.12-.7,1.66,1.66,0,0,1,.23-.87,1.93,1.93,0,0,1,.6-.64,2.94,2.94,0,0,1,.86-.39,4.07,4.07,0,0,1,1-.13,4,4,0,0,1,1.63.32v1.13a3.22,3.22,0,0,0-1.78-.5,1.91,1.91,0,0,0-.56.07,1.63,1.63,0,0,0-.44.2,1,1,0,0,0-.28.31.91.91,0,0,0-.1.4,1,1,0,0,0,.1.46,1.11,1.11,0,0,0,.29.33,2.92,2.92,0,0,0,.47.26l.62.25a7.3,7.3,0,0,1,.83.37,2.47,2.47,0,0,1,.63.42,1.58,1.58,0,0,1,.4.54,1.94,1.94,0,0,1-.09,1.64,1.84,1.84,0,0,1-.61.63,2.7,2.7,0,0,1-.88.38,4.44,4.44,0,0,1-1.05.12A4.06,4.06,0,0,1,1026.5,378.26Z" fill="#2f2f2f"/>
-      <path d="M1042.67,378.51h-1.12v-4a3.08,3.08,0,0,0-.36-1.68,1.37,1.37,0,0,0-1.21-.52,1.5,1.5,0,0,0-1.22.65,2.51,2.51,0,0,0-.5,1.58v4h-1.12v-4.16c0-1.37-.54-2.06-1.6-2.06a1.44,1.44,0,0,0-1.21.62,2.55,2.55,0,0,0-.48,1.61v4h-1.12v-7h1.12v1.11h0a2.37,2.37,0,0,1,2.17-1.28,2.07,2.07,0,0,1,1.25.4,2,2,0,0,1,.73,1.05,2.52,2.52,0,0,1,2.33-1.45c1.54,0,2.31,1,2.31,2.86Z" fill="#2f2f2f"/>
-      <path d="M1047.67,378.67a3.24,3.24,0,0,1-2.48-1,3.65,3.65,0,0,1-.92-2.6,3.77,3.77,0,0,1,1-2.75,3.49,3.49,0,0,1,2.61-1,3.14,3.14,0,0,1,2.44,1,3.79,3.79,0,0,1,.88,2.67,3.75,3.75,0,0,1-1,2.68A3.29,3.29,0,0,1,1047.67,378.67Zm.09-6.38a2.13,2.13,0,0,0-1.71.73,3,3,0,0,0-.63,2,2.87,2.87,0,0,0,.63,2,2.17,2.17,0,0,0,1.71.72,2.08,2.08,0,0,0,1.67-.7,3.79,3.79,0,0,0,0-4A2.06,2.06,0,0,0,1047.76,372.29Z" fill="#2f2f2f"/>
-      <path d="M1052.42,378.26v-1.21a3.34,3.34,0,0,0,2,.68c1,0,1.48-.33,1.48-1a.81.81,0,0,0-.13-.47,1.4,1.4,0,0,0-.34-.35,2.7,2.7,0,0,0-.51-.26l-.62-.25c-.31-.13-.58-.25-.82-.38a2.4,2.4,0,0,1-.59-.42,1.73,1.73,0,0,1-.35-.54,1.86,1.86,0,0,1-.12-.7,1.66,1.66,0,0,1,.22-.87,1.93,1.93,0,0,1,.6-.64,3.06,3.06,0,0,1,.86-.39,4.15,4.15,0,0,1,1-.13,4,4,0,0,1,1.62.32v1.13a3.19,3.19,0,0,0-1.77-.5,2,2,0,0,0-.57.07,1.56,1.56,0,0,0-.43.2.82.82,0,0,0-.28.31.79.79,0,0,0-.1.4.92.92,0,0,0,.1.46,1,1,0,0,0,.29.33,2.43,2.43,0,0,0,.46.26l.62.25a8.42,8.42,0,0,1,.84.37,2.88,2.88,0,0,1,.63.42,1.9,1.9,0,0,1,.4.54,1.84,1.84,0,0,1,.14.74,1.77,1.77,0,0,1-.23.9,2,2,0,0,1-.62.63,2.61,2.61,0,0,1-.88.38,4.42,4.42,0,0,1-1,.12A4.1,4.1,0,0,1,1052.42,378.26Z" fill="#2f2f2f"/>
-      <path d="M1062.77,378.51v-9.8h2.71q5.18,0,5.18,4.77a4.81,4.81,0,0,1-1.44,3.65,5.33,5.33,0,0,1-3.85,1.38Zm1.15-8.77v7.73h1.46a4.17,4.17,0,0,0,3-1,3.91,3.91,0,0,0,1.07-2.93q0-3.76-4-3.77Z" fill="#2f2f2f"/>
-      <path d="M1072.51,378.51v-9.8h2.79a3,3,0,0,1,2,.62,2,2,0,0,1,.74,1.62,2.35,2.35,0,0,1-1.69,2.32v0a2.49,2.49,0,0,1,1.58.75,2.29,2.29,0,0,1,.6,1.64,2.57,2.57,0,0,1-.9,2,3.36,3.36,0,0,1-2.28.78Zm1.15-8.77v3.17h1.18a2.24,2.24,0,0,0,1.48-.45,1.6,1.6,0,0,0,.54-1.29c0-.95-.63-1.43-1.88-1.43Zm0,4.2v3.53h1.56a2.34,2.34,0,0,0,1.57-.48,1.64,1.64,0,0,0,.56-1.31q0-1.74-2.37-1.74Z" fill="#2f2f2f"/>
-    </g>
-    <g>
-      <path d="M352.33,250a5.74,5.74,0,0,1-2.7.57,4.37,4.37,0,0,1-3.35-1.34,5,5,0,0,1-1.26-3.54,5.22,5.22,0,0,1,1.41-3.8,4.84,4.84,0,0,1,3.59-1.45,5.72,5.72,0,0,1,2.31.41v1.22a4.68,4.68,0,0,0-2.32-.59,3.57,3.57,0,0,0-2.74,1.13,4.25,4.25,0,0,0-1,3,4.07,4.07,0,0,0,1,2.86,3.34,3.34,0,0,0,2.58,1.06,4.79,4.79,0,0,0,2.55-.66Z" fill="#2f2f2f"/>
-      <path d="M356.88,250.55a3.24,3.24,0,0,1-2.48-1,3.65,3.65,0,0,1-.92-2.6,3.79,3.79,0,0,1,1-2.75,3.47,3.47,0,0,1,2.61-1,3.15,3.15,0,0,1,2.44,1,3.84,3.84,0,0,1,.88,2.67,3.75,3.75,0,0,1-.95,2.68A3.29,3.29,0,0,1,356.88,250.55Zm.08-6.38a2.13,2.13,0,0,0-1.71.73,3.08,3.08,0,0,0-.62,2,2.87,2.87,0,0,0,.63,2,2.15,2.15,0,0,0,1.7.72,2.05,2.05,0,0,0,1.67-.7,3.74,3.74,0,0,0,0-4A2,2,0,0,0,357,244.17Z" fill="#2f2f2f"/>
-      <path d="M365.73,244.52a1.34,1.34,0,0,0-.84-.22,1.41,1.41,0,0,0-1.2.68,3,3,0,0,0-.49,1.84v3.57h-1.12v-7h1.12v1.44h0a2.46,2.46,0,0,1,.73-1.15,1.65,1.65,0,0,1,1.1-.41,1.92,1.92,0,0,1,.67.09Z" fill="#2f2f2f"/>
-      <path d="M368.13,249.38h0v4.23H367V243.39h1.12v1.23h0a2.64,2.64,0,0,1,2.42-1.39,2.58,2.58,0,0,1,2.11.93,3.94,3.94,0,0,1,.76,2.52,4.35,4.35,0,0,1-.86,2.82,2.86,2.86,0,0,1-2.34,1.05A2.34,2.34,0,0,1,368.13,249.38Zm0-2.83v1a2.09,2.09,0,0,0,.56,1.47,1.87,1.87,0,0,0,1.43.61,1.89,1.89,0,0,0,1.6-.78,3.54,3.54,0,0,0,.58-2.17,2.81,2.81,0,0,0-.54-1.83,1.8,1.8,0,0,0-1.47-.66,2,2,0,0,0-1.57.68A2.51,2.51,0,0,0,368.1,246.55Z" fill="#2f2f2f"/>
-      <path d="M384.05,250.39h-1.12V249.3h0a2.34,2.34,0,0,1-2.15,1.25,2.31,2.31,0,0,1-1.64-.55,1.94,1.94,0,0,1-.59-1.47q0-2,2.31-2.28l2.1-.3c0-1.19-.48-1.78-1.44-1.78a3.47,3.47,0,0,0-2.28.86v-1.15a4.29,4.29,0,0,1,2.38-.65q2.46,0,2.46,2.61Zm-1.12-3.54-1.69.23a2.58,2.58,0,0,0-1.17.39,1.09,1.09,0,0,0-.4,1,1,1,0,0,0,.37.83,1.39,1.39,0,0,0,1,.33,1.83,1.83,0,0,0,1.38-.58,2.11,2.11,0,0,0,.54-1.48Z" fill="#2f2f2f"/>
-      <path d="M387.22,249.38h0v4.23h-1.13V243.39h1.13v1.23h0a2.65,2.65,0,0,1,2.42-1.39,2.59,2.59,0,0,1,2.12.93,3.94,3.94,0,0,1,.75,2.52,4.35,4.35,0,0,1-.85,2.82,2.86,2.86,0,0,1-2.34,1.05A2.35,2.35,0,0,1,387.22,249.38Zm0-2.83v1a2,2,0,0,0,.56,1.47,1.84,1.84,0,0,0,1.43.61,1.89,1.89,0,0,0,1.6-.78,3.61,3.61,0,0,0,.58-2.17,2.87,2.87,0,0,0-.54-1.83,1.8,1.8,0,0,0-1.47-.66,2,2,0,0,0-1.57.68A2.46,2.46,0,0,0,387.2,246.55Z" fill="#2f2f2f"/>
-      <path d="M395.38,249.38h0v4.23h-1.12V243.39h1.12v1.23h0a2.65,2.65,0,0,1,2.42-1.39,2.57,2.57,0,0,1,2.11.93,3.88,3.88,0,0,1,.76,2.52,4.41,4.41,0,0,1-.85,2.82,2.86,2.86,0,0,1-2.34,1.05A2.34,2.34,0,0,1,395.38,249.38Zm0-2.83v1a2.05,2.05,0,0,0,.57,1.47,2,2,0,0,0,3-.17,3.54,3.54,0,0,0,.58-2.17,2.81,2.81,0,0,0-.54-1.83,1.79,1.79,0,0,0-1.46-.66,2,2,0,0,0-1.57.68A2.47,2.47,0,0,0,395.35,246.55Z" fill="#2f2f2f"/>
-      <path d="M403.52,250.39H402.4V240h1.12Z" fill="#2f2f2f"/>
-      <path d="M406.21,241.61a.73.73,0,0,1-.51-.2.67.67,0,0,1-.22-.52.69.69,0,0,1,.22-.53.73.73,0,0,1,.51-.2.75.75,0,0,1,.52.2.73.73,0,0,1,.22.53.7.7,0,0,1-.22.51A.72.72,0,0,1,406.21,241.61Zm.55,8.78h-1.13v-7h1.13Z" fill="#2f2f2f"/>
-      <path d="M413.67,250.07a3.7,3.7,0,0,1-1.92.48,3.16,3.16,0,0,1-2.41-1,3.5,3.5,0,0,1-.92-2.53,3.89,3.89,0,0,1,1-2.78,3.49,3.49,0,0,1,2.64-1,3.65,3.65,0,0,1,1.63.34v1.15a2.81,2.81,0,0,0-1.67-.55,2.24,2.24,0,0,0-1.76.77,2.89,2.89,0,0,0-.68,2,2.79,2.79,0,0,0,.64,1.94,2.24,2.24,0,0,0,1.73.71,2.81,2.81,0,0,0,1.73-.61Z" fill="#2f2f2f"/>
-      <path d="M420.41,250.39h-1.12V249.3h0a2.35,2.35,0,0,1-2.15,1.25,2.31,2.31,0,0,1-1.64-.55,1.94,1.94,0,0,1-.59-1.47q0-2,2.31-2.28l2.1-.3c0-1.19-.48-1.78-1.44-1.78a3.47,3.47,0,0,0-2.29.86v-1.15a4.34,4.34,0,0,1,2.38-.65c1.65,0,2.47.87,2.47,2.61Zm-1.12-3.54-1.69.23a2.67,2.67,0,0,0-1.18.39,1.11,1.11,0,0,0-.39,1,1.05,1.05,0,0,0,.36.83,1.42,1.42,0,0,0,1,.33,1.86,1.86,0,0,0,1.38-.58,2.11,2.11,0,0,0,.54-1.48Z" fill="#2f2f2f"/>
-      <path d="M425.67,250.32a2.13,2.13,0,0,1-1.05.22c-1.22,0-1.84-.68-1.84-2v-4.14h-1.2v-1h1.2v-1.71l1.13-.36v2.07h1.76v1h-1.76v3.94a1.75,1.75,0,0,0,.23,1,1,1,0,0,0,.8.3,1.16,1.16,0,0,0,.73-.24Z" fill="#2f2f2f"/>
-      <path d="M427.62,241.61a.73.73,0,0,1-.51-.2.7.7,0,0,1-.21-.52.7.7,0,0,1,.72-.73.78.78,0,0,1,.53.2.72.72,0,0,1,.21.53.69.69,0,0,1-.21.51A.74.74,0,0,1,427.62,241.61Zm.55,8.78h-1.12v-7h1.12Z" fill="#2f2f2f"/>
-      <path d="M433.27,250.55a3.22,3.22,0,0,1-2.48-1,3.62,3.62,0,0,1-.93-2.6,3.75,3.75,0,0,1,1-2.75,3.46,3.46,0,0,1,2.6-1,3.13,3.13,0,0,1,2.44,1,3.79,3.79,0,0,1,.88,2.67,3.71,3.71,0,0,1-.95,2.68A3.27,3.27,0,0,1,433.27,250.55Zm.08-6.38a2.13,2.13,0,0,0-1.71.73,3,3,0,0,0-.63,2,2.82,2.82,0,0,0,.64,2,2.15,2.15,0,0,0,1.7.72,2.08,2.08,0,0,0,1.67-.7,3.79,3.79,0,0,0,0-4A2.06,2.06,0,0,0,433.35,244.17Z" fill="#2f2f2f"/>
-      <path d="M444.28,250.39h-1.12v-4c0-1.49-.54-2.23-1.63-2.23a1.77,1.77,0,0,0-1.39.63,2.32,2.32,0,0,0-.55,1.6v4h-1.12v-7h1.12v1.16h0a2.51,2.51,0,0,1,2.29-1.32,2.13,2.13,0,0,1,1.76.74,3.27,3.27,0,0,1,.61,2.14Z" fill="#2f2f2f"/>
-      <path d="M377.34,266.52a6.53,6.53,0,0,1-3.28.83,4.51,4.51,0,0,1-3.4-1.35,5,5,0,0,1-1.29-3.58,5.11,5.11,0,0,1,1.44-3.74,4.91,4.91,0,0,1,3.64-1.46,6.29,6.29,0,0,1,2.69.52V259a5.16,5.16,0,0,0-2.82-.75,3.53,3.53,0,0,0-2.7,1.14,4.74,4.74,0,0,0-.07,5.86,3.42,3.42,0,0,0,2.65,1.06,4,4,0,0,0,2-.46v-2.75H374v-1h3.3Z" fill="#2f2f2f"/>
-      <path d="M384.43,267.19H383.3v-1.1h0a2.36,2.36,0,0,1-2.16,1.26,2.28,2.28,0,0,1-1.63-.55,1.9,1.9,0,0,1-.59-1.47q0-2,2.31-2.28l2.09-.3c0-1.19-.48-1.78-1.44-1.78a3.42,3.42,0,0,0-2.28.86v-1.15A4.32,4.32,0,0,1,382,260c1.64,0,2.47.88,2.47,2.62Zm-1.13-3.54-1.68.23a2.63,2.63,0,0,0-1.18.39,1.12,1.12,0,0,0-.4,1,1.06,1.06,0,0,0,.37.83,1.39,1.39,0,0,0,1,.33,1.83,1.83,0,0,0,1.38-.58,2.12,2.12,0,0,0,.54-1.49Z" fill="#2f2f2f"/>
-      <path d="M389.68,267.12a2.09,2.09,0,0,1-1,.22c-1.23,0-1.84-.68-1.84-2v-4.14h-1.2v-1h1.2v-1.71l1.12-.36v2.07h1.76v1h-1.76v3.94a1.61,1.61,0,0,0,.24,1,.92.92,0,0,0,.79.31,1.13,1.13,0,0,0,.73-.24Z" fill="#2f2f2f"/>
-      <path d="M396.68,264h-4.95a2.61,2.61,0,0,0,.63,1.8,2.16,2.16,0,0,0,1.66.64,3.42,3.42,0,0,0,2.17-.78v1.05a4,4,0,0,1-2.44.67,3,3,0,0,1-2.33-1,3.93,3.93,0,0,1-.85-2.68,3.84,3.84,0,0,1,.93-2.67,3,3,0,0,1,2.3-1,2.62,2.62,0,0,1,2.12.89,3.69,3.69,0,0,1,.76,2.47Zm-1.15-1a2.29,2.29,0,0,0-.47-1.51,1.59,1.59,0,0,0-1.28-.54,1.81,1.81,0,0,0-1.35.57,2.55,2.55,0,0,0-.68,1.48Z" fill="#2f2f2f"/>
-      <path d="M407.15,260.19l-2.1,7h-1.16l-1.44-5a3,3,0,0,1-.11-.65h0a2.81,2.81,0,0,1-.14.63l-1.57,5h-1.12l-2.12-7h1.18l1.45,5.26a3.93,3.93,0,0,1,.09.63h.06a2.65,2.65,0,0,1,.12-.64l1.61-5.25h1l1.45,5.28a3.82,3.82,0,0,1,.1.62h.06a2.32,2.32,0,0,1,.11-.62l1.42-5.28Z" fill="#2f2f2f"/>
-      <path d="M413.33,267.19H412.2v-1.1h0a2.36,2.36,0,0,1-2.16,1.26,2.28,2.28,0,0,1-1.63-.55,1.9,1.9,0,0,1-.59-1.47q0-2,2.31-2.28l2.09-.3c0-1.19-.48-1.78-1.44-1.78a3.42,3.42,0,0,0-2.28.86v-1.15a4.32,4.32,0,0,1,2.38-.66c1.64,0,2.47.88,2.47,2.62Zm-1.13-3.54-1.68.23a2.63,2.63,0,0,0-1.18.39,1.12,1.12,0,0,0-.4,1,1.06,1.06,0,0,0,.37.83,1.39,1.39,0,0,0,1,.33,1.83,1.83,0,0,0,1.38-.58,2.12,2.12,0,0,0,.54-1.49Z" fill="#2f2f2f"/>
-      <path d="M420.84,260.19l-3.22,8.12c-.58,1.45-1.38,2.17-2.42,2.17a3,3,0,0,1-.73-.08v-1a2.1,2.1,0,0,0,.66.12,1.37,1.37,0,0,0,1.27-1l.56-1.33-2.73-7h1.24l1.89,5.39c0,.06.07.24.15.53h0c0-.11.07-.28.14-.52l2-5.4Z" fill="#2f2f2f"/>
-    </g>
-    <g>
-      <path d="M623.61,236.83h-1.28l-1-2.75h-4.16l-1,2.75h-1.28l3.76-9.8h1.19Zm-2.69-3.78-1.54-4.18a3.75,3.75,0,0,1-.15-.65h0a3,3,0,0,1-.15.65l-1.53,4.18Z" fill="#2f2f2f"/>
-      <path d="M630.22,230.15l-4.15,5.72h4.11v1h-5.75v-.35l4.14-5.69h-3.75v-1h5.4Z" fill="#2f2f2f"/>
-      <path d="M637.31,236.83h-1.12v-1.11h0A2.32,2.32,0,0,1,634,237c-1.67,0-2.51-1-2.51-3v-4.19h1.12v4c0,1.47.56,2.21,1.69,2.21a1.71,1.71,0,0,0,1.35-.6,2.29,2.29,0,0,0,.53-1.58v-4h1.12Z" fill="#2f2f2f"/>
-      <path d="M643.07,231a1.37,1.37,0,0,0-.85-.23,1.45,1.45,0,0,0-1.2.68,3.12,3.12,0,0,0-.48,1.84v3.57h-1.12v-7h1.12v1.44h0a2.46,2.46,0,0,1,.73-1.15,1.71,1.71,0,0,1,1.1-.41,1.92,1.92,0,0,1,.67.09Z" fill="#2f2f2f"/>
-      <path d="M649.91,233.61H645a2.66,2.66,0,0,0,.63,1.81,2.18,2.18,0,0,0,1.66.63,3.44,3.44,0,0,0,2.17-.78v1.06A4.12,4.12,0,0,1,647,237a2.94,2.94,0,0,1-2.33-1,3.87,3.87,0,0,1-.85-2.68,3.8,3.8,0,0,1,.93-2.66,2.94,2.94,0,0,1,2.3-1,2.6,2.6,0,0,1,2.12.89,3.69,3.69,0,0,1,.75,2.46Zm-1.14-1a2.37,2.37,0,0,0-.47-1.51,1.6,1.6,0,0,0-1.28-.54,1.81,1.81,0,0,0-1.35.57,2.52,2.52,0,0,0-.68,1.48Z" fill="#2f2f2f"/>
-      <path d="M596.22,253.63h-5.09v-9.8h1.15v8.76h3.94Z" fill="#2f2f2f"/>
-      <path d="M600.4,253.8a3.28,3.28,0,0,1-2.48-1,3.65,3.65,0,0,1-.92-2.61,3.79,3.79,0,0,1,1-2.75,3.46,3.46,0,0,1,2.6-1,3.16,3.16,0,0,1,2.45,1,3.85,3.85,0,0,1,.88,2.67,3.78,3.78,0,0,1-.95,2.69A3.33,3.33,0,0,1,600.4,253.8Zm.08-6.39a2.14,2.14,0,0,0-1.71.74,3,3,0,0,0-.63,2,2.85,2.85,0,0,0,.64,2,2.15,2.15,0,0,0,1.7.72,2,2,0,0,0,1.67-.7,3.06,3.06,0,0,0,.59-2,3.13,3.13,0,0,0-.59-2A2,2,0,0,0,600.48,247.41Z" fill="#2f2f2f"/>
-      <path d="M610.64,253.63h-1.13v-1.09h0a2.36,2.36,0,0,1-2.16,1.26,2.29,2.29,0,0,1-1.63-.56,1.9,1.9,0,0,1-.59-1.47q0-2,2.31-2.28l2.09-.29c0-1.19-.48-1.79-1.44-1.79a3.47,3.47,0,0,0-2.28.86v-1.15a4.4,4.4,0,0,1,2.38-.65c1.64,0,2.47.87,2.47,2.61Zm-1.13-3.54-1.68.23a2.9,2.9,0,0,0-1.18.39,1.12,1.12,0,0,0-.4,1,1.1,1.1,0,0,0,.37.84,1.44,1.44,0,0,0,1,.32,1.79,1.79,0,0,0,1.38-.58,2.09,2.09,0,0,0,.54-1.48Z" fill="#2f2f2f"/>
-      <path d="M618.7,253.63h-1.12v-1.19h0a2.61,2.61,0,0,1-2.41,1.36,2.64,2.64,0,0,1-2.11-.94,3.84,3.84,0,0,1-.79-2.56,4.18,4.18,0,0,1,.88-2.79,2.9,2.9,0,0,1,2.33-1,2.26,2.26,0,0,1,2.1,1.13h0v-4.33h1.12Zm-1.12-3.16v-1A2,2,0,0,0,617,248a1.89,1.89,0,0,0-1.42-.59,1.93,1.93,0,0,0-1.61.75,3.32,3.32,0,0,0-.59,2.08,3,3,0,0,0,.56,1.91,1.84,1.84,0,0,0,1.52.7,1.92,1.92,0,0,0,1.52-.67A2.53,2.53,0,0,0,617.58,250.47Z" fill="#2f2f2f"/>
-      <path d="M625,253.63v-9.8h2.79a3,3,0,0,1,2,.62,2,2,0,0,1,.75,1.62,2.38,2.38,0,0,1-.45,1.45,2.49,2.49,0,0,1-1.25.88v0a2.51,2.51,0,0,1,1.59.75,2.29,2.29,0,0,1,.6,1.65,2.57,2.57,0,0,1-.91,2,3.35,3.35,0,0,1-2.27.78Zm1.15-8.76V248h1.17a2.27,2.27,0,0,0,1.49-.45,1.58,1.58,0,0,0,.54-1.28c0-1-.63-1.43-1.88-1.43Zm0,4.2v3.52h1.56a2.36,2.36,0,0,0,1.57-.48,1.62,1.62,0,0,0,.55-1.31c0-1.16-.79-1.73-2.36-1.73Z" fill="#2f2f2f"/>
-      <path d="M637.8,253.63h-1.12v-1.09h0a2.54,2.54,0,0,1-3.79.7,1.94,1.94,0,0,1-.59-1.47q0-2,2.31-2.28l2.1-.29c0-1.19-.48-1.79-1.44-1.79a3.45,3.45,0,0,0-2.28.86v-1.15a4.38,4.38,0,0,1,2.38-.65q2.46,0,2.46,2.61Zm-1.12-3.54-1.69.23a2.85,2.85,0,0,0-1.17.39,1.09,1.09,0,0,0-.4,1,1.07,1.07,0,0,0,.37.84,1.44,1.44,0,0,0,1,.32,1.79,1.79,0,0,0,1.38-.58,2.09,2.09,0,0,0,.54-1.48Z" fill="#2f2f2f"/>
-      <path d="M640.94,253.63h-1.12V243.27h1.12Z" fill="#2f2f2f"/>
-      <path d="M648.1,253.63H647v-1.09h0a2.35,2.35,0,0,1-2.15,1.26,2.3,2.3,0,0,1-1.64-.56,1.9,1.9,0,0,1-.59-1.47q0-2,2.31-2.28l2.1-.29c0-1.19-.48-1.79-1.45-1.79a3.47,3.47,0,0,0-2.28.86v-1.15a4.4,4.4,0,0,1,2.38-.65c1.65,0,2.47.87,2.47,2.61ZM647,250.09l-1.69.23a3,3,0,0,0-1.18.39,1.11,1.11,0,0,0-.39,1,1.09,1.09,0,0,0,.36.84,1.46,1.46,0,0,0,1,.32,1.78,1.78,0,0,0,1.37-.58,2.06,2.06,0,0,0,.55-1.48Z" fill="#2f2f2f"/>
-      <path d="M655.93,253.63h-1.12v-4c0-1.49-.54-2.23-1.63-2.23a1.77,1.77,0,0,0-1.39.63,2.34,2.34,0,0,0-.55,1.6v4h-1.12v-7h1.12v1.16h0a2.52,2.52,0,0,1,2.29-1.32,2.12,2.12,0,0,1,1.76.74,3.27,3.27,0,0,1,.61,2.14Z" fill="#2f2f2f"/>
-      <path d="M662.78,253.31a3.7,3.7,0,0,1-1.92.49,3.16,3.16,0,0,1-2.41-1,3.54,3.54,0,0,1-.92-2.52,3.88,3.88,0,0,1,1-2.78,3.46,3.46,0,0,1,2.65-1.05,3.64,3.64,0,0,1,1.62.34V248a2.81,2.81,0,0,0-1.67-.55,2.27,2.27,0,0,0-1.76.77,3,3,0,0,0-.68,2,2.77,2.77,0,0,0,.64,1.94,2.21,2.21,0,0,0,1.74.71,2.78,2.78,0,0,0,1.72-.61Z" fill="#2f2f2f"/>
-      <path d="M670,250.41H665a2.6,2.6,0,0,0,.62,1.81,2.21,2.21,0,0,0,1.66.63,3.42,3.42,0,0,0,2.17-.78v1.06a4.1,4.1,0,0,1-2.44.67,3,3,0,0,1-2.33-1,3.92,3.92,0,0,1-.85-2.68,3.8,3.8,0,0,1,.93-2.66,3,3,0,0,1,2.3-1,2.61,2.61,0,0,1,2.13.89,3.69,3.69,0,0,1,.75,2.46Zm-1.15-.95a2.26,2.26,0,0,0-.47-1.51,1.59,1.59,0,0,0-1.28-.54,1.81,1.81,0,0,0-1.35.57,2.58,2.58,0,0,0-.68,1.48Z" fill="#2f2f2f"/>
-      <path d="M675.28,247.77a1.37,1.37,0,0,0-.85-.23,1.45,1.45,0,0,0-1.2.68,3.12,3.12,0,0,0-.48,1.84v3.57h-1.12v-7h1.12v1.44h0a2.46,2.46,0,0,1,.73-1.15,1.71,1.71,0,0,1,1.1-.41,1.92,1.92,0,0,1,.67.09Z" fill="#2f2f2f"/>
-    </g>
-    <g>
-      <path d="M665.75,23h-1.14V16.46c0-.52,0-1.16.1-1.91h0a7.17,7.17,0,0,1-.29.95L661,23h-.56l-3.35-7.48a6.47,6.47,0,0,1-.29-1h0q.06.58.06,1.92V23h-1.11v-9.8h1.52l3,6.84a8.09,8.09,0,0,1,.46,1.17h0c.19-.54.35-.94.47-1.2l3.07-6.81h1.43Z" fill="#2f2f2f"/>
-      <path d="M671.29,23.2a3.28,3.28,0,0,1-2.48-1,3.65,3.65,0,0,1-.92-2.61,3.79,3.79,0,0,1,1-2.75,3.46,3.46,0,0,1,2.6-1,3.16,3.16,0,0,1,2.45,1,3.85,3.85,0,0,1,.88,2.67,3.78,3.78,0,0,1-.95,2.69A3.33,3.33,0,0,1,671.29,23.2Zm.08-6.39a2.14,2.14,0,0,0-1.71.74,3,3,0,0,0-.63,2,2.85,2.85,0,0,0,.64,2,2.15,2.15,0,0,0,1.7.72,2,2,0,0,0,1.67-.7,3.06,3.06,0,0,0,.59-2,3.13,3.13,0,0,0-.59-2A2,2,0,0,0,671.37,16.81Z" fill="#2f2f2f"/>
-      <path d="M682.58,23h-1.12V19c0-1.49-.54-2.23-1.63-2.23a1.77,1.77,0,0,0-1.39.63,2.41,2.41,0,0,0-.55,1.6v4h-1.12V16h1.12v1.16h0a2.54,2.54,0,0,1,2.3-1.32,2.14,2.14,0,0,1,1.75.74,3.27,3.27,0,0,1,.61,2.14Z" fill="#2f2f2f"/>
-      <path d="M685.45,14.25a.72.72,0,0,1-.52-.2.75.75,0,0,1,0-1,.73.73,0,0,1,.52-.21A.72.72,0,0,1,686,13a.74.74,0,0,1,0,1A.72.72,0,0,1,685.45,14.25ZM686,23h-1.12V16H686Z" fill="#2f2f2f"/>
-      <path d="M691.72,23a2.09,2.09,0,0,1-1,.22c-1.23,0-1.84-.68-1.84-2.05V17h-1.21V16h1.21V14.32L690,14V16h1.76v1H690v3.94a1.65,1.65,0,0,0,.24,1,1,1,0,0,0,.79.3,1.2,1.2,0,0,0,.73-.23Z" fill="#2f2f2f"/>
-      <path d="M696.26,23.2a3.26,3.26,0,0,1-2.48-1,3.66,3.66,0,0,1-.93-2.61,3.79,3.79,0,0,1,1-2.75,3.46,3.46,0,0,1,2.6-1,3.16,3.16,0,0,1,2.45,1,3.85,3.85,0,0,1,.88,2.67,3.78,3.78,0,0,1-1,2.69A3.33,3.33,0,0,1,696.26,23.2Zm.08-6.39a2.14,2.14,0,0,0-1.71.74,3,3,0,0,0-.63,2,2.85,2.85,0,0,0,.64,2,2.15,2.15,0,0,0,1.7.72,2,2,0,0,0,1.67-.7,3.06,3.06,0,0,0,.59-2,3.13,3.13,0,0,0-.59-2A2,2,0,0,0,696.34,16.81Z" fill="#2f2f2f"/>
-      <path d="M705.39,17.17a1.39,1.39,0,0,0-.85-.23,1.43,1.43,0,0,0-1.2.68,3.12,3.12,0,0,0-.48,1.84V23h-1.12V16h1.12v1.44h0a2.46,2.46,0,0,1,.73-1.15,1.71,1.71,0,0,1,1.1-.41,1.92,1.92,0,0,1,.67.09Z" fill="#2f2f2f"/>
-      <path d="M707.49,14.25a.69.69,0,0,1-.51-.2.72.72,0,0,1,0-1,.69.69,0,0,1,.51-.21A.72.72,0,0,1,708,13a.71.71,0,0,1,0,1A.72.72,0,0,1,707.49,14.25ZM708,23h-1.13V16H708Z" fill="#2f2f2f"/>
-      <path d="M716.24,23h-1.12V19c0-1.49-.54-2.23-1.62-2.23a1.76,1.76,0,0,0-1.39.63,2.36,2.36,0,0,0-.56,1.6v4h-1.12V16h1.12v1.16h0a2.54,2.54,0,0,1,2.3-1.32,2.17,2.17,0,0,1,1.76.74,3.33,3.33,0,0,1,.6,2.14Z" fill="#2f2f2f"/>
-      <path d="M724.6,22.47q0,3.86-3.69,3.86a4.93,4.93,0,0,1-2.27-.5V24.71a4.64,4.64,0,0,0,2.25.66c1.73,0,2.59-.92,2.59-2.75v-.76h0a2.83,2.83,0,0,1-4.51.4,3.71,3.71,0,0,1-.79-2.5,4.37,4.37,0,0,1,.85-2.84,2.89,2.89,0,0,1,2.35-1.05,2.29,2.29,0,0,1,2.1,1.13h0V16h1.12Zm-1.12-2.6v-1a2,2,0,0,0-.57-1.42,1.83,1.83,0,0,0-1.4-.6,1.94,1.94,0,0,0-1.63.76,3.37,3.37,0,0,0-.59,2.11,2.88,2.88,0,0,0,.57,1.87,1.8,1.8,0,0,0,1.49.7,2,2,0,0,0,1.54-.67A2.5,2.5,0,0,0,723.48,19.87Z" fill="#2f2f2f"/>
-      <path d="M649,31.05a.72.72,0,0,1-.52-.2.75.75,0,0,1,0-1,.73.73,0,0,1,.52-.21.72.72,0,0,1,.52.21.71.71,0,0,1,0,1A.72.72,0,0,1,649,31.05Zm.54,8.78h-1.12v-7h1.12Z" fill="#2f2f2f"/>
-      <path d="M657.71,39.83h-1.12v-4c0-1.49-.54-2.23-1.62-2.23a1.78,1.78,0,0,0-1.4.63,2.39,2.39,0,0,0-.55,1.6v4H651.9v-7H653V34h0a2.54,2.54,0,0,1,2.3-1.32,2.11,2.11,0,0,1,1.75.74,3.27,3.27,0,0,1,.61,2.14Z" fill="#2f2f2f"/>
-      <path d="M663.4,30.45a1.54,1.54,0,0,0-.75-.18c-.78,0-1.17.49-1.17,1.48v1.08h1.64v1h-1.64v6h-1.12v-6h-1.19v-1h1.19V31.7A2.36,2.36,0,0,1,661,30a2.13,2.13,0,0,1,1.59-.64,2.23,2.23,0,0,1,.81.12Z" fill="#2f2f2f"/>
-      <path d="M668.29,34a1.39,1.39,0,0,0-.85-.23,1.43,1.43,0,0,0-1.2.68,3.12,3.12,0,0,0-.48,1.84v3.57h-1.12v-7h1.12v1.44h0a2.46,2.46,0,0,1,.73-1.15,1.71,1.71,0,0,1,1.1-.41,1.92,1.92,0,0,1,.67.09Z" fill="#2f2f2f"/>
-      <path d="M674.75,39.83h-1.12V38.74h0A2.36,2.36,0,0,1,671.44,40a2.29,2.29,0,0,1-1.63-.56,1.9,1.9,0,0,1-.59-1.47q0-2,2.31-2.28l2.1-.29c0-1.19-.49-1.79-1.45-1.79a3.47,3.47,0,0,0-2.28.86V33.32a4.4,4.4,0,0,1,2.38-.65c1.64,0,2.47.87,2.47,2.61Zm-1.12-3.54-1.69.23a2.76,2.76,0,0,0-1.18.39,1.12,1.12,0,0,0-.4,1,1.1,1.1,0,0,0,.37.84,1.44,1.44,0,0,0,1,.32,1.79,1.79,0,0,0,1.38-.58,2.1,2.1,0,0,0,.55-1.48Z" fill="#2f2f2f"/>
-      <path d="M676.67,39.58v-1.2a3.31,3.31,0,0,0,2,.67c1,0,1.48-.33,1.48-1a.9.9,0,0,0-.12-.48,1.26,1.26,0,0,0-.35-.34,2.61,2.61,0,0,0-.5-.27c-.2-.08-.4-.17-.63-.25a7.93,7.93,0,0,1-.81-.37,2.31,2.31,0,0,1-.59-.43,1.56,1.56,0,0,1-.36-.53,2,2,0,0,1-.12-.71,1.66,1.66,0,0,1,.23-.87,2,2,0,0,1,.6-.64,2.68,2.68,0,0,1,.86-.38,3.64,3.64,0,0,1,1-.13A4,4,0,0,1,681,33v1.14a3.17,3.17,0,0,0-1.78-.51,2.47,2.47,0,0,0-.57.07,1.71,1.71,0,0,0-.43.2,1.06,1.06,0,0,0-.28.32.77.77,0,0,0-.1.4.88.88,0,0,0,.1.45.91.91,0,0,0,.29.33,2.22,2.22,0,0,0,.46.26l.63.25a8.19,8.19,0,0,1,.83.37,3.13,3.13,0,0,1,.63.42,1.66,1.66,0,0,1,.4.55,1.79,1.79,0,0,1,.14.73,1.74,1.74,0,0,1-.23.9,2,2,0,0,1-.61.64,2.78,2.78,0,0,1-.88.37,4.44,4.44,0,0,1-1.05.13A3.94,3.94,0,0,1,676.67,39.58Z" fill="#2f2f2f"/>
-      <path d="M686.6,39.76a2.09,2.09,0,0,1-1,.22c-1.23,0-1.84-.68-1.84-2V33.79h-1.21v-1h1.21V31.12l1.12-.36v2.07h1.76v1h-1.76v3.94a1.65,1.65,0,0,0,.24,1,1,1,0,0,0,.79.3,1.2,1.2,0,0,0,.73-.23Z" fill="#2f2f2f"/>
-      <path d="M691.91,34a1.37,1.37,0,0,0-.85-.23,1.43,1.43,0,0,0-1.19.68,3,3,0,0,0-.49,1.84v3.57h-1.12v-7h1.12v1.44h0a2.46,2.46,0,0,1,.73-1.15,1.71,1.71,0,0,1,1.1-.41,1.89,1.89,0,0,1,.67.09Z" fill="#2f2f2f"/>
-      <path d="M699.17,39.83h-1.12V38.72h0A2.3,2.3,0,0,1,695.86,40c-1.66,0-2.5-1-2.5-3V32.83h1.12v4c0,1.47.56,2.21,1.69,2.21a1.71,1.71,0,0,0,1.35-.6,2.29,2.29,0,0,0,.53-1.58v-4h1.12Z" fill="#2f2f2f"/>
-      <path d="M706.4,39.51a3.7,3.7,0,0,1-1.92.49,3.15,3.15,0,0,1-2.41-1,3.49,3.49,0,0,1-.92-2.52,3.88,3.88,0,0,1,1-2.78,3.46,3.46,0,0,1,2.64-1,3.65,3.65,0,0,1,1.63.34v1.15a2.81,2.81,0,0,0-1.67-.55,2.27,2.27,0,0,0-1.76.77,2.91,2.91,0,0,0-.68,2,2.77,2.77,0,0,0,.64,1.94,2.21,2.21,0,0,0,1.73.71,2.81,2.81,0,0,0,1.73-.61Z" fill="#2f2f2f"/>
-      <path d="M711.84,39.76a2.1,2.1,0,0,1-1.05.22c-1.22,0-1.83-.68-1.83-2V33.79h-1.21v-1H709V31.12l1.12-.36v2.07h1.76v1h-1.76v3.94a1.65,1.65,0,0,0,.24,1,.94.94,0,0,0,.79.3,1.22,1.22,0,0,0,.73-.23Z" fill="#2f2f2f"/>
-      <path d="M719.24,39.83h-1.12V38.72h0A2.3,2.3,0,0,1,715.93,40c-1.67,0-2.5-1-2.5-3V32.83h1.11v4c0,1.47.57,2.21,1.7,2.21a1.74,1.74,0,0,0,1.35-.6,2.34,2.34,0,0,0,.53-1.58v-4h1.12Z" fill="#2f2f2f"/>
-      <path d="M725.28,34a1.39,1.39,0,0,0-.85-.23,1.43,1.43,0,0,0-1.2.68,3.12,3.12,0,0,0-.48,1.84v3.57h-1.12v-7h1.12v1.44h0a2.47,2.47,0,0,1,.74-1.15,1.67,1.67,0,0,1,1.1-.41,2,2,0,0,1,.67.09Z" fill="#2f2f2f"/>
-      <path d="M732.4,36.61h-4.94a2.56,2.56,0,0,0,.63,1.81,2.17,2.17,0,0,0,1.65.63,3.42,3.42,0,0,0,2.17-.78v1.06a4.1,4.1,0,0,1-2.44.67,3,3,0,0,1-2.33-1,3.92,3.92,0,0,1-.85-2.68,3.8,3.8,0,0,1,.93-2.66,3,3,0,0,1,2.3-1,2.61,2.61,0,0,1,2.13.89A3.69,3.69,0,0,1,732.4,36Zm-1.15-1a2.24,2.24,0,0,0-.47-1.51,1.59,1.59,0,0,0-1.28-.54,1.81,1.81,0,0,0-1.35.57,2.58,2.58,0,0,0-.68,1.48Z" fill="#2f2f2f"/>
-    </g>
-    <g>
-      <path d="M815.06,22.64V21.28a2.52,2.52,0,0,0,.55.37,5.24,5.24,0,0,0,.69.28,6.25,6.25,0,0,0,.72.17,4.06,4.06,0,0,0,.67.06,2.65,2.65,0,0,0,1.58-.39,1.32,1.32,0,0,0,.52-1.13,1.26,1.26,0,0,0-.17-.69,2,2,0,0,0-.48-.54,5.42,5.42,0,0,0-.73-.46c-.28-.15-.58-.31-.91-.47s-.66-.35-1-.53a4,4,0,0,1-.78-.59,2.42,2.42,0,0,1-.51-.72,2.19,2.19,0,0,1-.19-1,2.29,2.29,0,0,1,.29-1.16,2.55,2.55,0,0,1,.78-.82,3.72,3.72,0,0,1,1.09-.48,5.14,5.14,0,0,1,1.24-.16,4.86,4.86,0,0,1,2.12.35v1.3a4.15,4.15,0,0,0-3-.53,2,2,0,0,0-.67.26,1.41,1.41,0,0,0-.48.46,1.21,1.21,0,0,0-.19.68,1.45,1.45,0,0,0,.14.65,1.63,1.63,0,0,0,.42.5,4,4,0,0,0,.66.44l.91.46c.35.17.68.36,1,.55a4.44,4.44,0,0,1,.82.63,2.84,2.84,0,0,1,.57.78,2.13,2.13,0,0,1,.21,1,2.42,2.42,0,0,1-.29,1.22,2.3,2.3,0,0,1-.76.82,3.46,3.46,0,0,1-1.11.46,6.31,6.31,0,0,1-1.33.14c-.15,0-.35,0-.57,0s-.46-.06-.7-.11a5.92,5.92,0,0,1-.67-.18A2.06,2.06,0,0,1,815.06,22.64Z" fill="#2f2f2f"/>
-      <path d="M828.66,19.81h-4.94a2.6,2.6,0,0,0,.62,1.81,2.21,2.21,0,0,0,1.66.63,3.42,3.42,0,0,0,2.17-.78v1.06a4.1,4.1,0,0,1-2.44.67,3,3,0,0,1-2.33-1,3.92,3.92,0,0,1-.85-2.68,3.8,3.8,0,0,1,.93-2.66,3,3,0,0,1,2.3-1,2.61,2.61,0,0,1,2.13.89,3.69,3.69,0,0,1,.75,2.46Zm-1.15-.95a2.24,2.24,0,0,0-.47-1.51,1.59,1.59,0,0,0-1.28-.54,1.81,1.81,0,0,0-1.35.57,2.58,2.58,0,0,0-.68,1.48Z" fill="#2f2f2f"/>
-      <path d="M835.44,22.71a3.7,3.7,0,0,1-1.92.49,3.15,3.15,0,0,1-2.41-1,3.49,3.49,0,0,1-.92-2.52,3.88,3.88,0,0,1,1-2.78,3.46,3.46,0,0,1,2.64-1.05,3.65,3.65,0,0,1,1.63.34v1.15a2.83,2.83,0,0,0-1.67-.55,2.27,2.27,0,0,0-1.76.77,2.91,2.91,0,0,0-.68,2,2.77,2.77,0,0,0,.64,1.94,2.21,2.21,0,0,0,1.73.71,2.81,2.81,0,0,0,1.73-.61Z" fill="#2f2f2f"/>
-      <path d="M842.94,23h-1.12V21.92h0a2.3,2.3,0,0,1-2.16,1.28c-1.66,0-2.5-1-2.5-3V16h1.12v4c0,1.47.56,2.21,1.69,2.21a1.71,1.71,0,0,0,1.35-.6,2.35,2.35,0,0,0,.53-1.59V16h1.12Z" fill="#2f2f2f"/>
-      <path d="M849,17.17a1.39,1.39,0,0,0-.85-.23,1.43,1.43,0,0,0-1.2.68,3.12,3.12,0,0,0-.48,1.84V23h-1.12V16h1.12v1.44h0a2.46,2.46,0,0,1,.73-1.15,1.69,1.69,0,0,1,1.1-.41A2,2,0,0,1,849,16Z" fill="#2f2f2f"/>
-      <path d="M851.08,14.25a.72.72,0,0,1-.52-.2.75.75,0,0,1,0-1,.73.73,0,0,1,.52-.21.72.72,0,0,1,.52.21.71.71,0,0,1,0,1A.72.72,0,0,1,851.08,14.25Zm.54,8.78H850.5V16h1.12Z" fill="#2f2f2f"/>
-      <path d="M857.35,23a2.09,2.09,0,0,1-1,.22c-1.23,0-1.84-.68-1.84-2.05V17h-1.21V16h1.21V14.32l1.12-.36V16h1.76v1h-1.76v3.94a1.65,1.65,0,0,0,.24,1,1,1,0,0,0,.79.3,1.2,1.2,0,0,0,.73-.23Z" fill="#2f2f2f"/>
-      <path d="M865.11,16l-3.22,8.12c-.57,1.45-1.38,2.18-2.42,2.18a2.55,2.55,0,0,1-.73-.09v-1a2.14,2.14,0,0,0,.66.13,1.37,1.37,0,0,0,1.27-1l.56-1.32-2.73-7h1.24l1.9,5.39c0,.07.07.24.14.53h0c0-.11.07-.28.14-.52l2-5.4Z" fill="#2f2f2f"/>
-      <path d="M798.56,31.05a.69.69,0,0,1-.51-.2.72.72,0,0,1,0-1,.69.69,0,0,1,.51-.21.72.72,0,0,1,.52.21.71.71,0,0,1,0,1A.72.72,0,0,1,798.56,31.05Zm.54,8.78H798v-7h1.12Z" fill="#2f2f2f"/>
-      <path d="M807.31,39.83h-1.12v-4c0-1.49-.54-2.23-1.62-2.23a1.79,1.79,0,0,0-1.4.63,2.39,2.39,0,0,0-.55,1.6v4H801.5v-7h1.12V34h0a2.54,2.54,0,0,1,2.3-1.32,2.14,2.14,0,0,1,1.76.74,3.33,3.33,0,0,1,.6,2.14Z" fill="#2f2f2f"/>
-      <path d="M813,30.45a1.54,1.54,0,0,0-.75-.18c-.78,0-1.17.49-1.17,1.48v1.08h1.64v1h-1.64v6H810v-6h-1.19v-1H810V31.7A2.36,2.36,0,0,1,810.6,30a2.13,2.13,0,0,1,1.59-.64,2.23,2.23,0,0,1,.81.12Z" fill="#2f2f2f"/>
-      <path d="M817.89,34a1.39,1.39,0,0,0-.85-.23,1.43,1.43,0,0,0-1.2.68,3.12,3.12,0,0,0-.48,1.84v3.57h-1.12v-7h1.12v1.44h0a2.46,2.46,0,0,1,.73-1.15,1.69,1.69,0,0,1,1.1-.41,1.92,1.92,0,0,1,.67.09Z" fill="#2f2f2f"/>
-      <path d="M824.35,39.83h-1.13V38.74h0A2.36,2.36,0,0,1,821,40a2.29,2.29,0,0,1-1.63-.56,1.9,1.9,0,0,1-.59-1.47q0-2,2.31-2.28l2.09-.3c0-1.18-.48-1.78-1.44-1.78a3.47,3.47,0,0,0-2.28.86V33.32a4.4,4.4,0,0,1,2.38-.65c1.64,0,2.47.87,2.47,2.61Zm-1.13-3.54-1.68.23a2.81,2.81,0,0,0-1.18.39,1.12,1.12,0,0,0-.4,1,1.1,1.1,0,0,0,.37.84,1.44,1.44,0,0,0,1,.32,1.79,1.79,0,0,0,1.38-.58,2.11,2.11,0,0,0,.54-1.48Z" fill="#2f2f2f"/>
-      <path d="M826.27,39.58v-1.2a3.31,3.31,0,0,0,2,.67c1,0,1.47-.33,1.47-1a.82.82,0,0,0-.13-.48,1.1,1.1,0,0,0-.34-.34,2.61,2.61,0,0,0-.5-.27l-.63-.25c-.31-.13-.58-.25-.82-.37a2.43,2.43,0,0,1-.58-.43,1.51,1.51,0,0,1-.36-.54,1.86,1.86,0,0,1-.12-.7,1.66,1.66,0,0,1,.23-.87,2,2,0,0,1,.6-.64,2.68,2.68,0,0,1,.86-.38,3.64,3.64,0,0,1,1-.13,4,4,0,0,1,1.63.31v1.14a3.17,3.17,0,0,0-1.78-.51,2,2,0,0,0-.57.07,1.71,1.71,0,0,0-.43.2,1,1,0,0,0-.28.32.77.77,0,0,0-.1.4.88.88,0,0,0,.1.45.91.91,0,0,0,.29.33,2.07,2.07,0,0,0,.47.26l.62.25a7.3,7.3,0,0,1,.83.37,3.13,3.13,0,0,1,.63.42,1.66,1.66,0,0,1,.4.55,1.79,1.79,0,0,1,.14.73,1.74,1.74,0,0,1-.23.9,2,2,0,0,1-.61.64,3,3,0,0,1-.88.37,4.51,4.51,0,0,1-1.05.13A3.94,3.94,0,0,1,826.27,39.58Z" fill="#2f2f2f"/>
-      <path d="M836.2,39.76a2.09,2.09,0,0,1-1,.22c-1.23,0-1.84-.68-1.84-2V33.79h-1.21v-1h1.21V31.12l1.12-.36v2.07h1.76v1h-1.76v3.94a1.65,1.65,0,0,0,.24,1,1,1,0,0,0,.79.3,1.2,1.2,0,0,0,.73-.23Z" fill="#2f2f2f"/>
-      <path d="M841.51,34a1.35,1.35,0,0,0-.84-.23,1.43,1.43,0,0,0-1.2.68,3,3,0,0,0-.49,1.84v3.57h-1.12v-7H839v1.44h0a2.54,2.54,0,0,1,.73-1.15,1.71,1.71,0,0,1,1.1-.41,1.89,1.89,0,0,1,.67.09Z" fill="#2f2f2f"/>
-      <path d="M848.77,39.83h-1.12V38.72h0A2.32,2.32,0,0,1,845.47,40c-1.67,0-2.51-1-2.51-3V32.83h1.12v4c0,1.47.56,2.21,1.69,2.21a1.71,1.71,0,0,0,1.35-.6,2.3,2.3,0,0,0,.53-1.59v-4h1.12Z" fill="#2f2f2f"/>
-      <path d="M856,39.51a3.7,3.7,0,0,1-1.92.49,3.16,3.16,0,0,1-2.41-1,3.49,3.49,0,0,1-.92-2.52,3.88,3.88,0,0,1,1-2.78,3.46,3.46,0,0,1,2.64-1A3.65,3.65,0,0,1,856,33v1.15a2.81,2.81,0,0,0-1.67-.55,2.27,2.27,0,0,0-1.76.77,2.91,2.91,0,0,0-.68,2,2.77,2.77,0,0,0,.64,1.94,2.21,2.21,0,0,0,1.73.71,2.81,2.81,0,0,0,1.73-.61Z" fill="#2f2f2f"/>
-      <path d="M861.44,39.76a2.1,2.1,0,0,1-1.05.22c-1.22,0-1.83-.68-1.83-2V33.79h-1.21v-1h1.21V31.12l1.12-.36v2.07h1.76v1h-1.76v3.94a1.65,1.65,0,0,0,.24,1,1,1,0,0,0,.79.3,1.2,1.2,0,0,0,.73-.23Z" fill="#2f2f2f"/>
-      <path d="M868.84,39.83h-1.12V38.72h0A2.3,2.3,0,0,1,865.53,40c-1.67,0-2.5-1-2.5-3V32.83h1.11v4c0,1.47.57,2.21,1.7,2.21a1.73,1.73,0,0,0,1.35-.6,2.35,2.35,0,0,0,.53-1.59v-4h1.12Z" fill="#2f2f2f"/>
-      <path d="M874.88,34a1.39,1.39,0,0,0-.85-.23,1.43,1.43,0,0,0-1.2.68,3.12,3.12,0,0,0-.48,1.84v3.57h-1.12v-7h1.12v1.44h0a2.47,2.47,0,0,1,.74-1.15,1.67,1.67,0,0,1,1.1-.41,2,2,0,0,1,.67.09Z" fill="#2f2f2f"/>
-      <path d="M882,36.61h-4.94a2.61,2.61,0,0,0,.63,1.81,2.17,2.17,0,0,0,1.65.63,3.42,3.42,0,0,0,2.17-.78v1.06a4.08,4.08,0,0,1-2.44.67,3,3,0,0,1-2.33-1,3.92,3.92,0,0,1-.85-2.68,3.8,3.8,0,0,1,.93-2.66,3,3,0,0,1,2.3-1,2.61,2.61,0,0,1,2.13.89A3.69,3.69,0,0,1,882,36Zm-1.15-1a2.24,2.24,0,0,0-.47-1.51,1.59,1.59,0,0,0-1.28-.54,1.81,1.81,0,0,0-1.35.57,2.58,2.58,0,0,0-.68,1.48Z" fill="#2f2f2f"/>
-    </g>
-    <g>
-      <path d="M979.71,27.92a5.81,5.81,0,0,1-2.71.58,4.36,4.36,0,0,1-3.35-1.35,5,5,0,0,1-1.26-3.53,5.21,5.21,0,0,1,1.42-3.81,4.81,4.81,0,0,1,3.58-1.44,5.82,5.82,0,0,1,2.32.4V20a4.75,4.75,0,0,0-2.33-.59,3.59,3.59,0,0,0-2.74,1.13,4.25,4.25,0,0,0-1,3,4.06,4.06,0,0,0,1,2.85,3.36,3.36,0,0,0,2.58,1.06,4.94,4.94,0,0,0,2.56-.65Z" fill="#2f2f2f"/>
-      <path d="M982.76,28.33h-1.15v-9.8h1.15Z" fill="#2f2f2f"/>
-      <path d="M989.66,18.53,985,30h-1l4.69-11.43Z" fill="#2f2f2f"/>
-      <path d="M997.42,27.92a5.81,5.81,0,0,1-2.71.58,4.36,4.36,0,0,1-3.35-1.35,5,5,0,0,1-1.26-3.53,5.21,5.21,0,0,1,1.42-3.81,4.81,4.81,0,0,1,3.59-1.44,5.73,5.73,0,0,1,2.31.4V20a4.72,4.72,0,0,0-2.33-.59,3.59,3.59,0,0,0-2.74,1.13,4.25,4.25,0,0,0-1.05,3,4,4,0,0,0,1,2.85,3.32,3.32,0,0,0,2.57,1.06,4.92,4.92,0,0,0,2.56-.65Z" fill="#2f2f2f"/>
-      <path d="M999.32,28.33v-9.8h2.7q5.19,0,5.19,4.78a4.79,4.79,0,0,1-1.44,3.64,5.34,5.34,0,0,1-3.85,1.38Zm1.15-8.76v7.72h1.46a4.16,4.16,0,0,0,3-1,3.89,3.89,0,0,0,1.07-2.93q0-3.76-4-3.76Z" fill="#2f2f2f"/>
-      <path d="M1014.68,24.63v3.7h-1.15v-9.8h2.69a3.57,3.57,0,0,1,2.44.76,2.73,2.73,0,0,1,.86,2.16,3,3,0,0,1-1,2.29,3.67,3.67,0,0,1-2.59.89Zm0-5.06v4h1.2a2.68,2.68,0,0,0,1.82-.55,1.93,1.93,0,0,0,.62-1.53c0-1.29-.77-1.94-2.3-1.94Z" fill="#2f2f2f"/>
-      <path d="M1021.86,19.55a.72.72,0,0,1-.52-.2.75.75,0,0,1,0-1,.73.73,0,0,1,.52-.21.72.72,0,0,1,.52.21.71.71,0,0,1,0,1A.72.72,0,0,1,1021.86,19.55Zm.54,8.78h-1.12v-7h1.12Z" fill="#2f2f2f"/>
-      <path d="M1026,27.32h0v4.23h-1.12V21.33h1.12v1.23h0a2.65,2.65,0,0,1,2.42-1.39,2.54,2.54,0,0,1,2.11.94,3.85,3.85,0,0,1,.76,2.52,4.32,4.32,0,0,1-.85,2.81,2.86,2.86,0,0,1-2.34,1.06A2.35,2.35,0,0,1,1026,27.32Zm0-2.82v1a2.09,2.09,0,0,0,.57,1.48,1.86,1.86,0,0,0,1.43.6,1.89,1.89,0,0,0,1.6-.78,3.6,3.6,0,0,0,.57-2.16,2.86,2.86,0,0,0-.54-1.84,1.78,1.78,0,0,0-1.46-.66,2,2,0,0,0-1.57.68A2.48,2.48,0,0,0,1025.92,24.5Z" fill="#2f2f2f"/>
-      <path d="M1038.93,25.11H1034a2.61,2.61,0,0,0,.63,1.81,2.17,2.17,0,0,0,1.65.63,3.42,3.42,0,0,0,2.17-.78v1.06a4.1,4.1,0,0,1-2.44.67,3,3,0,0,1-2.33-1,3.92,3.92,0,0,1-.85-2.68,3.8,3.8,0,0,1,.93-2.66,3,3,0,0,1,2.3-1,2.61,2.61,0,0,1,2.13.89,3.69,3.69,0,0,1,.75,2.46Zm-1.15-.95a2.24,2.24,0,0,0-.47-1.51,1.59,1.59,0,0,0-1.28-.54,1.81,1.81,0,0,0-1.35.57,2.58,2.58,0,0,0-.68,1.48Z" fill="#2f2f2f"/>
-      <path d="M1042,28.33h-1.12V18H1042Z" fill="#2f2f2f"/>
-      <path d="M1045,19.55a.69.69,0,0,1-.51-.2.73.73,0,0,1,1-1,.71.71,0,0,1,0,1A.7.7,0,0,1,1045,19.55Zm.55,8.78h-1.12v-7h1.12Z" fill="#2f2f2f"/>
-      <path d="M1053.73,28.33h-1.12v-4c0-1.49-.55-2.23-1.63-2.23a1.76,1.76,0,0,0-1.39.63,2.34,2.34,0,0,0-.55,1.6v4h-1.12v-7H1049v1.16h0a2.54,2.54,0,0,1,2.3-1.32,2.13,2.13,0,0,1,1.76.74,3.33,3.33,0,0,1,.61,2.14Z" fill="#2f2f2f"/>
-      <path d="M1061.71,25.11h-4.94a2.66,2.66,0,0,0,.63,1.81,2.17,2.17,0,0,0,1.65.63,3.42,3.42,0,0,0,2.17-.78v1.06a4.08,4.08,0,0,1-2.44.67,3,3,0,0,1-2.33-1,3.91,3.91,0,0,1-.84-2.68,3.79,3.79,0,0,1,.92-2.66,3,3,0,0,1,2.3-1,2.61,2.61,0,0,1,2.13.89,3.69,3.69,0,0,1,.75,2.46Zm-1.15-.95a2.24,2.24,0,0,0-.47-1.51,1.58,1.58,0,0,0-1.28-.54,1.78,1.78,0,0,0-1.34.57,2.59,2.59,0,0,0-.69,1.48Z" fill="#2f2f2f"/>
-      <path d="M1063.23,28.08v-1.2a3.31,3.31,0,0,0,2,.67c1,0,1.47-.33,1.47-1a.9.9,0,0,0-.12-.48,1.37,1.37,0,0,0-.34-.34,3.05,3.05,0,0,0-.51-.27l-.62-.25a8.17,8.17,0,0,1-.82-.37,2.5,2.5,0,0,1-.59-.43,1.56,1.56,0,0,1-.36-.53,2.2,2.2,0,0,1-.11-.71,1.66,1.66,0,0,1,.22-.87,2,2,0,0,1,.6-.64,2.68,2.68,0,0,1,.86-.38,3.64,3.64,0,0,1,1-.13,4,4,0,0,1,1.63.31v1.14a3.15,3.15,0,0,0-1.78-.51,2.38,2.38,0,0,0-.56.07,1.63,1.63,0,0,0-.44.2,1.06,1.06,0,0,0-.28.32.88.88,0,0,0-.1.4,1,1,0,0,0,.1.45,1,1,0,0,0,.29.33,2.31,2.31,0,0,0,.47.26l.62.25a7.3,7.3,0,0,1,.83.37,3.13,3.13,0,0,1,.63.42,1.53,1.53,0,0,1,.4.55,1.92,1.92,0,0,1-.09,1.63,1.87,1.87,0,0,1-.61.64,2.68,2.68,0,0,1-.88.37,4.44,4.44,0,0,1-1.05.13A3.94,3.94,0,0,1,1063.23,28.08Z" fill="#2f2f2f"/>
-    </g>
-    <g>
-      <path d="M709.17,236.42a5.78,5.78,0,0,1-2.71.58,4.37,4.37,0,0,1-3.35-1.35,5,5,0,0,1-1.25-3.53,5.24,5.24,0,0,1,1.41-3.81,4.81,4.81,0,0,1,3.59-1.44,5.73,5.73,0,0,1,2.31.4v1.22a4.71,4.71,0,0,0-2.32-.59,3.57,3.57,0,0,0-2.74,1.13,4.25,4.25,0,0,0-1.05,3,4.06,4.06,0,0,0,1,2.85,3.32,3.32,0,0,0,2.57,1.06,4.89,4.89,0,0,0,2.56-.65Z" fill="#2f2f2f"/>
-      <path d="M713.72,237a3.26,3.26,0,0,1-2.48-1,3.66,3.66,0,0,1-.93-2.61,3.79,3.79,0,0,1,1-2.75,3.46,3.46,0,0,1,2.6-1,3.16,3.16,0,0,1,2.45,1,3.85,3.85,0,0,1,.88,2.67,3.78,3.78,0,0,1-1,2.69A3.33,3.33,0,0,1,713.72,237Zm.08-6.39a2.14,2.14,0,0,0-1.71.74,3,3,0,0,0-.63,2,2.81,2.81,0,0,0,.64,2,2.15,2.15,0,0,0,1.7.72,2,2,0,0,0,1.67-.7,3.06,3.06,0,0,0,.59-2,3.13,3.13,0,0,0-.59-2A2,2,0,0,0,713.8,230.61Z" fill="#2f2f2f"/>
-      <path d="M724.73,236.83h-1.12v-4c0-1.49-.54-2.23-1.63-2.23a1.77,1.77,0,0,0-1.39.63,2.39,2.39,0,0,0-.55,1.6v4h-1.12v-7H720V231h0a2.53,2.53,0,0,1,2.3-1.32,2.11,2.11,0,0,1,1.75.74,3.27,3.27,0,0,1,.61,2.14Z" fill="#2f2f2f"/>
-      <path d="M730.14,227.45a1.54,1.54,0,0,0-.75-.18c-.78,0-1.17.49-1.17,1.48v1.08h1.64v1h-1.64v6H727.1v-6h-1.19v-1h1.19V228.7a2.32,2.32,0,0,1,.64-1.74,2.12,2.12,0,0,1,1.58-.64,2.25,2.25,0,0,1,.82.12Z" fill="#2f2f2f"/>
-      <path d="M731.89,228.05a.69.69,0,0,1-.51-.2.73.73,0,0,1,1-1,.71.71,0,0,1,0,1A.7.7,0,0,1,731.89,228.05Zm.55,8.78h-1.12v-7h1.12Z" fill="#2f2f2f"/>
-      <path d="M740.58,236.27q0,3.85-3.69,3.86a4.93,4.93,0,0,1-2.27-.5v-1.12a4.65,4.65,0,0,0,2.26.66c1.72,0,2.58-.92,2.58-2.75v-.76h0a2.83,2.83,0,0,1-4.51.4,3.71,3.71,0,0,1-.79-2.5,4.32,4.32,0,0,1,.86-2.84,2.86,2.86,0,0,1,2.34-1.05,2.28,2.28,0,0,1,2.1,1.13h0v-1h1.12Zm-1.12-2.6v-1a2,2,0,0,0-.56-1.42,1.87,1.87,0,0,0-1.41-.6,2,2,0,0,0-1.63.76,3.37,3.37,0,0,0-.58,2.11,2.88,2.88,0,0,0,.56,1.87,1.81,1.81,0,0,0,1.49.7,2,2,0,0,0,1.54-.67A2.5,2.5,0,0,0,739.46,233.67Z" fill="#2f2f2f"/>
-      <path d="M703.51,253.38v-1.2a3.31,3.31,0,0,0,2,.67c1,0,1.47-.33,1.47-1a.9.9,0,0,0-.12-.48,1.37,1.37,0,0,0-.34-.34,3.05,3.05,0,0,0-.51-.27l-.63-.25a7.93,7.93,0,0,1-.81-.37,2.5,2.5,0,0,1-.59-.43,1.47,1.47,0,0,1-.36-.53,2,2,0,0,1-.12-.71,1.66,1.66,0,0,1,.23-.87,2.15,2.15,0,0,1,.6-.64,2.68,2.68,0,0,1,.86-.38,3.64,3.64,0,0,1,1-.13,4,4,0,0,1,1.63.31v1.14a3.15,3.15,0,0,0-1.78-.51,2.38,2.38,0,0,0-.56.07,1.63,1.63,0,0,0-.44.2,1,1,0,0,0-.28.32.88.88,0,0,0-.1.4,1,1,0,0,0,.1.45,1,1,0,0,0,.29.33,2.31,2.31,0,0,0,.47.26l.62.25a7.3,7.3,0,0,1,.83.37,3.13,3.13,0,0,1,.63.42,1.53,1.53,0,0,1,.4.55,1.92,1.92,0,0,1-.09,1.63,1.87,1.87,0,0,1-.61.64,2.68,2.68,0,0,1-.88.37,4.44,4.44,0,0,1-1,.13A3.94,3.94,0,0,1,703.51,253.38Z" fill="#2f2f2f"/>
-      <path d="M715.47,250.41h-5a2.66,2.66,0,0,0,.63,1.81,2.19,2.19,0,0,0,1.66.63,3.42,3.42,0,0,0,2.17-.78v1.06a4.1,4.1,0,0,1-2.44.67,2.94,2.94,0,0,1-2.33-1,3.87,3.87,0,0,1-.85-2.68,3.8,3.8,0,0,1,.93-2.66,3,3,0,0,1,2.3-1,2.6,2.6,0,0,1,2.12.89,3.64,3.64,0,0,1,.76,2.46Zm-1.15-.95a2.31,2.31,0,0,0-.47-1.51,1.6,1.6,0,0,0-1.28-.54,1.81,1.81,0,0,0-1.35.57,2.52,2.52,0,0,0-.68,1.48Z" fill="#2f2f2f"/>
-      <path d="M720.8,247.77a1.39,1.39,0,0,0-.85-.23,1.43,1.43,0,0,0-1.2.68,3.12,3.12,0,0,0-.48,1.84v3.57h-1.12v-7h1.12v1.44h0a2.46,2.46,0,0,1,.73-1.15,1.69,1.69,0,0,1,1.1-.41,2,2,0,0,1,.67.09Z" fill="#2f2f2f"/>
-      <path d="M728.07,246.63l-2.79,7h-1.1l-2.65-7h1.23l1.78,5.09a4.47,4.47,0,0,1,.24,1h0a5,5,0,0,1,.22-1l1.86-5.11Z" fill="#2f2f2f"/>
-      <path d="M734.71,250.41h-4.94a2.66,2.66,0,0,0,.63,1.81,2.17,2.17,0,0,0,1.65.63,3.45,3.45,0,0,0,2.18-.78v1.06a4.12,4.12,0,0,1-2.44.67,2.94,2.94,0,0,1-2.33-1,3.87,3.87,0,0,1-.85-2.68,3.8,3.8,0,0,1,.93-2.66,2.94,2.94,0,0,1,2.3-1,2.6,2.6,0,0,1,2.12.89,3.69,3.69,0,0,1,.75,2.46Zm-1.14-.95a2.37,2.37,0,0,0-.47-1.51,1.6,1.6,0,0,0-1.28-.54,1.81,1.81,0,0,0-1.35.57,2.52,2.52,0,0,0-.68,1.48Z" fill="#2f2f2f"/>
-      <path d="M740.05,247.77a1.39,1.39,0,0,0-.85-.23,1.43,1.43,0,0,0-1.2.68,3.12,3.12,0,0,0-.48,1.84v3.57H736.4v-7h1.12v1.44h0a2.38,2.38,0,0,1,.73-1.15,1.67,1.67,0,0,1,1.1-.41,2,2,0,0,1,.67.09Z" fill="#2f2f2f"/>
-    </g>
-    <g>
-      <path d="M766.62,236.44v-1.36a2.59,2.59,0,0,0,.56.37,4.61,4.61,0,0,0,.68.28,6.25,6.25,0,0,0,.72.17,4.16,4.16,0,0,0,.67.06,2.66,2.66,0,0,0,1.59-.39,1.35,1.35,0,0,0,.52-1.13,1.31,1.31,0,0,0-.18-.69,1.73,1.73,0,0,0-.48-.54,4.85,4.85,0,0,0-.73-.46l-.9-.47c-.34-.17-.66-.35-1-.53a3.56,3.56,0,0,1-.77-.59,2.45,2.45,0,0,1-.52-.72,2.35,2.35,0,0,1-.19-1,2.2,2.2,0,0,1,.3-1.16,2.51,2.51,0,0,1,.77-.82,3.72,3.72,0,0,1,1.09-.48,5.28,5.28,0,0,1,1.25-.15,4.81,4.81,0,0,1,2.11.34v1.3a4.15,4.15,0,0,0-3-.53,2.08,2.08,0,0,0-.67.26,1.51,1.51,0,0,0-.48.46,1.21,1.21,0,0,0-.18.68,1.33,1.33,0,0,0,.14.65,1.59,1.59,0,0,0,.41.5,4.09,4.09,0,0,0,.67.44l.9.46c.35.18.69.36,1,.55a4.52,4.52,0,0,1,.83.63,2.8,2.8,0,0,1,.56.78,2.13,2.13,0,0,1,.21,1,2.42,2.42,0,0,1-.28,1.22,2.33,2.33,0,0,1-.77.82,3.46,3.46,0,0,1-1.11.46,6.28,6.28,0,0,1-1.32.14c-.16,0-.35,0-.58,0s-.46-.06-.7-.11a6.55,6.55,0,0,1-.67-.18A2.47,2.47,0,0,1,766.62,236.44Z" fill="#2f2f2f"/>
-      <path d="M779.94,233.61H775a2.66,2.66,0,0,0,.63,1.81,2.17,2.17,0,0,0,1.65.63,3.45,3.45,0,0,0,2.18-.78v1.06A4.12,4.12,0,0,1,777,237a2.94,2.94,0,0,1-2.33-1,4.47,4.47,0,0,1,.07-5.34,3,3,0,0,1,2.31-1,2.6,2.6,0,0,1,2.12.89,3.69,3.69,0,0,1,.75,2.46Zm-1.14-1a2.37,2.37,0,0,0-.47-1.51,1.6,1.6,0,0,0-1.28-.54,1.81,1.81,0,0,0-1.35.57,2.59,2.59,0,0,0-.69,1.48Z" fill="#2f2f2f"/>
-      <path d="M785.28,231a1.39,1.39,0,0,0-.85-.23,1.43,1.43,0,0,0-1.2.68,3.12,3.12,0,0,0-.48,1.84v3.57h-1.12v-7h1.12v1.44h0a2.47,2.47,0,0,1,.74-1.15,1.67,1.67,0,0,1,1.1-.41,2,2,0,0,1,.67.09Z" fill="#2f2f2f"/>
-      <path d="M792.55,229.83l-2.79,7h-1.1l-2.65-7h1.23l1.77,5.09a4,4,0,0,1,.25,1h0a4.15,4.15,0,0,1,.22-1l1.86-5.12Z" fill="#2f2f2f"/>
-      <path d="M794.36,228.05a.69.69,0,0,1-.51-.2.73.73,0,0,1,.51-1.25.74.74,0,0,1,.53.21.74.74,0,0,1,0,1A.74.74,0,0,1,794.36,228.05Zm.55,8.78h-1.12v-7h1.12Z" fill="#2f2f2f"/>
-      <path d="M801.82,236.51a3.64,3.64,0,0,1-1.91.49,3.19,3.19,0,0,1-2.42-1,3.54,3.54,0,0,1-.92-2.52,3.88,3.88,0,0,1,1-2.78,3.49,3.49,0,0,1,2.65-1.05,3.65,3.65,0,0,1,1.63.34v1.15a2.83,2.83,0,0,0-1.67-.55,2.26,2.26,0,0,0-1.76.77,2.91,2.91,0,0,0-.69,2,2.77,2.77,0,0,0,.65,1.94,2.21,2.21,0,0,0,1.73.71,2.76,2.76,0,0,0,1.72-.61Z" fill="#2f2f2f"/>
-      <path d="M809,233.61h-4.94a2.66,2.66,0,0,0,.63,1.81,2.17,2.17,0,0,0,1.65.63,3.45,3.45,0,0,0,2.18-.78v1.06a4.12,4.12,0,0,1-2.44.67,2.94,2.94,0,0,1-2.33-1,4.47,4.47,0,0,1,.07-5.34,3,3,0,0,1,2.31-1,2.6,2.6,0,0,1,2.12.89A3.69,3.69,0,0,1,809,233Zm-1.15-1a2.31,2.31,0,0,0-.46-1.51,1.61,1.61,0,0,0-1.29-.54,1.81,1.81,0,0,0-1.34.57,2.59,2.59,0,0,0-.69,1.48Z" fill="#2f2f2f"/>
-      <path d="M771.15,253.63h-1.37l-1.64-2.75a5.22,5.22,0,0,0-.44-.65,2.25,2.25,0,0,0-.43-.44,1.57,1.57,0,0,0-.48-.25,2,2,0,0,0-.58-.08h-.94v4.17h-1.15v-9.8h2.93a4,4,0,0,1,1.18.16,2.68,2.68,0,0,1,.95.49,2.31,2.31,0,0,1,.62.82,2.66,2.66,0,0,1,.23,1.14,2.81,2.81,0,0,1-.15.94,2.61,2.61,0,0,1-.44.76,2.39,2.39,0,0,1-.69.57,3.33,3.33,0,0,1-.9.37v0a1.62,1.62,0,0,1,.43.25,2.15,2.15,0,0,1,.35.33,5.34,5.34,0,0,1,.32.43q.16.24.36.57Zm-5.88-8.76v3.55h1.56a2.32,2.32,0,0,0,.8-.13,1.81,1.81,0,0,0,.63-.37,1.53,1.53,0,0,0,.41-.59,1.86,1.86,0,0,0,.16-.79,1.53,1.53,0,0,0-.51-1.23,2.22,2.22,0,0,0-1.48-.44Z" fill="#2f2f2f"/>
-      <path d="M777.76,250.41h-4.94a2.66,2.66,0,0,0,.63,1.81,2.17,2.17,0,0,0,1.65.63,3.45,3.45,0,0,0,2.18-.78v1.06a4.12,4.12,0,0,1-2.44.67,2.94,2.94,0,0,1-2.33-1,4.47,4.47,0,0,1,.07-5.34,3,3,0,0,1,2.3-1,2.61,2.61,0,0,1,2.13.89,3.69,3.69,0,0,1,.75,2.46Zm-1.15-.95a2.31,2.31,0,0,0-.46-1.51,1.61,1.61,0,0,0-1.29-.54,1.81,1.81,0,0,0-1.34.57,2.59,2.59,0,0,0-.69,1.48Z" fill="#2f2f2f"/>
-      <path d="M785.46,253.07q0,3.85-3.69,3.86a5,5,0,0,1-2.27-.5v-1.12a4.65,4.65,0,0,0,2.26.66c1.72,0,2.58-.92,2.58-2.75v-.76h0a2.82,2.82,0,0,1-4.5.4,3.71,3.71,0,0,1-.8-2.5,4.37,4.37,0,0,1,.86-2.84,2.86,2.86,0,0,1,2.35-1.05,2.27,2.27,0,0,1,2.09,1.13h0v-1h1.12Zm-1.12-2.6v-1a2,2,0,0,0-.56-1.42,1.87,1.87,0,0,0-1.41-.6,1.92,1.92,0,0,0-1.62.76,3.31,3.31,0,0,0-.59,2.11,2.93,2.93,0,0,0,.56,1.87,1.83,1.83,0,0,0,1.5.7,1.94,1.94,0,0,0,1.53-.67A2.5,2.5,0,0,0,784.34,250.47Z" fill="#2f2f2f"/>
-      <path d="M788.15,244.85a.69.69,0,0,1-.51-.2.73.73,0,0,1,.51-1.25.74.74,0,0,1,.53.21.74.74,0,0,1,0,1A.74.74,0,0,1,788.15,244.85Zm.55,8.78h-1.12v-7h1.12Z" fill="#2f2f2f"/>
-      <path d="M790.42,253.38v-1.2a3.31,3.31,0,0,0,2,.67c1,0,1.48-.33,1.48-1a.82.82,0,0,0-.13-.48,1.22,1.22,0,0,0-.34-.34,2.61,2.61,0,0,0-.5-.27l-.63-.25c-.31-.12-.58-.25-.82-.37a2.72,2.72,0,0,1-.59-.43,1.58,1.58,0,0,1-.35-.53,2,2,0,0,1-.12-.71,1.66,1.66,0,0,1,.23-.87,2.15,2.15,0,0,1,.6-.64,2.59,2.59,0,0,1,.86-.38,3.64,3.64,0,0,1,1-.13,4,4,0,0,1,1.63.31v1.14a3.17,3.17,0,0,0-1.78-.51,2.47,2.47,0,0,0-.57.07,1.56,1.56,0,0,0-.43.2.86.86,0,0,0-.28.32.77.77,0,0,0-.1.4.88.88,0,0,0,.1.45.83.83,0,0,0,.29.33,2.22,2.22,0,0,0,.46.26l.62.25a8.42,8.42,0,0,1,.84.37,3.83,3.83,0,0,1,.63.42,1.63,1.63,0,0,1,.54,1.28,1.72,1.72,0,0,1-.23.9,2,2,0,0,1-.61.64,2.78,2.78,0,0,1-.88.37,4.57,4.57,0,0,1-1.05.13A3.91,3.91,0,0,1,790.42,253.38Z" fill="#2f2f2f"/>
-      <path d="M800.07,253.56a2.13,2.13,0,0,1-1.05.22c-1.22,0-1.84-.68-1.84-2.05v-4.14H796v-1h1.2v-1.71l1.13-.36v2.07h1.76v1h-1.76v3.94a1.65,1.65,0,0,0,.24,1,.94.94,0,0,0,.79.3,1.22,1.22,0,0,0,.73-.23Z" fill="#2f2f2f"/>
-      <path d="M805.1,247.77a1.39,1.39,0,0,0-.85-.23,1.43,1.43,0,0,0-1.2.68,3.12,3.12,0,0,0-.48,1.84v3.57h-1.12v-7h1.12v1.44h0a2.46,2.46,0,0,1,.73-1.15,1.71,1.71,0,0,1,1.1-.41,1.92,1.92,0,0,1,.67.09Z" fill="#2f2f2f"/>
-      <path d="M812.44,246.63l-3.22,8.12c-.57,1.45-1.38,2.18-2.42,2.18a2.55,2.55,0,0,1-.73-.09v-1a2.14,2.14,0,0,0,.66.13,1.39,1.39,0,0,0,1.28-1l.56-1.32-2.74-7h1.25L809,252c0,.07.07.24.14.53h0c0-.11.07-.28.14-.52l2-5.4Z" fill="#2f2f2f"/>
-    </g>
-    <g>
-      <path d="M676.09,411.83v3.7H675v-9.8h2.69a3.57,3.57,0,0,1,2.44.76,2.77,2.77,0,0,1,.86,2.17,3,3,0,0,1-1,2.28,3.69,3.69,0,0,1-2.6.89Zm0-5.06v4h1.21a2.65,2.65,0,0,0,1.81-.55,1.91,1.91,0,0,0,.63-1.53c0-1.3-.77-1.94-2.3-1.94Z" fill="#2f2f2f"/>
-      <path d="M686.07,409.67a1.39,1.39,0,0,0-.85-.23,1.43,1.43,0,0,0-1.2.68,3.12,3.12,0,0,0-.48,1.84v3.57h-1.12v-7h1.12V410h0a2.46,2.46,0,0,1,.73-1.15,1.69,1.69,0,0,1,1.1-.41,1.92,1.92,0,0,1,.67.09Z" fill="#2f2f2f"/>
-      <path d="M687.89,406.75a.69.69,0,0,1-.51-.2.72.72,0,0,1,0-1,.69.69,0,0,1,.51-.21.72.72,0,0,1,.52.21.71.71,0,0,1,0,1A.72.72,0,0,1,687.89,406.75Zm.54,8.78h-1.12v-7h1.12Z" fill="#2f2f2f"/>
-      <path d="M696.23,408.53l-2.79,7h-1.1l-2.65-7h1.23l1.78,5.09a5.23,5.23,0,0,1,.25,1h0a4.75,4.75,0,0,1,.22-1l1.86-5.12Z" fill="#2f2f2f"/>
-      <path d="M702.35,415.53h-1.12v-1.09h0a2.54,2.54,0,0,1-3.79.7,1.94,1.94,0,0,1-.59-1.47q0-2,2.31-2.28l2.1-.29c0-1.19-.48-1.79-1.44-1.79a3.47,3.47,0,0,0-2.29.86V409a4.43,4.43,0,0,1,2.38-.65c1.65,0,2.47.87,2.47,2.61ZM701.23,412l-1.69.23a2.71,2.71,0,0,0-1.17.39,1.09,1.09,0,0,0-.4,1,1.07,1.07,0,0,0,.37.84,1.42,1.42,0,0,0,1,.32,1.81,1.81,0,0,0,1.38-.58,2.11,2.11,0,0,0,.54-1.48Z" fill="#2f2f2f"/>
-      <path d="M707.61,415.46a2.09,2.09,0,0,1-1,.22c-1.23,0-1.84-.68-1.84-2.05v-4.14h-1.2v-1h1.2v-1.71l1.12-.36v2.07h1.76v1h-1.76v3.94a1.65,1.65,0,0,0,.24,1,1,1,0,0,0,.79.3,1.18,1.18,0,0,0,.73-.23Z" fill="#2f2f2f"/>
-      <path d="M714.61,412.31h-5a2.66,2.66,0,0,0,.63,1.81,2.19,2.19,0,0,0,1.66.63,3.42,3.42,0,0,0,2.17-.78V415a4.1,4.1,0,0,1-2.44.67,2.94,2.94,0,0,1-2.33-1,3.92,3.92,0,0,1-.85-2.68,3.8,3.8,0,0,1,.93-2.66,3,3,0,0,1,2.3-1,2.6,2.6,0,0,1,2.12.89,3.64,3.64,0,0,1,.76,2.46Zm-1.15-.95a2.29,2.29,0,0,0-.47-1.51,1.59,1.59,0,0,0-1.28-.54,1.81,1.81,0,0,0-1.35.57,2.52,2.52,0,0,0-.68,1.48Z" fill="#2f2f2f"/>
-      <path d="M725.26,406.77h-3.82v3.39H725v1h-3.54v4.34h-1.15v-9.8h5Z" fill="#2f2f2f"/>
-      <path d="M731,415.7a4.3,4.3,0,0,1-3.34-1.38,5.07,5.07,0,0,1-1.25-3.57,5.4,5.4,0,0,1,1.27-3.78,4.48,4.48,0,0,1,3.48-1.4,4.21,4.21,0,0,1,3.27,1.36,5.1,5.1,0,0,1,1.25,3.58,5.4,5.4,0,0,1-1.28,3.79,3.86,3.86,0,0,1-.64.58l2.76,2h-2.09l-1.84-1.38A5.41,5.41,0,0,1,731,415.7Zm.08-9.1a3.19,3.19,0,0,0-2.51,1.12,5,5,0,0,0,0,5.84,3,3,0,0,0,2.45,1.1,3.22,3.22,0,0,0,2.54-1.05,4.3,4.3,0,0,0,.93-2.95,4.51,4.51,0,0,0-.9-3A3.11,3.11,0,0,0,731,406.6Z" fill="#2f2f2f"/>
-      <path d="M737.43,415.53v-9.8h2.71q5.18,0,5.18,4.78a4.79,4.79,0,0,1-1.44,3.64,5.34,5.34,0,0,1-3.85,1.38Zm1.15-8.76v7.72H740a4.12,4.12,0,0,0,3-1,3.85,3.85,0,0,0,1.07-2.93q0-3.76-4-3.76Z" fill="#2f2f2f"/>
-      <path d="M755.07,415.53h-1.41l-5-7.81a3,3,0,0,1-.32-.62h0a9.25,9.25,0,0,1,.06,1.35v7.08h-1.15v-9.8h1.49l4.91,7.69q.3.48.39.66h0a9.82,9.82,0,0,1-.07-1.45v-6.9h1.15Z" fill="#2f2f2f"/>
-    </g>
-    <g>
-      <path d="M218.91,382.79h-5.19V373h5v1h-3.83v3.26h3.55v1h-3.55v3.43h4Z" fill="#2f2f2f"/>
-      <path d="M226,375.79l-2.35,3.54,2.31,3.46h-1.3l-1.38-2.27c-.08-.14-.19-.32-.3-.53h0l-.32.53-1.4,2.27h-1.3l2.39-3.43L220,375.79h1.3l1.36,2.39.29.55h0l1.75-2.94Z" fill="#2f2f2f"/>
-      <path d="M228.45,381.78h0V386H227.3V375.79h1.12V377h0a2.65,2.65,0,0,1,2.42-1.4,2.57,2.57,0,0,1,2.11.95,3.89,3.89,0,0,1,.76,2.51,4.37,4.37,0,0,1-.86,2.82,2.85,2.85,0,0,1-2.33,1.05A2.34,2.34,0,0,1,228.45,381.78Zm0-2.83v1a2.13,2.13,0,0,0,.56,1.48,1.9,1.9,0,0,0,1.44.6,1.87,1.87,0,0,0,1.59-.78,3.54,3.54,0,0,0,.58-2.17,2.81,2.81,0,0,0-.54-1.83,1.79,1.79,0,0,0-1.46-.66,2,2,0,0,0-1.58.68A2.51,2.51,0,0,0,228.42,379Z" fill="#2f2f2f"/>
-      <path d="M239.1,376.92a1.34,1.34,0,0,0-.84-.22,1.42,1.42,0,0,0-1.2.67,3.17,3.17,0,0,0-.48,1.85v3.57h-1.13v-7h1.13v1.44h0a2.54,2.54,0,0,1,.73-1.15,1.65,1.65,0,0,1,1.1-.41,1.89,1.89,0,0,1,.67.09Z" fill="#2f2f2f"/>
-      <path d="M246,379.57H241a2.56,2.56,0,0,0,.62,1.8,2.16,2.16,0,0,0,1.66.64,3.42,3.42,0,0,0,2.17-.78v1A4,4,0,0,1,243,383a3,3,0,0,1-2.33-.95,3.93,3.93,0,0,1-.85-2.68,3.84,3.84,0,0,1,.93-2.67,3,3,0,0,1,2.3-1,2.65,2.65,0,0,1,2.13.89A3.74,3.74,0,0,1,246,379Zm-1.15-.95a2.29,2.29,0,0,0-.47-1.51,1.59,1.59,0,0,0-1.28-.54,1.81,1.81,0,0,0-1.35.57,2.49,2.49,0,0,0-.68,1.48Z" fill="#2f2f2f"/>
-      <path d="M247.19,382.54v-1.21a3.32,3.32,0,0,0,2,.68c1,0,1.47-.33,1.47-1a.9.9,0,0,0-.12-.48,1.45,1.45,0,0,0-.35-.35,2.61,2.61,0,0,0-.5-.27l-.63-.24a7.83,7.83,0,0,1-.81-.38,2.22,2.22,0,0,1-.59-.42,1.6,1.6,0,0,1-.36-.54,1.86,1.86,0,0,1-.12-.7,1.66,1.66,0,0,1,.23-.87,1.93,1.93,0,0,1,.6-.64,2.94,2.94,0,0,1,.86-.39,4.07,4.07,0,0,1,1-.13,4,4,0,0,1,1.63.32v1.13a3.25,3.25,0,0,0-1.78-.5,1.91,1.91,0,0,0-.56.07,1.37,1.37,0,0,0-.44.2,1,1,0,0,0-.28.31.79.79,0,0,0-.1.4.9.9,0,0,0,.1.46,1.11,1.11,0,0,0,.29.33,2.54,2.54,0,0,0,.47.26l.62.25a7.3,7.3,0,0,1,.83.37,2.47,2.47,0,0,1,.63.42,1.72,1.72,0,0,1,.4.54,1.84,1.84,0,0,1,.14.74,1.68,1.68,0,0,1-.23.9,1.84,1.84,0,0,1-.61.63,2.79,2.79,0,0,1-.88.38,4.44,4.44,0,0,1-1.05.12A4.06,4.06,0,0,1,247.19,382.54Z" fill="#2f2f2f"/>
-      <path d="M253.12,382.54v-1.21a3.32,3.32,0,0,0,2,.68c1,0,1.48-.33,1.48-1a.82.82,0,0,0-.13-.48,1.4,1.4,0,0,0-.34-.35,2.43,2.43,0,0,0-.51-.27l-.62-.24c-.31-.13-.58-.25-.82-.38a2.4,2.4,0,0,1-.59-.42,1.73,1.73,0,0,1-.35-.54,1.86,1.86,0,0,1-.12-.7,1.66,1.66,0,0,1,.23-.87,1.93,1.93,0,0,1,.6-.64,2.88,2.88,0,0,1,.85-.39,4.15,4.15,0,0,1,1-.13,4,4,0,0,1,1.63.32v1.13a3.25,3.25,0,0,0-1.78-.5,2,2,0,0,0-.57.07,1.32,1.32,0,0,0-.43.2.91.91,0,0,0-.28.31.79.79,0,0,0-.1.4.9.9,0,0,0,.1.46,1,1,0,0,0,.29.33,2.79,2.79,0,0,0,.46.26l.62.25a8.42,8.42,0,0,1,.84.37,2.66,2.66,0,0,1,.63.42,1.9,1.9,0,0,1,.4.54,1.84,1.84,0,0,1,.14.74,1.77,1.77,0,0,1-.23.9,1.93,1.93,0,0,1-.61.63,2.79,2.79,0,0,1-.88.38A4.57,4.57,0,0,1,255,383,4,4,0,0,1,253.12,382.54Z" fill="#2f2f2f"/>
-      <path d="M266.53,382.79h-1.37L263.52,380a6.61,6.61,0,0,0-.44-.65,2.25,2.25,0,0,0-.43-.44,1.38,1.38,0,0,0-.48-.25,2,2,0,0,0-.58-.08h-.94v4.17H259.5V373h2.93a4.06,4.06,0,0,1,1.18.16,2.48,2.48,0,0,1,.94.49,2.19,2.19,0,0,1,.63.81,2.74,2.74,0,0,1,.23,1.15,2.61,2.61,0,0,1-.16.94,2.4,2.4,0,0,1-.44.76,2.55,2.55,0,0,1-.68.57,3.33,3.33,0,0,1-.9.37v0a2.44,2.44,0,0,1,.43.25,3.61,3.61,0,0,1,.35.33l.32.44c.11.16.23.35.36.56ZM260.65,374v3.55h1.56a2.26,2.26,0,0,0,.79-.13,1.92,1.92,0,0,0,.64-.37,1.73,1.73,0,0,0,.41-.6,2,2,0,0,0,.15-.79,1.52,1.52,0,0,0-.51-1.22,2.15,2.15,0,0,0-1.47-.44Z" fill="#2f2f2f"/>
-      <path d="M270.44,383a3.24,3.24,0,0,1-2.48-1,3.61,3.61,0,0,1-.92-2.6,3.79,3.79,0,0,1,1-2.75,3.47,3.47,0,0,1,2.6-1,3.16,3.16,0,0,1,2.45,1,3.84,3.84,0,0,1,.88,2.67,3.75,3.75,0,0,1-.95,2.68A3.29,3.29,0,0,1,270.44,383Zm.08-6.38a2.13,2.13,0,0,0-1.71.73,3,3,0,0,0-.63,2,2.87,2.87,0,0,0,.64,2,2.15,2.15,0,0,0,1.7.72,2.07,2.07,0,0,0,1.67-.7,3.74,3.74,0,0,0,0-4A2,2,0,0,0,270.52,376.57Z" fill="#2f2f2f"/>
-      <path d="M281.34,382.79h-1.13v-1.11h0A2.31,2.31,0,0,1,278,383c-1.67,0-2.51-1-2.51-3v-4.18h1.12v4c0,1.48.56,2.22,1.69,2.22a1.71,1.71,0,0,0,1.35-.6,2.32,2.32,0,0,0,.53-1.59v-4h1.13Z" fill="#2f2f2f"/>
-      <path d="M286.78,382.72a2.15,2.15,0,0,1-1,.22c-1.22,0-1.84-.68-1.84-2.05v-4.14h-1.2v-1h1.2v-1.71l1.12-.36v2.07h1.77v1H285v3.94a1.67,1.67,0,0,0,.24,1,1,1,0,0,0,.8.3,1.16,1.16,0,0,0,.73-.24Z" fill="#2f2f2f"/>
-      <path d="M293.77,379.57h-4.94a2.61,2.61,0,0,0,.63,1.8,2.14,2.14,0,0,0,1.65.64,3.47,3.47,0,0,0,2.18-.78v1a4.06,4.06,0,0,1-2.45.67,3,3,0,0,1-2.33-.95,3.93,3.93,0,0,1-.84-2.68,3.84,3.84,0,0,1,.92-2.67,3,3,0,0,1,2.3-1,2.64,2.64,0,0,1,2.13.89,3.74,3.74,0,0,1,.75,2.47Zm-1.15-.95a2.24,2.24,0,0,0-.47-1.51,1.58,1.58,0,0,0-1.28-.54,1.78,1.78,0,0,0-1.34.57,2.56,2.56,0,0,0-.69,1.48Z" fill="#2f2f2f"/>
-      <path d="M235.9,398.92a6.48,6.48,0,0,1-3.28.83,4.47,4.47,0,0,1-3.39-1.35,5,5,0,0,1-1.3-3.58,5.1,5.1,0,0,1,1.44-3.74,4.93,4.93,0,0,1,3.65-1.46,6.32,6.32,0,0,1,2.69.52v1.27a5.21,5.21,0,0,0-2.82-.75,3.51,3.51,0,0,0-2.7,1.14,4.76,4.76,0,0,0-.08,5.86,3.44,3.44,0,0,0,2.66,1.06,4.06,4.06,0,0,0,2-.46v-2.75h-2.15v-1h3.29Z" fill="#2f2f2f"/>
-      <path d="M243,399.59h-1.12v-1.1h0a2.34,2.34,0,0,1-2.15,1.26,2.31,2.31,0,0,1-1.64-.55,1.94,1.94,0,0,1-.59-1.47q0-2,2.31-2.28l2.1-.3c0-1.19-.48-1.78-1.44-1.78a3.47,3.47,0,0,0-2.29.86v-1.15a4.35,4.35,0,0,1,2.38-.66c1.65,0,2.47.88,2.47,2.62Zm-1.12-3.54-1.69.23a2.58,2.58,0,0,0-1.17.39,1.28,1.28,0,0,0,0,1.82,1.46,1.46,0,0,0,1,.32,1.84,1.84,0,0,0,1.38-.58,2.13,2.13,0,0,0,.54-1.49Z" fill="#2f2f2f"/>
-      <path d="M248.25,399.52a2.1,2.1,0,0,1-1.05.22c-1.22,0-1.84-.68-1.84-2.05v-4.14h-1.2v-1h1.2v-1.71l1.13-.36v2.07h1.76v1h-1.76v3.94a1.69,1.69,0,0,0,.23,1,1,1,0,0,0,.8.31,1.16,1.16,0,0,0,.73-.24Z" fill="#2f2f2f"/>
-      <path d="M255.24,396.37H250.3a2.61,2.61,0,0,0,.63,1.8,2.14,2.14,0,0,0,1.65.64,3.45,3.45,0,0,0,2.18-.78v1.05a4.05,4.05,0,0,1-2.44.67,3,3,0,0,1-2.33-.95,4.49,4.49,0,0,1,.07-5.35,3,3,0,0,1,2.3-1,2.64,2.64,0,0,1,2.13.89,3.74,3.74,0,0,1,.75,2.47Zm-1.15-.95a2.29,2.29,0,0,0-.46-1.51,1.61,1.61,0,0,0-1.29-.54,1.81,1.81,0,0,0-1.34.57,2.56,2.56,0,0,0-.69,1.48Z" fill="#2f2f2f"/>
-      <path d="M265.72,392.59l-2.1,7h-1.16l-1.45-5a3.82,3.82,0,0,1-.11-.65h0a3.07,3.07,0,0,1-.15.63l-1.56,5h-1.12l-2.12-7h1.17l1.45,5.26a3,3,0,0,1,.1.63h.05a3.31,3.31,0,0,1,.13-.64l1.61-5.25h1l1.44,5.28a3.7,3.7,0,0,1,.11.62h.05a2.9,2.9,0,0,1,.12-.62l1.42-5.28Z" fill="#2f2f2f"/>
-      <path d="M271.89,399.59h-1.12v-1.1h0a2.33,2.33,0,0,1-2.15,1.26,2.31,2.31,0,0,1-1.64-.55,1.94,1.94,0,0,1-.59-1.47q0-2,2.31-2.28l2.1-.3c0-1.19-.48-1.78-1.44-1.78a3.47,3.47,0,0,0-2.29.86v-1.15a4.35,4.35,0,0,1,2.38-.66c1.65,0,2.47.88,2.47,2.62Zm-1.12-3.54-1.69.23a2.58,2.58,0,0,0-1.17.39,1.28,1.28,0,0,0,0,1.82,1.46,1.46,0,0,0,1,.32,1.86,1.86,0,0,0,1.38-.58,2.13,2.13,0,0,0,.54-1.49Z" fill="#2f2f2f"/>
-      <path d="M279.4,392.59l-3.22,8.12c-.57,1.45-1.38,2.17-2.42,2.17a2.55,2.55,0,0,1-.73-.09v-1a2.1,2.1,0,0,0,.66.12,1.38,1.38,0,0,0,1.28-1l.56-1.32-2.74-7H274l1.89,5.39c0,.06.07.24.14.53h0c0-.11.07-.28.14-.52l2-5.4Z" fill="#2f2f2f"/>
-    </g>
-    <g>
-      <path d="M213.15,312.62a6.64,6.64,0,0,1-3.29.83,4.49,4.49,0,0,1-3.39-1.35,5,5,0,0,1-1.3-3.58,5.1,5.1,0,0,1,1.44-3.74,4.93,4.93,0,0,1,3.65-1.46,6.17,6.17,0,0,1,2.69.52v1.27a5.19,5.19,0,0,0-2.82-.75,3.51,3.51,0,0,0-2.7,1.14,4.74,4.74,0,0,0-.07,5.86,3.41,3.41,0,0,0,2.65,1.06,4.06,4.06,0,0,0,2-.46v-2.75h-2.15v-1h3.3Z" fill="#2f2f2f"/>
-      <path d="M220.23,313.29h-1.12V312.2h0a2.34,2.34,0,0,1-2.15,1.25,2.31,2.31,0,0,1-1.64-.55,1.94,1.94,0,0,1-.59-1.47q0-2,2.31-2.28l2.1-.3c0-1.19-.48-1.78-1.44-1.78a3.47,3.47,0,0,0-2.29.86v-1.15a4.35,4.35,0,0,1,2.38-.66c1.65,0,2.47.87,2.47,2.62Zm-1.12-3.54-1.69.23a2.58,2.58,0,0,0-1.17.39,1.09,1.09,0,0,0-.4,1,1,1,0,0,0,.37.83,1.37,1.37,0,0,0,1,.33,1.81,1.81,0,0,0,1.38-.59,2.08,2.08,0,0,0,.54-1.47Z" fill="#2f2f2f"/>
-      <path d="M225.49,313.22a2.1,2.1,0,0,1-1.05.22c-1.22,0-1.83-.68-1.83-2.05v-4.14H221.4v-1h1.21v-1.71l1.12-.36v2.07h1.76v1h-1.76v3.94a1.67,1.67,0,0,0,.24,1,1,1,0,0,0,.79.3,1.16,1.16,0,0,0,.73-.24Z" fill="#2f2f2f"/>
-      <path d="M232.48,310.07h-4.94a2.61,2.61,0,0,0,.63,1.8,2.14,2.14,0,0,0,1.65.64,3.45,3.45,0,0,0,2.18-.78v1a4.05,4.05,0,0,1-2.44.67,3,3,0,0,1-2.33-.95,4.49,4.49,0,0,1,.07-5.35,3,3,0,0,1,2.31-1,2.63,2.63,0,0,1,2.12.89,3.74,3.74,0,0,1,.75,2.47Zm-1.15-.95a2.29,2.29,0,0,0-.46-1.51,1.61,1.61,0,0,0-1.29-.54,1.81,1.81,0,0,0-1.34.57,2.56,2.56,0,0,0-.69,1.48Z" fill="#2f2f2f"/>
-      <path d="M243,306.29l-2.1,7H239.7l-1.45-5a3.82,3.82,0,0,1-.11-.65h0a3.07,3.07,0,0,1-.15.63l-1.56,5h-1.12l-2.12-7h1.17l1.45,5.26a3,3,0,0,1,.1.63h.05a3.31,3.31,0,0,1,.13-.64l1.61-5.25h1l1.44,5.28a3.66,3.66,0,0,1,.11.63h.05a2.86,2.86,0,0,1,.12-.63l1.42-5.28Z" fill="#2f2f2f"/>
-      <path d="M249.13,313.29H248V312.2h0a2.34,2.34,0,0,1-2.15,1.25,2.31,2.31,0,0,1-1.64-.55,1.94,1.94,0,0,1-.59-1.47q0-2,2.31-2.28l2.1-.3c0-1.19-.48-1.78-1.44-1.78a3.47,3.47,0,0,0-2.29.86v-1.15a4.35,4.35,0,0,1,2.38-.66c1.65,0,2.47.87,2.47,2.62ZM248,309.75l-1.69.23a2.58,2.58,0,0,0-1.17.39,1.09,1.09,0,0,0-.4,1,1,1,0,0,0,.37.83,1.37,1.37,0,0,0,1,.33,1.81,1.81,0,0,0,1.38-.59,2.08,2.08,0,0,0,.54-1.47Z" fill="#2f2f2f"/>
-      <path d="M256.64,306.29l-3.22,8.12c-.57,1.45-1.38,2.17-2.42,2.17a2.55,2.55,0,0,1-.73-.09v-1a2.1,2.1,0,0,0,.66.12,1.38,1.38,0,0,0,1.28-1l.56-1.32-2.74-7h1.25l1.89,5.39c0,.06.07.24.14.53h0c0-.11.07-.28.14-.52l2-5.4Z" fill="#2f2f2f"/>
-      <path d="M261.26,313v-1.21a3.32,3.32,0,0,0,2,.68c1,0,1.48-.33,1.48-1a.82.82,0,0,0-.13-.48,1.25,1.25,0,0,0-.34-.35,2.61,2.61,0,0,0-.5-.27l-.63-.24c-.31-.13-.58-.25-.82-.38a2.17,2.17,0,0,1-.58-.42,1.6,1.6,0,0,1-.36-.54,1.86,1.86,0,0,1-.12-.7,1.66,1.66,0,0,1,.23-.87,1.93,1.93,0,0,1,.6-.64,2.82,2.82,0,0,1,.86-.39,4.07,4.07,0,0,1,1-.13,4,4,0,0,1,1.63.32v1.13a3.25,3.25,0,0,0-1.78-.5,2,2,0,0,0-.57.07,1.32,1.32,0,0,0-.43.2.91.91,0,0,0-.28.31.79.79,0,0,0-.1.4.92.92,0,0,0,.1.46,1,1,0,0,0,.29.33,2.79,2.79,0,0,0,.46.26l.63.25a8.19,8.19,0,0,1,.83.37,2.47,2.47,0,0,1,.63.42,1.72,1.72,0,0,1,.4.54,1.84,1.84,0,0,1,.14.74,1.77,1.77,0,0,1-.23.9,2,2,0,0,1-.61.63,2.79,2.79,0,0,1-.88.38,4.57,4.57,0,0,1-1.05.12A4.06,4.06,0,0,1,261.26,313Z" fill="#2f2f2f"/>
-      <path d="M273.17,313.29H272v-1.11h0a2.31,2.31,0,0,1-2.16,1.27c-1.67,0-2.51-1-2.51-3v-4.18h1.12v4c0,1.48.56,2.22,1.69,2.22a1.69,1.69,0,0,0,1.35-.61,2.27,2.27,0,0,0,.53-1.58v-4h1.13Z" fill="#2f2f2f"/>
-      <path d="M276.42,312.28h0v1h-1.12V302.93h1.12v4.59h0a2.66,2.66,0,0,1,2.42-1.4,2.59,2.59,0,0,1,2.11.94,3.88,3.88,0,0,1,.76,2.52,4.37,4.37,0,0,1-.85,2.82,2.86,2.86,0,0,1-2.34,1.05A2.3,2.3,0,0,1,276.42,312.28Zm0-2.83v1a2.05,2.05,0,0,0,.57,1.47,1.84,1.84,0,0,0,1.43.61,1.89,1.89,0,0,0,1.6-.78,3.61,3.61,0,0,0,.57-2.17,2.81,2.81,0,0,0-.54-1.83,1.78,1.78,0,0,0-1.46-.66,2,2,0,0,0-1.57.68A2.47,2.47,0,0,0,276.39,309.45Z" fill="#2f2f2f"/>
-      <path d="M289.24,313.29h-1.12v-4c0-1.49-.54-2.23-1.63-2.23a1.77,1.77,0,0,0-1.39.63,2.32,2.32,0,0,0-.55,1.6v4h-1.12v-7h1.12v1.16h0a2.53,2.53,0,0,1,2.29-1.33,2.12,2.12,0,0,1,1.76.75,3.27,3.27,0,0,1,.61,2.14Z" fill="#2f2f2f"/>
-      <path d="M296.94,310.07H292a2.61,2.61,0,0,0,.63,1.8,2.14,2.14,0,0,0,1.65.64,3.45,3.45,0,0,0,2.18-.78v1a4.05,4.05,0,0,1-2.44.67,3,3,0,0,1-2.33-.95,4.49,4.49,0,0,1,.07-5.35,3,3,0,0,1,2.3-1,2.64,2.64,0,0,1,2.13.89,3.74,3.74,0,0,1,.75,2.47Zm-1.15-.95a2.29,2.29,0,0,0-.46-1.51,1.61,1.61,0,0,0-1.29-.54,1.81,1.81,0,0,0-1.34.57,2.56,2.56,0,0,0-.69,1.48Z" fill="#2f2f2f"/>
-      <path d="M301.87,313.22a2.15,2.15,0,0,1-1.05.22c-1.22,0-1.84-.68-1.84-2.05v-4.14h-1.2v-1H299v-1.71l1.12-.36v2.07h1.77v1H300.1v3.94a1.67,1.67,0,0,0,.24,1,1,1,0,0,0,.8.3,1.16,1.16,0,0,0,.73-.24Z" fill="#2f2f2f"/>
-    </g>
-    <g>
-      <path d="M368.56,312.88a5.74,5.74,0,0,1-2.7.57,4.38,4.38,0,0,1-3.35-1.34,5,5,0,0,1-1.26-3.54,5.19,5.19,0,0,1,1.42-3.8,4.76,4.76,0,0,1,3.58-1.45,5.72,5.72,0,0,1,2.31.41V305a4.68,4.68,0,0,0-2.32-.59,3.59,3.59,0,0,0-2.74,1.13,4.25,4.25,0,0,0-1.05,3,4.07,4.07,0,0,0,1,2.86,3.36,3.36,0,0,0,2.58,1.06,4.79,4.79,0,0,0,2.55-.66Z" fill="#2f2f2f"/>
-      <path d="M375.84,310.07h-4.95a2.61,2.61,0,0,0,.63,1.8,2.15,2.15,0,0,0,1.66.64,3.44,3.44,0,0,0,2.17-.78v1a4.05,4.05,0,0,1-2.44.67,3,3,0,0,1-2.33-.95,3.88,3.88,0,0,1-.85-2.68,3.84,3.84,0,0,1,.93-2.67,3,3,0,0,1,2.3-1,2.63,2.63,0,0,1,2.12.89,3.74,3.74,0,0,1,.76,2.47Zm-1.15-.95a2.29,2.29,0,0,0-.47-1.51,1.6,1.6,0,0,0-1.28-.54,1.81,1.81,0,0,0-1.35.57,2.49,2.49,0,0,0-.68,1.48Z" fill="#2f2f2f"/>
-      <path d="M383.33,313.29h-1.12v-4c0-1.49-.55-2.23-1.63-2.23a1.77,1.77,0,0,0-1.39.63,2.32,2.32,0,0,0-.55,1.6v4h-1.12v-7h1.12v1.16h0a2.52,2.52,0,0,1,2.29-1.33,2.14,2.14,0,0,1,1.76.75,3.27,3.27,0,0,1,.61,2.14Z" fill="#2f2f2f"/>
-      <path d="M388.56,313.22a2.15,2.15,0,0,1-1.05.22c-1.22,0-1.84-.68-1.84-2.05v-4.14h-1.2v-1h1.2v-1.71l1.12-.36v2.07h1.77v1h-1.77v3.94a1.67,1.67,0,0,0,.24,1,1,1,0,0,0,.8.3,1.16,1.16,0,0,0,.73-.24Z" fill="#2f2f2f"/>
-      <path d="M393.59,307.42a1.39,1.39,0,0,0-.85-.22,1.42,1.42,0,0,0-1.2.67,3.17,3.17,0,0,0-.48,1.85v3.57h-1.12v-7h1.12v1.44h0a2.46,2.46,0,0,1,.73-1.15,1.64,1.64,0,0,1,1.1-.41,2,2,0,0,1,.67.09Z" fill="#2f2f2f"/>
-      <path d="M399.76,313.29h-1.12V312.2h0a2.37,2.37,0,0,1-2.16,1.25,2.27,2.27,0,0,1-1.63-.55,1.91,1.91,0,0,1-.6-1.47q0-2,2.31-2.28l2.1-.3c0-1.19-.48-1.78-1.44-1.78a3.47,3.47,0,0,0-2.28.86v-1.15a4.32,4.32,0,0,1,2.38-.66c1.64,0,2.46.87,2.46,2.62Zm-1.12-3.54L397,310a2.58,2.58,0,0,0-1.17.39,1.09,1.09,0,0,0-.4,1,1,1,0,0,0,.37.83,1.39,1.39,0,0,0,1,.33,1.8,1.8,0,0,0,1.38-.59,2.08,2.08,0,0,0,.54-1.47Z" fill="#2f2f2f"/>
-      <path d="M402.91,313.29h-1.13V302.93h1.13Z" fill="#2f2f2f"/>
-      <path d="M405.59,304.51a.73.73,0,0,1-.51-.2.7.7,0,0,1-.21-.52.72.72,0,0,1,.21-.53.69.69,0,0,1,.51-.2.73.73,0,0,1,.53.2.72.72,0,0,1,.21.53.69.69,0,0,1-.21.51A.74.74,0,0,1,405.59,304.51Zm.55,8.78H405v-7h1.12Z" fill="#2f2f2f"/>
-      <path d="M413.25,306.61l-4.14,5.72h4.1v1h-5.75v-.35l4.14-5.69h-3.75v-1h5.4Z" fill="#2f2f2f"/>
-      <path d="M420.16,310.07h-5a2.61,2.61,0,0,0,.63,1.8,2.16,2.16,0,0,0,1.66.64,3.42,3.42,0,0,0,2.17-.78v1a4,4,0,0,1-2.44.67,3,3,0,0,1-2.33-.95,3.88,3.88,0,0,1-.85-2.68,3.84,3.84,0,0,1,.93-2.67,3,3,0,0,1,2.3-1,2.63,2.63,0,0,1,2.12.89,3.69,3.69,0,0,1,.76,2.47Zm-1.15-.95a2.29,2.29,0,0,0-.47-1.51,1.6,1.6,0,0,0-1.28-.54,1.81,1.81,0,0,0-1.35.57,2.49,2.49,0,0,0-.68,1.48Z" fill="#2f2f2f"/>
-      <path d="M427.89,313.29h-1.12V312.1h0a2.83,2.83,0,0,1-4.52.41,3.88,3.88,0,0,1-.79-2.56,4.21,4.21,0,0,1,.88-2.78,2.88,2.88,0,0,1,2.33-1.05,2.25,2.25,0,0,1,2.1,1.14h0v-4.33h1.12Zm-1.12-3.17v-1a2,2,0,0,0-.56-1.43,1.87,1.87,0,0,0-1.43-.59,1.93,1.93,0,0,0-1.61.75,3.3,3.3,0,0,0-.59,2.08,3,3,0,0,0,.57,1.91,1.82,1.82,0,0,0,1.51.7,1.91,1.91,0,0,0,1.52-.68A2.52,2.52,0,0,0,426.77,310.12Z" fill="#2f2f2f"/>
-      <path d="M348.67,329.84v-1.21a3.34,3.34,0,0,0,2,.68c1,0,1.48-.33,1.48-1a.9.9,0,0,0-.13-.48,1.25,1.25,0,0,0-.34-.35,2.7,2.7,0,0,0-.51-.27l-.62-.24a8.07,8.07,0,0,1-.82-.38,2.22,2.22,0,0,1-.59-.42,1.73,1.73,0,0,1-.35-.54,1.86,1.86,0,0,1-.12-.7,1.66,1.66,0,0,1,.22-.87,1.93,1.93,0,0,1,.6-.64,2.94,2.94,0,0,1,.86-.39,4.09,4.09,0,0,1,1-.13,4,4,0,0,1,1.62.32v1.13a3.19,3.19,0,0,0-1.77-.5,2,2,0,0,0-.57.07,1.32,1.32,0,0,0-.43.2,1,1,0,0,0-.29.31.9.9,0,0,0-.09.4,1,1,0,0,0,.09.46,1.28,1.28,0,0,0,.29.33,2.92,2.92,0,0,0,.47.26l.62.25a8.42,8.42,0,0,1,.84.37,2.59,2.59,0,0,1,.62.42,1.58,1.58,0,0,1,.4.54,1.69,1.69,0,0,1,.14.74,1.77,1.77,0,0,1-.22.9,2.07,2.07,0,0,1-.62.63,2.7,2.7,0,0,1-.88.38,4.42,4.42,0,0,1-1,.12A4.1,4.1,0,0,1,348.67,329.84Z" fill="#2f2f2f"/>
-      <path d="M360.63,326.87h-4.94a2.56,2.56,0,0,0,.62,1.8,2.18,2.18,0,0,0,1.66.64,3.42,3.42,0,0,0,2.17-.78v1.05a4,4,0,0,1-2.44.67,3,3,0,0,1-2.33-.95,3.93,3.93,0,0,1-.85-2.68,3.84,3.84,0,0,1,.93-2.67,3,3,0,0,1,2.3-1,2.64,2.64,0,0,1,2.13.89,3.74,3.74,0,0,1,.75,2.47Zm-1.15-.95a2.24,2.24,0,0,0-.47-1.51,1.59,1.59,0,0,0-1.28-.54,1.81,1.81,0,0,0-1.35.57,2.55,2.55,0,0,0-.68,1.48Z" fill="#2f2f2f"/>
-      <path d="M366,324.22a1.37,1.37,0,0,0-.85-.22,1.45,1.45,0,0,0-1.2.67,3.17,3.17,0,0,0-.48,1.85v3.57h-1.12v-7h1.12v1.44h0a2.46,2.46,0,0,1,.73-1.15,1.65,1.65,0,0,1,1.1-.41,1.92,1.92,0,0,1,.67.09Z" fill="#2f2f2f"/>
-      <path d="M373.23,323.09l-2.78,7h-1.11l-2.65-7h1.23l1.78,5.08a5.43,5.43,0,0,1,.25,1h0a4.92,4.92,0,0,1,.22-.95l1.86-5.11Z" fill="#2f2f2f"/>
-      <path d="M375.05,321.31a.73.73,0,0,1-.51-.2.71.71,0,0,1-.22-.52.73.73,0,0,1,.22-.53.69.69,0,0,1,.51-.2.71.71,0,0,1,.52.2.69.69,0,0,1,.22.53.67.67,0,0,1-.22.51A.72.72,0,0,1,375.05,321.31Zm.55,8.78h-1.13v-7h1.13Z" fill="#2f2f2f"/>
-      <path d="M382.51,329.77a3.7,3.7,0,0,1-1.92.48,3.16,3.16,0,0,1-2.41-1,3.55,3.55,0,0,1-.92-2.53,3.89,3.89,0,0,1,1-2.78,3.46,3.46,0,0,1,2.65-1.05,3.64,3.64,0,0,1,1.62.35v1.14a2.87,2.87,0,0,0-1.67-.54,2.24,2.24,0,0,0-1.76.77,2.94,2.94,0,0,0-.68,2,2.79,2.79,0,0,0,.64,1.94,2.25,2.25,0,0,0,1.74.71,2.78,2.78,0,0,0,1.72-.61Z" fill="#2f2f2f"/>
-      <path d="M389.68,326.87h-4.94a2.52,2.52,0,0,0,.63,1.8,2.14,2.14,0,0,0,1.65.64,3.42,3.42,0,0,0,2.17-.78v1.05a4,4,0,0,1-2.44.67,3,3,0,0,1-2.33-.95,3.93,3.93,0,0,1-.85-2.68,3.84,3.84,0,0,1,.93-2.67,3,3,0,0,1,2.3-1,2.65,2.65,0,0,1,2.13.89,3.74,3.74,0,0,1,.75,2.47Zm-1.15-.95a2.24,2.24,0,0,0-.47-1.51,1.59,1.59,0,0,0-1.28-.54,1.81,1.81,0,0,0-1.35.57,2.55,2.55,0,0,0-.68,1.48Z" fill="#2f2f2f"/>
-      <path d="M390.92,329.84v-1.21a3.32,3.32,0,0,0,2,.68c1,0,1.47-.33,1.47-1a.9.9,0,0,0-.12-.48,1.41,1.41,0,0,0-.34-.35,3.05,3.05,0,0,0-.51-.27l-.63-.24a7.83,7.83,0,0,1-.81-.38,2.22,2.22,0,0,1-.59-.42,1.6,1.6,0,0,1-.36-.54,1.86,1.86,0,0,1-.12-.7,1.66,1.66,0,0,1,.23-.87,1.93,1.93,0,0,1,.6-.64,2.94,2.94,0,0,1,.86-.39,4.07,4.07,0,0,1,1-.13,4,4,0,0,1,1.63.32v1.13a3.22,3.22,0,0,0-1.78-.5,1.91,1.91,0,0,0-.56.07,1.37,1.37,0,0,0-.44.2,1,1,0,0,0-.28.31.91.91,0,0,0-.1.4,1,1,0,0,0,.1.46,1.11,1.11,0,0,0,.29.33,2.92,2.92,0,0,0,.47.26l.62.25a7.3,7.3,0,0,1,.83.37,2.47,2.47,0,0,1,.63.42,1.58,1.58,0,0,1,.4.54,1.94,1.94,0,0,1-.09,1.64,1.93,1.93,0,0,1-.61.63,2.7,2.7,0,0,1-.88.38,4.44,4.44,0,0,1-1,.12A4.06,4.06,0,0,1,390.92,329.84Z" fill="#2f2f2f"/>
-      <path d="M400.7,329.84v-1.21a3.32,3.32,0,0,0,2,.68c1,0,1.48-.33,1.48-1a.82.82,0,0,0-.13-.48,1.25,1.25,0,0,0-.34-.35,2.61,2.61,0,0,0-.5-.27l-.63-.24c-.31-.13-.58-.25-.82-.38a2.4,2.4,0,0,1-.59-.42,1.73,1.73,0,0,1-.35-.54,1.86,1.86,0,0,1-.12-.7,1.66,1.66,0,0,1,.22-.87,2.07,2.07,0,0,1,.61-.64,2.88,2.88,0,0,1,.85-.39,4.22,4.22,0,0,1,1-.13,4,4,0,0,1,1.63.32v1.13a3.25,3.25,0,0,0-1.78-.5,2,2,0,0,0-.57.07,1.32,1.32,0,0,0-.43.2.91.91,0,0,0-.28.31.79.79,0,0,0-.1.4.92.92,0,0,0,.1.46,1,1,0,0,0,.29.33,2.79,2.79,0,0,0,.46.26l.62.25a8.42,8.42,0,0,1,.84.37,2.88,2.88,0,0,1,.63.42,1.9,1.9,0,0,1,.4.54,1.84,1.84,0,0,1,.14.74,1.77,1.77,0,0,1-.23.9,2,2,0,0,1-.61.63,2.75,2.75,0,0,1-.89.38,4.42,4.42,0,0,1-1,.12A4,4,0,0,1,400.7,329.84Z" fill="#2f2f2f"/>
-      <path d="M412.6,330.09h-1.12V329h0a2.31,2.31,0,0,1-2.16,1.27c-1.67,0-2.51-1-2.51-3v-4.18h1.12v4c0,1.48.56,2.22,1.69,2.22a1.69,1.69,0,0,0,1.35-.61,2.27,2.27,0,0,0,.53-1.58v-4h1.12Z" fill="#2f2f2f"/>
-      <path d="M415.86,329.08h0v1h-1.12V319.73h1.12v4.59h0a2.66,2.66,0,0,1,2.42-1.4,2.59,2.59,0,0,1,2.11.94,3.88,3.88,0,0,1,.76,2.52,4.37,4.37,0,0,1-.85,2.82,2.86,2.86,0,0,1-2.34,1.05A2.3,2.3,0,0,1,415.86,329.08Zm0-2.83v1a2.05,2.05,0,0,0,.57,1.47,2,2,0,0,0,3-.17,3.54,3.54,0,0,0,.58-2.17,2.81,2.81,0,0,0-.54-1.83,1.79,1.79,0,0,0-1.46-.66,2,2,0,0,0-1.57.68A2.47,2.47,0,0,0,415.83,326.25Z" fill="#2f2f2f"/>
-      <path d="M428.68,330.09h-1.12v-4c0-1.49-.55-2.23-1.63-2.23a1.77,1.77,0,0,0-1.39.63,2.32,2.32,0,0,0-.55,1.6v4h-1.12v-7H424v1.16h0a2.52,2.52,0,0,1,2.29-1.33,2.14,2.14,0,0,1,1.76.75,3.31,3.31,0,0,1,.61,2.14Z" fill="#2f2f2f"/>
-      <path d="M436.38,326.87h-4.94a2.61,2.61,0,0,0,.63,1.8,2.14,2.14,0,0,0,1.65.64,3.47,3.47,0,0,0,2.18-.78v1.05a4.05,4.05,0,0,1-2.44.67,3,3,0,0,1-2.34-.95,3.93,3.93,0,0,1-.84-2.68,3.88,3.88,0,0,1,.92-2.67,3,3,0,0,1,2.3-1,2.64,2.64,0,0,1,2.13.89,3.74,3.74,0,0,1,.75,2.47Zm-1.15-.95a2.24,2.24,0,0,0-.47-1.51,1.58,1.58,0,0,0-1.28-.54,1.79,1.79,0,0,0-1.34.57,2.56,2.56,0,0,0-.69,1.48Z" fill="#2f2f2f"/>
-      <path d="M441.31,330a2.15,2.15,0,0,1-1.05.22c-1.23,0-1.84-.68-1.84-2.05v-4.14h-1.2v-1h1.2v-1.71l1.12-.36v2.07h1.77v1h-1.77V328a1.61,1.61,0,0,0,.24,1,.94.94,0,0,0,.79.31,1.17,1.17,0,0,0,.74-.24Z" fill="#2f2f2f"/>
-    </g>
-    <g>
-      <path d="M356.32,396.89v-9.8H359c3.46,0,5.18,1.59,5.18,4.77a4.81,4.81,0,0,1-1.44,3.65,5.31,5.31,0,0,1-3.85,1.38Zm1.14-8.77v7.73h1.47a4.16,4.16,0,0,0,3-1,3.91,3.91,0,0,0,1.07-2.93q0-3.76-4-3.77Z" fill="#2f2f2f"/>
-      <path d="M374,396.89h-1.41l-5.05-7.81a4,4,0,0,1-.31-.62h0a11.85,11.85,0,0,1,.05,1.35v7.08h-1.15v-9.8h1.5l4.9,7.69c.21.32.34.53.4.65h0a9.58,9.58,0,0,1-.07-1.44v-6.9H374Z" fill="#2f2f2f"/>
-      <path d="M376,396.49v-1.35a2.37,2.37,0,0,0,.56.37,3.71,3.71,0,0,0,.68.27,4.74,4.74,0,0,0,.72.18,4.16,4.16,0,0,0,.67.06,2.63,2.63,0,0,0,1.58-.39,1.33,1.33,0,0,0,.53-1.13,1.27,1.27,0,0,0-.18-.69,1.73,1.73,0,0,0-.48-.54,5.42,5.42,0,0,0-.73-.47l-.9-.46c-.35-.18-.66-.35-1-.53a3.91,3.91,0,0,1-.77-.59,2.5,2.5,0,0,1-.52-.73,2.3,2.3,0,0,1-.19-.95,2.21,2.21,0,0,1,.3-1.17,2.39,2.39,0,0,1,.77-.81,3.26,3.26,0,0,1,1.09-.48,4.76,4.76,0,0,1,1.25-.16,4.81,4.81,0,0,1,2.11.35v1.29a4.19,4.19,0,0,0-3-.52,2,2,0,0,0-.67.26,1.38,1.38,0,0,0-.48.45,1.27,1.27,0,0,0-.18.69,1.33,1.33,0,0,0,.14.65,1.59,1.59,0,0,0,.41.5,3.7,3.7,0,0,0,.67.43l.9.47c.35.17.69.35,1,.54a5.51,5.51,0,0,1,.83.64,3,3,0,0,1,.56.77,2.19,2.19,0,0,1,.21,1,2.54,2.54,0,0,1-.28,1.23,2.33,2.33,0,0,1-.77.82,3.24,3.24,0,0,1-1.11.45,5.71,5.71,0,0,1-1.33.14l-.57,0-.7-.11a5.92,5.92,0,0,1-.67-.18A2,2,0,0,1,376,396.49Z" fill="#2f2f2f"/>
-      <path d="M387.13,396.64v-1.21a3.32,3.32,0,0,0,2,.68c1,0,1.48-.33,1.48-1a.81.81,0,0,0-.13-.47,1.4,1.4,0,0,0-.34-.35,2.43,2.43,0,0,0-.51-.27l-.62-.25a7.11,7.11,0,0,1-.82-.37,2.4,2.4,0,0,1-.59-.42,1.73,1.73,0,0,1-.35-.54,1.86,1.86,0,0,1-.12-.7,1.66,1.66,0,0,1,.22-.87,2,2,0,0,1,.61-.64,2.88,2.88,0,0,1,.85-.39,4.15,4.15,0,0,1,1-.13,4.05,4.05,0,0,1,1.63.32v1.13a3.25,3.25,0,0,0-1.78-.5,2,2,0,0,0-.57.07,1.56,1.56,0,0,0-.43.2.91.91,0,0,0-.28.31.79.79,0,0,0-.1.4.92.92,0,0,0,.1.46,1,1,0,0,0,.29.33,2.43,2.43,0,0,0,.46.26l.62.25a8.42,8.42,0,0,1,.84.37,2.88,2.88,0,0,1,.63.42,1.9,1.9,0,0,1,.4.54,1.84,1.84,0,0,1,.14.74,1.77,1.77,0,0,1-.23.9,2,2,0,0,1-.61.63,2.75,2.75,0,0,1-.89.38,4.42,4.42,0,0,1-1,.12A4,4,0,0,1,387.13,396.64Z" fill="#2f2f2f"/>
-      <path d="M399.08,393.67h-4.94a2.56,2.56,0,0,0,.63,1.8,2.14,2.14,0,0,0,1.65.64,3.42,3.42,0,0,0,2.17-.78v1.05a4,4,0,0,1-2.44.67,3,3,0,0,1-2.33-.95,3.93,3.93,0,0,1-.84-2.68,3.84,3.84,0,0,1,.92-2.67,3,3,0,0,1,2.3-1,2.64,2.64,0,0,1,2.13.89,3.74,3.74,0,0,1,.75,2.47Zm-1.15-.95a2.24,2.24,0,0,0-.47-1.51,1.58,1.58,0,0,0-1.28-.54,1.78,1.78,0,0,0-1.34.57,2.56,2.56,0,0,0-.69,1.48Z" fill="#2f2f2f"/>
-      <path d="M404.41,391a1.36,1.36,0,0,0-.84-.22,1.42,1.42,0,0,0-1.2.67,3.1,3.1,0,0,0-.49,1.85v3.57h-1.12v-7h1.12v1.44h0a2.41,2.41,0,0,1,.73-1.15,1.65,1.65,0,0,1,1.1-.41,1.89,1.89,0,0,1,.67.09Z" fill="#2f2f2f"/>
-      <path d="M411.69,389.89l-2.79,7h-1.1l-2.66-7h1.23l1.78,5.08a4.7,4.7,0,0,1,.25,1h0a4.92,4.92,0,0,1,.22-.95l1.86-5.11Z" fill="#2f2f2f"/>
-      <path d="M413.5,388.11a.73.73,0,0,1-.51-.2.7.7,0,0,1-.21-.52.72.72,0,0,1,.21-.53.69.69,0,0,1,.51-.2.72.72,0,0,1,.74.73.67.67,0,0,1-.22.51A.7.7,0,0,1,413.5,388.11Zm.55,8.78h-1.12v-7h1.12Z" fill="#2f2f2f"/>
-      <path d="M421,396.57a3.69,3.69,0,0,1-1.91.48,3.16,3.16,0,0,1-2.42-1,3.55,3.55,0,0,1-.92-2.53,3.89,3.89,0,0,1,1-2.78,3.46,3.46,0,0,1,2.65-1,3.64,3.64,0,0,1,1.62.35v1.14a2.86,2.86,0,0,0-1.66-.54,2.21,2.21,0,0,0-1.76.77,2.9,2.9,0,0,0-.69,2,2.74,2.74,0,0,0,.65,1.94,2.21,2.21,0,0,0,1.73.71,2.78,2.78,0,0,0,1.72-.61Z" fill="#2f2f2f"/>
-      <path d="M428.13,393.67h-4.94a2.61,2.61,0,0,0,.63,1.8,2.14,2.14,0,0,0,1.65.64,3.42,3.42,0,0,0,2.17-.78v1.05a4,4,0,0,1-2.44.67,3,3,0,0,1-2.33-.95,3.93,3.93,0,0,1-.84-2.68,3.84,3.84,0,0,1,.92-2.67,3,3,0,0,1,2.3-1,2.64,2.64,0,0,1,2.13.89,3.74,3.74,0,0,1,.75,2.47Zm-1.15-.95a2.24,2.24,0,0,0-.47-1.51,1.58,1.58,0,0,0-1.28-.54,1.81,1.81,0,0,0-1.35.57,2.62,2.62,0,0,0-.68,1.48Z" fill="#2f2f2f"/>
-      <path d="M429.37,396.64v-1.21a3.34,3.34,0,0,0,2,.68c1,0,1.48-.33,1.48-1a.89.89,0,0,0-.13-.47,1.6,1.6,0,0,0-.34-.35,2.7,2.7,0,0,0-.51-.27l-.62-.25a6.41,6.41,0,0,1-.82-.37,2.22,2.22,0,0,1-.59-.42,1.57,1.57,0,0,1-.35-.54,1.86,1.86,0,0,1-.12-.7,1.66,1.66,0,0,1,.22-.87,1.93,1.93,0,0,1,.6-.64,2.94,2.94,0,0,1,.86-.39,4.09,4.09,0,0,1,1-.13,4,4,0,0,1,1.62.32v1.13a3.19,3.19,0,0,0-1.77-.5,2,2,0,0,0-.57.07,1.63,1.63,0,0,0-.44.2,1,1,0,0,0-.28.31.91.91,0,0,0-.1.4,1,1,0,0,0,.1.46,1.28,1.28,0,0,0,.29.33,2.92,2.92,0,0,0,.47.26l.62.25a7.3,7.3,0,0,1,.83.37,2.47,2.47,0,0,1,.63.42,1.58,1.58,0,0,1,.4.54,1.94,1.94,0,0,1-.09,1.64,1.84,1.84,0,0,1-.61.63,2.7,2.7,0,0,1-.88.38,4.42,4.42,0,0,1-1,.12A4.1,4.1,0,0,1,429.37,396.64Z" fill="#2f2f2f"/>
-    </g>
-    <g>
-      <path d="M465.72,27.49h-1.27l-1-2.74h-4.15l-1,2.74H457l3.76-9.8H462ZM463,23.71l-1.54-4.17a4.18,4.18,0,0,1-.15-.66h0a4,4,0,0,1-.16.66l-1.52,4.17Z" fill="#2f2f2f"/>
-      <path d="M472.33,20.82l-4.14,5.72h4.1v.95h-5.75v-.34l4.15-5.7h-3.76v-1h5.4Z" fill="#2f2f2f"/>
-      <path d="M479.43,27.49h-1.12v-1.1h0a2.29,2.29,0,0,1-2.16,1.27c-1.67,0-2.5-1-2.5-3V20.49h1.11v4c0,1.48.57,2.22,1.7,2.22a1.72,1.72,0,0,0,1.35-.61,2.32,2.32,0,0,0,.53-1.58v-4h1.12Z" fill="#2f2f2f"/>
-      <path d="M485.19,21.63a1.39,1.39,0,0,0-.85-.23,1.43,1.43,0,0,0-1.2.68,3.15,3.15,0,0,0-.48,1.85v3.56h-1.12v-7h1.12v1.45h0a2.41,2.41,0,0,1,.73-1.15,1.65,1.65,0,0,1,1.1-.42,1.72,1.72,0,0,1,.67.1Z" fill="#2f2f2f"/>
-      <path d="M492,24.28h-4.94a2.63,2.63,0,0,0,.63,1.8,2.18,2.18,0,0,0,1.65.64,3.47,3.47,0,0,0,2.18-.78v1a4.05,4.05,0,0,1-2.44.67,3,3,0,0,1-2.34-.95,3.94,3.94,0,0,1-.84-2.69,3.86,3.86,0,0,1,.92-2.66,3,3,0,0,1,2.3-1,2.64,2.64,0,0,1,2.13.89,3.7,3.7,0,0,1,.75,2.47Zm-1.15-1a2.32,2.32,0,0,0-.46-1.52,1.61,1.61,0,0,0-1.29-.54,1.79,1.79,0,0,0-1.34.57,2.59,2.59,0,0,0-.69,1.49Z" fill="#2f2f2f"/>
-      <path d="M497.25,27.1V25.74a2.59,2.59,0,0,0,.56.37,4.15,4.15,0,0,0,.69.28,5.41,5.41,0,0,0,.72.18,4.06,4.06,0,0,0,.67.06,2.57,2.57,0,0,0,1.58-.4A1.32,1.32,0,0,0,502,25.1a1.41,1.41,0,0,0-.17-.69,2.16,2.16,0,0,0-.48-.53,4.6,4.6,0,0,0-.73-.47l-.91-.47c-.34-.17-.66-.35-1-.52a4.73,4.73,0,0,1-.77-.59,2.41,2.41,0,0,1-.51-.73,2.18,2.18,0,0,1-.19-1,2.31,2.31,0,0,1,.29-1.17,2.62,2.62,0,0,1,.77-.82,3.56,3.56,0,0,1,1.09-.47,4.82,4.82,0,0,1,1.25-.16,4.64,4.64,0,0,1,2.11.35v1.29a3.8,3.8,0,0,0-2.22-.6,3.22,3.22,0,0,0-.76.08,2.07,2.07,0,0,0-.67.25,1.47,1.47,0,0,0-.47.46,1.16,1.16,0,0,0-.19.68,1.45,1.45,0,0,0,.14.65,1.48,1.48,0,0,0,.41.5,4.58,4.58,0,0,0,.67.44c.26.14.57.3.91.46s.68.36,1,.55a4.15,4.15,0,0,1,.83.64,2.8,2.8,0,0,1,.57.77,2.16,2.16,0,0,1,.2,1,2.49,2.49,0,0,1-.28,1.23,2.36,2.36,0,0,1-.76.81,3.39,3.39,0,0,1-1.12.46,6.21,6.21,0,0,1-1.32.14,4.45,4.45,0,0,1-.58,0,5.81,5.81,0,0,1-.69-.11,4.84,4.84,0,0,1-.68-.18A2.47,2.47,0,0,1,497.25,27.1Z" fill="#2f2f2f"/>
-      <path d="M506,26.48h0v4.23h-1.12V20.49h1.12v1.24h0a2.66,2.66,0,0,1,2.42-1.4,2.54,2.54,0,0,1,2.11.94,3.88,3.88,0,0,1,.76,2.52,4.32,4.32,0,0,1-.85,2.81,2.83,2.83,0,0,1-2.34,1.06A2.33,2.33,0,0,1,506,26.48Zm0-2.82v1a2.05,2.05,0,0,0,.57,1.47,2,2,0,0,0,3-.17,3.56,3.56,0,0,0,.58-2.17,2.81,2.81,0,0,0-.54-1.83,1.79,1.79,0,0,0-1.46-.67,2,2,0,0,0-1.57.68A2.51,2.51,0,0,0,505.93,23.66Z" fill="#2f2f2f"/>
-      <path d="M516.62,21.63a1.39,1.39,0,0,0-.85-.23,1.43,1.43,0,0,0-1.2.68,3.15,3.15,0,0,0-.48,1.85v3.56H513v-7h1.12v1.45h0a2.41,2.41,0,0,1,.73-1.15,1.65,1.65,0,0,1,1.1-.42,1.72,1.72,0,0,1,.67.1Z" fill="#2f2f2f"/>
-      <path d="M518.44,18.72a.72.72,0,0,1-.52-.21.69.69,0,0,1-.21-.52.7.7,0,0,1,.21-.52.72.72,0,0,1,.52-.21.73.73,0,0,1,.52.21.7.7,0,0,1,.21.52.72.72,0,0,1-.73.73Zm.54,8.77h-1.12v-7H519Z" fill="#2f2f2f"/>
-      <path d="M526.91,27.49h-1.12v-4c0-1.48-.54-2.23-1.63-2.23a1.78,1.78,0,0,0-1.39.64,2.36,2.36,0,0,0-.55,1.59v4H521.1v-7h1.12v1.17h0a2.52,2.52,0,0,1,2.3-1.33,2.14,2.14,0,0,1,1.75.74,3.3,3.3,0,0,1,.61,2.15Z" fill="#2f2f2f"/>
-      <path d="M535,26.93q0,3.86-3.7,3.86A5,5,0,0,1,529,30.3V29.18a4.74,4.74,0,0,0,2.26.65c1.72,0,2.58-.91,2.58-2.75v-.76h0a2.84,2.84,0,0,1-4.51.41,3.76,3.76,0,0,1-.8-2.51,4.39,4.39,0,0,1,.86-2.84,2.87,2.87,0,0,1,2.35-1.05,2.29,2.29,0,0,1,2.1,1.14h0v-1H535Zm-1.13-2.6v-1a2,2,0,0,0-.56-1.43,1.85,1.85,0,0,0-1.4-.6,2,2,0,0,0-1.63.76,3.38,3.38,0,0,0-.59,2.12,2.85,2.85,0,0,0,.57,1.86,1.81,1.81,0,0,0,1.49.71,2,2,0,0,0,1.53-.67A2.48,2.48,0,0,0,533.86,24.33Z" fill="#2f2f2f"/>
-      <path d="M547.91,27.08a5.62,5.62,0,0,1-2.7.58,4.34,4.34,0,0,1-3.35-1.35,5,5,0,0,1-1.26-3.53A5.2,5.2,0,0,1,542,19a4.8,4.8,0,0,1,3.59-1.45,5.73,5.73,0,0,1,2.31.4v1.23a4.58,4.58,0,0,0-2.32-.59,3.54,3.54,0,0,0-2.74,1.13,4.23,4.23,0,0,0-1.05,3,4,4,0,0,0,1,2.85,3.35,3.35,0,0,0,2.58,1.07,4.79,4.79,0,0,0,2.55-.66Z" fill="#2f2f2f"/>
-      <path d="M550.59,27.49h-1.13V17.13h1.13Z" fill="#2f2f2f"/>
-      <path d="M555.7,27.66a3.28,3.28,0,0,1-2.48-1,3.67,3.67,0,0,1-.92-2.6,3.8,3.8,0,0,1,1-2.76,3.48,3.48,0,0,1,2.61-1,3.13,3.13,0,0,1,2.44,1,3.83,3.83,0,0,1,.88,2.68,3.77,3.77,0,0,1-1,2.68A3.33,3.33,0,0,1,555.7,27.66Zm.09-6.39a2.14,2.14,0,0,0-1.71.74,3,3,0,0,0-.63,2,2.87,2.87,0,0,0,.63,2,2.17,2.17,0,0,0,1.71.72,2.06,2.06,0,0,0,1.67-.71,3.06,3.06,0,0,0,.58-2,3.08,3.08,0,0,0-.58-2A2,2,0,0,0,555.79,21.27Z" fill="#2f2f2f"/>
-      <path d="M566.6,27.49h-1.12v-1.1h0a2.29,2.29,0,0,1-2.16,1.27c-1.67,0-2.5-1-2.5-3V20.49h1.11v4c0,1.48.57,2.22,1.7,2.22a1.75,1.75,0,0,0,1.35-.61,2.32,2.32,0,0,0,.53-1.58v-4h1.12Z" fill="#2f2f2f"/>
-      <path d="M574.77,27.49h-1.12V26.31h0a2.83,2.83,0,0,1-4.52.41,3.9,3.9,0,0,1-.79-2.56,4.19,4.19,0,0,1,.88-2.78,2.88,2.88,0,0,1,2.33-1.05,2.25,2.25,0,0,1,2.1,1.14h0V17.13h1.12Zm-1.12-3.16v-1a2,2,0,0,0-.56-1.44,2.06,2.06,0,0,0-3,.17,3.29,3.29,0,0,0-.59,2.07A2.92,2.92,0,0,0,570,26a1.83,1.83,0,0,0,1.51.71,1.91,1.91,0,0,0,1.52-.68A2.52,2.52,0,0,0,573.65,24.33Z" fill="#2f2f2f"/>
-      <path d="M465.3,43.28h0v4.23h-1.12V37.29h1.12v1.24h0a2.66,2.66,0,0,1,2.42-1.4,2.56,2.56,0,0,1,2.11.94,3.88,3.88,0,0,1,.76,2.52,4.32,4.32,0,0,1-.86,2.81,2.8,2.8,0,0,1-2.33,1.06A2.33,2.33,0,0,1,465.3,43.28Zm0-2.82v1a2.05,2.05,0,0,0,.57,1.47,2,2,0,0,0,3-.17,3.56,3.56,0,0,0,.58-2.17,2.81,2.81,0,0,0-.54-1.83,1.8,1.8,0,0,0-1.46-.67,2,2,0,0,0-1.57.68A2.51,2.51,0,0,0,465.27,40.46Z" fill="#2f2f2f"/>
-      <path d="M476,38.43a1.39,1.39,0,0,0-.85-.23,1.43,1.43,0,0,0-1.2.68,3.15,3.15,0,0,0-.48,1.85v3.56h-1.12v-7h1.12v1.45h0a2.37,2.37,0,0,1,.74-1.15,1.63,1.63,0,0,1,1.1-.42,1.72,1.72,0,0,1,.67.1Z" fill="#2f2f2f"/>
-      <path d="M477.77,35.52a.69.69,0,0,1-.51-.21.69.69,0,0,1-.21-.52.72.72,0,0,1,.72-.73.74.74,0,0,1,.53.21.7.7,0,0,1,.21.52.72.72,0,0,1-.74.73Zm.55,8.77H477.2v-7h1.12Z" fill="#2f2f2f"/>
-      <path d="M486.12,37.29l-2.79,7h-1.1l-2.65-7h1.23l1.78,5.09a4.47,4.47,0,0,1,.24,1h0a4.28,4.28,0,0,1,.22-1l1.86-5.12Z" fill="#2f2f2f"/>
-      <path d="M492.24,44.29h-1.12V43.2h0a2.56,2.56,0,0,1-3.79.71,1.9,1.9,0,0,1-.59-1.47c0-1.31.77-2.07,2.31-2.29l2.1-.29c0-1.19-.48-1.79-1.45-1.79a3.43,3.43,0,0,0-2.28.87V37.79a4.32,4.32,0,0,1,2.38-.66c1.65,0,2.47.87,2.47,2.61Zm-1.12-3.54-1.69.24a2.82,2.82,0,0,0-1.18.38,1.13,1.13,0,0,0-.39,1,1.07,1.07,0,0,0,.36.84,1.42,1.42,0,0,0,1,.33,1.79,1.79,0,0,0,1.37-.59,2.06,2.06,0,0,0,.55-1.48Z" fill="#2f2f2f"/>
-      <path d="M497.5,44.23a2.22,2.22,0,0,1-1.05.22c-1.22,0-1.83-.69-1.83-2.06V38.25h-1.21v-1h1.21v-1.7l1.12-.37v2.07h1.76v1h-1.76v4a1.61,1.61,0,0,0,.24,1,.94.94,0,0,0,.79.3,1.2,1.2,0,0,0,.73-.23Z" fill="#2f2f2f"/>
-      <path d="M504.49,41.08h-4.94a2.63,2.63,0,0,0,.63,1.8,2.18,2.18,0,0,0,1.65.64,3.45,3.45,0,0,0,2.18-.78v1a4.05,4.05,0,0,1-2.44.67,3,3,0,0,1-2.33-1,3.91,3.91,0,0,1-.85-2.69,3.86,3.86,0,0,1,.92-2.66,3,3,0,0,1,2.3-1,2.64,2.64,0,0,1,2.13.89,3.7,3.7,0,0,1,.75,2.47Zm-1.15-1a2.31,2.31,0,0,0-.46-1.51,1.61,1.61,0,0,0-1.29-.54,1.81,1.81,0,0,0-1.34.57,2.59,2.59,0,0,0-.69,1.48Z" fill="#2f2f2f"/>
-      <path d="M510.17,44.29v-9.8h2.71q5.18,0,5.18,4.78a4.83,4.83,0,0,1-1.44,3.65,5.32,5.32,0,0,1-3.85,1.37Zm1.15-8.76v7.73h1.46a4.17,4.17,0,0,0,3-1,3.87,3.87,0,0,0,1.07-2.92q0-3.77-4-3.77Z" fill="#2f2f2f"/>
-      <path d="M527.81,44.29h-1.4l-5-7.81a2.92,2.92,0,0,1-.31-.61h0a11.63,11.63,0,0,1,0,1.34v7.08h-1.15v-9.8h1.49l4.91,7.69a7.6,7.6,0,0,1,.4.66h0a11.72,11.72,0,0,1-.06-1.44V34.49h1.14Z" fill="#2f2f2f"/>
-      <path d="M529.83,43.9V42.54a2.52,2.52,0,0,0,.55.37,4.15,4.15,0,0,0,.69.28,6.31,6.31,0,0,0,.72.18,4.06,4.06,0,0,0,.67.06A2.57,2.57,0,0,0,534,43a1.49,1.49,0,0,0,.35-1.82,2.16,2.16,0,0,0-.48-.53,4.6,4.6,0,0,0-.73-.47l-.91-.47c-.34-.17-.66-.35-.95-.52a4.42,4.42,0,0,1-.78-.59,2.6,2.6,0,0,1-.51-.73,2.18,2.18,0,0,1-.19-.95,2.31,2.31,0,0,1,.29-1.17,2.65,2.65,0,0,1,.78-.82,3.46,3.46,0,0,1,1.09-.47,5.85,5.85,0,0,1,3.36.19V36a3.84,3.84,0,0,0-2.23-.6,3.19,3.19,0,0,0-.75.08,2,2,0,0,0-.67.25,1.41,1.41,0,0,0-.48.46,1.16,1.16,0,0,0-.19.68,1.45,1.45,0,0,0,.14.65,1.52,1.52,0,0,0,.42.5,4,4,0,0,0,.66.44c.27.14.57.3.91.46s.68.36,1,.55a4.08,4.08,0,0,1,.82.64,2.8,2.8,0,0,1,.57.77,2.16,2.16,0,0,1,.21,1,2.49,2.49,0,0,1-.29,1.23,2.36,2.36,0,0,1-.76.81,3.25,3.25,0,0,1-1.11.46,6.31,6.31,0,0,1-1.33.14,4.31,4.31,0,0,1-.57,0,6.58,6.58,0,0,1-1.37-.29A2.06,2.06,0,0,1,529.83,43.9Z" fill="#2f2f2f"/>
-      <path d="M546.29,37.62l-4.15,5.72h4.11v.95H540.5V44l4.14-5.7h-3.75v-1h5.4Z" fill="#2f2f2f"/>
-      <path d="M550.46,44.46a3.26,3.26,0,0,1-2.48-1,3.63,3.63,0,0,1-.93-2.6,3.8,3.8,0,0,1,1-2.76,3.46,3.46,0,0,1,2.6-1,3.16,3.16,0,0,1,2.45,1,3.88,3.88,0,0,1,.88,2.68,3.77,3.77,0,0,1-1,2.68A3.33,3.33,0,0,1,550.46,44.46Zm.08-6.39a2.14,2.14,0,0,0-1.71.74,3,3,0,0,0-.63,2,2.87,2.87,0,0,0,.64,2,2.15,2.15,0,0,0,1.7.72,2,2,0,0,0,1.67-.71,3.06,3.06,0,0,0,.59-2,3.13,3.13,0,0,0-.59-2A2,2,0,0,0,550.54,38.07Z" fill="#2f2f2f"/>
-      <path d="M561.47,44.29h-1.12v-4c0-1.48-.54-2.23-1.63-2.23a1.75,1.75,0,0,0-1.39.64,2.36,2.36,0,0,0-.55,1.59v4h-1.12v-7h1.12v1.17h0a2.52,2.52,0,0,1,2.3-1.33,2.14,2.14,0,0,1,1.75.74,3.3,3.3,0,0,1,.61,2.15Z" fill="#2f2f2f"/>
-      <path d="M569.17,41.08h-4.94a2.63,2.63,0,0,0,.63,1.8,2.18,2.18,0,0,0,1.66.64,3.44,3.44,0,0,0,2.17-.78v1a4.05,4.05,0,0,1-2.44.67,3,3,0,0,1-2.33-1,3.91,3.91,0,0,1-.85-2.69,3.82,3.82,0,0,1,.93-2.66,2.94,2.94,0,0,1,2.3-1,2.63,2.63,0,0,1,2.12.89,3.7,3.7,0,0,1,.75,2.47Zm-1.14-1a2.31,2.31,0,0,0-.47-1.51,1.6,1.6,0,0,0-1.28-.54,1.81,1.81,0,0,0-1.35.57,2.52,2.52,0,0,0-.68,1.48Z" fill="#2f2f2f"/>
-    </g>
-    <g>
-      <path d="M639.2,300.09h-2.58l-.75-2.34h-3.73l-.74,2.34h-2.57l3.83-10.51h2.8Zm-3.87-4.16-1.13-3.53a5.07,5.07,0,0,1-.18-.94h0a4.1,4.1,0,0,1-.19.91l-1.14,3.56Z" fill="#2f2f2f"/>
-      <path d="M646.59,300.09h-6.73v-1l3.77-4.84h-3.4v-1.7h6.33v1.14L643,298.38h3.59Z" fill="#2f2f2f"/>
-      <path d="M655,300.09h-2.3V299h0a2.62,2.62,0,0,1-2.29,1.32c-1.74,0-2.61-1-2.61-3.16v-4.52h2.31v4.32q0,1.59,1.26,1.59a1.25,1.25,0,0,0,1-.44,1.74,1.74,0,0,0,.38-1.18v-4.29H655Z" fill="#2f2f2f"/>
-      <path d="M661.82,294.67a2.05,2.05,0,0,0-1-.22,1.41,1.41,0,0,0-1.18.55,2.44,2.44,0,0,0-.42,1.51v3.58h-2.32v-7.5h2.32V294h0a2,2,0,0,1,2-1.52,1.75,1.75,0,0,1,.58.08Z" fill="#2f2f2f"/>
-      <path d="M669.71,297h-4.89c.08,1.09.76,1.63,2.06,1.63a4,4,0,0,0,2.17-.59v1.67a5.7,5.7,0,0,1-2.7.56,3.49,3.49,0,0,1-3.82-3.82,4,4,0,0,1,1.08-2.95,3.61,3.61,0,0,1,2.67-1.1,3.25,3.25,0,0,1,2.53,1,3.74,3.74,0,0,1,.9,2.64Zm-2.14-1.42c0-1.08-.44-1.62-1.31-1.62a1.24,1.24,0,0,0-1,.47,2.09,2.09,0,0,0-.5,1.15Z" fill="#2f2f2f"/>
-      <path d="M675,299.68v-2.34a4.6,4.6,0,0,0,1.38.8,4.46,4.46,0,0,0,1.51.27,3.53,3.53,0,0,0,.78-.08,1.82,1.82,0,0,0,.56-.22,1,1,0,0,0,.33-.34.78.78,0,0,0,.11-.42.88.88,0,0,0-.17-.55,2.09,2.09,0,0,0-.48-.45,4.76,4.76,0,0,0-.72-.39l-.9-.39a4.61,4.61,0,0,1-1.84-1.25,2.76,2.76,0,0,1-.6-1.79,2.73,2.73,0,0,1,1.22-2.38,3.93,3.93,0,0,1,1.32-.56,6.71,6.71,0,0,1,1.58-.18,8.92,8.92,0,0,1,1.45.1,5,5,0,0,1,1.17.3V292a3.49,3.49,0,0,0-.57-.32,4.88,4.88,0,0,0-.64-.23,5.18,5.18,0,0,0-.66-.14,4.49,4.49,0,0,0-.62,0,2.77,2.77,0,0,0-.73.08,1.93,1.93,0,0,0-.56.21,1.14,1.14,0,0,0-.35.34.8.8,0,0,0-.12.43.77.77,0,0,0,.14.47,1.47,1.47,0,0,0,.39.4,4.83,4.83,0,0,0,.62.37l.83.37a7.93,7.93,0,0,1,1.13.56,3.66,3.66,0,0,1,.86.67,2.4,2.4,0,0,1,.55.85,3,3,0,0,1,.19,1.12,3,3,0,0,1-.33,1.47,2.7,2.7,0,0,1-.9,1,4,4,0,0,1-1.33.53,7.55,7.55,0,0,1-1.6.16,8.73,8.73,0,0,1-1.65-.15A4.56,4.56,0,0,1,675,299.68Z" fill="#2f2f2f"/>
-      <path d="M686,299.22h0v4.32h-2.31v-11H686v1.13h0a2.94,2.94,0,0,1,4.66-.32,4.27,4.27,0,0,1,.8,2.72,4.64,4.64,0,0,1-.93,3,3,3,0,0,1-2.47,1.13A2.33,2.33,0,0,1,686,299.22Zm-.07-3.08v.6a1.94,1.94,0,0,0,.41,1.27,1.38,1.38,0,0,0,1.08.49,1.44,1.44,0,0,0,1.23-.61,3,3,0,0,0,.43-1.74c0-1.31-.51-2-1.54-2a1.45,1.45,0,0,0-1.16.54A2.12,2.12,0,0,0,685.91,296.14Z" fill="#2f2f2f"/>
-      <path d="M697.84,294.67a2,2,0,0,0-1-.22,1.39,1.39,0,0,0-1.18.55,2.38,2.38,0,0,0-.43,1.51v3.58H693v-7.5h2.31V294h0a2,2,0,0,1,2-1.52,1.73,1.73,0,0,1,.57.08Z" fill="#2f2f2f"/>
-      <path d="M700.07,291.4a1.37,1.37,0,0,1-1-.35,1.1,1.1,0,0,1-.37-.85,1.07,1.07,0,0,1,.37-.85,1.58,1.58,0,0,1,1.93,0,1.1,1.1,0,0,1,.37.85,1.13,1.13,0,0,1-.37.86A1.37,1.37,0,0,1,700.07,291.4Zm1.15,8.69H698.9v-7.5h2.32Z" fill="#2f2f2f"/>
-      <path d="M710.37,300.09h-2.31v-4.17c0-1.16-.42-1.74-1.25-1.74a1.23,1.23,0,0,0-1,.46,1.81,1.81,0,0,0-.38,1.17v4.28h-2.32v-7.5h2.32v1.18h0a2.65,2.65,0,0,1,2.41-1.37q2.49,0,2.49,3.09Z" fill="#2f2f2f"/>
-      <path d="M719.6,299.23a4.25,4.25,0,0,1-1.21,3.23,4.89,4.89,0,0,1-3.5,1.15,5.56,5.56,0,0,1-2.41-.43v-1.95a4.61,4.61,0,0,0,2.34.67,2.5,2.5,0,0,0,1.82-.62,2.21,2.21,0,0,0,.64-1.68V299h0a2.58,2.58,0,0,1-2.33,1.26,2.82,2.82,0,0,1-2.28-1,4.1,4.1,0,0,1-.84-2.71,4.56,4.56,0,0,1,.93-3,3.07,3.07,0,0,1,2.47-1.13,2.29,2.29,0,0,1,2,1.06h0v-.87h2.32Zm-2.29-2.75v-.59a1.82,1.82,0,0,0-.42-1.21,1.35,1.35,0,0,0-1.1-.5,1.4,1.4,0,0,0-1.2.6,2.76,2.76,0,0,0-.44,1.69,2.43,2.43,0,0,0,.41,1.48,1.36,1.36,0,0,0,1.15.55,1.45,1.45,0,0,0,1.16-.55A2.32,2.32,0,0,0,717.31,296.48Z" fill="#2f2f2f"/>
-      <path d="M733.42,299.71a6.89,6.89,0,0,1-3,.56,5,5,0,0,1-3.8-1.42,5.21,5.21,0,0,1-1.38-3.79,5.51,5.51,0,0,1,1.55-4.08,5.44,5.44,0,0,1,4-1.57,7.47,7.47,0,0,1,2.59.39v2.28a4.57,4.57,0,0,0-2.4-.63,3.2,3.2,0,0,0-2.39.92,3.47,3.47,0,0,0-.9,2.52,3.38,3.38,0,0,0,.85,2.43,3,3,0,0,0,2.31.91,4.89,4.89,0,0,0,2.53-.68Z" fill="#2f2f2f"/>
-      <path d="M737.29,300.09H735V289h2.32Z" fill="#2f2f2f"/>
-      <path d="M742.8,300.27a4,4,0,0,1-2.95-1,4.32,4.32,0,0,1,0-5.76,4.16,4.16,0,0,1,3-1.06,4,4,0,0,1,2.93,1.06,3.75,3.75,0,0,1,1.06,2.78,4,4,0,0,1-1.1,2.95A4.08,4.08,0,0,1,742.8,300.27Zm.05-6.09a1.55,1.55,0,0,0-1.27.56,2.52,2.52,0,0,0-.45,1.6q0,2.16,1.74,2.16c1.11,0,1.66-.74,1.66-2.22S744,294.18,742.85,294.18Z" fill="#2f2f2f"/>
-      <path d="M755.49,300.09h-2.31V299h0a2.62,2.62,0,0,1-2.29,1.32c-1.74,0-2.61-1-2.61-3.16v-4.52h2.3v4.32q0,1.59,1.26,1.59a1.25,1.25,0,0,0,1-.44,1.74,1.74,0,0,0,.37-1.18v-4.29h2.31Z" fill="#2f2f2f"/>
-      <path d="M764.79,300.09h-2.31v-1h0a2.58,2.58,0,0,1-2.32,1.22,2.86,2.86,0,0,1-2.27-1,4.12,4.12,0,0,1-.85-2.77,4.45,4.45,0,0,1,.94-3,3.09,3.09,0,0,1,2.48-1.13,2.12,2.12,0,0,1,2,1h0V289h2.31Zm-2.27-3.65v-.56a1.79,1.79,0,0,0-.42-1.22,1.43,1.43,0,0,0-1.11-.48,1.4,1.4,0,0,0-1.2.6,2.8,2.8,0,0,0-.43,1.66,2.46,2.46,0,0,0,.41,1.52,1.48,1.48,0,0,0,2.31,0A2.36,2.36,0,0,0,762.52,296.44Z" fill="#2f2f2f"/>
-    </g>
-    <g>
-      <path d="M66.32,28.33H65.17v-9.8h1.15Z" fill="#2f2f2f"/>
-      <path d="M74.4,28.33H73.27v-4c0-1.49-.54-2.23-1.62-2.23a1.76,1.76,0,0,0-1.39.63,2.34,2.34,0,0,0-.55,1.6v4H68.59v-7h1.12v1.16h0A2.54,2.54,0,0,1,72,21.17a2.13,2.13,0,0,1,1.76.74,3.33,3.33,0,0,1,.61,2.14Z" fill="#2f2f2f"/>
-      <path d="M82.47,27.77q0,3.86-3.69,3.86a4.93,4.93,0,0,1-2.27-.5V30a4.64,4.64,0,0,0,2.25.66c1.73,0,2.59-.92,2.59-2.75v-.76h0a2.62,2.62,0,0,1-2.4,1.34,2.66,2.66,0,0,1-2.11-.94,3.71,3.71,0,0,1-.79-2.5,4.37,4.37,0,0,1,.85-2.84,2.89,2.89,0,0,1,2.35-1,2.28,2.28,0,0,1,2.1,1.13h0v-1h1.12Zm-1.12-2.6v-1a2,2,0,0,0-.57-1.42,1.83,1.83,0,0,0-1.4-.6,1.94,1.94,0,0,0-1.63.76A3.37,3.37,0,0,0,77.17,25a2.88,2.88,0,0,0,.56,1.87,1.8,1.8,0,0,0,1.49.7,2,2,0,0,0,1.54-.67A2.5,2.5,0,0,0,81.35,25.17Z" fill="#2f2f2f"/>
-      <path d="M88.23,22.47a1.39,1.39,0,0,0-.85-.23,1.43,1.43,0,0,0-1.2.68,3.12,3.12,0,0,0-.48,1.84v3.57H84.58v-7H85.7v1.44h0a2.38,2.38,0,0,1,.73-1.15,1.69,1.69,0,0,1,1.1-.41,2,2,0,0,1,.67.09Z" fill="#2f2f2f"/>
-      <path d="M95.07,25.11H90.13a2.66,2.66,0,0,0,.63,1.81,2.17,2.17,0,0,0,1.65.63,3.47,3.47,0,0,0,2.18-.78v1.06a4.13,4.13,0,0,1-2.45.67,3,3,0,0,1-2.33-1A3.91,3.91,0,0,1,89,24.86a3.79,3.79,0,0,1,.92-2.66,3,3,0,0,1,2.3-1,2.61,2.61,0,0,1,2.13.89,3.69,3.69,0,0,1,.75,2.46Zm-1.15-.95a2.24,2.24,0,0,0-.47-1.51,1.58,1.58,0,0,0-1.28-.54,1.78,1.78,0,0,0-1.34.57,2.59,2.59,0,0,0-.69,1.48Z" fill="#2f2f2f"/>
-      <path d="M96.31,28.08v-1.2a3.31,3.31,0,0,0,2,.67c1,0,1.47-.33,1.47-1a.9.9,0,0,0-.12-.48,1.37,1.37,0,0,0-.34-.34,3.05,3.05,0,0,0-.51-.27l-.62-.25c-.31-.13-.59-.25-.82-.37a2.5,2.5,0,0,1-.59-.43,1.51,1.51,0,0,1-.36-.54,2.1,2.1,0,0,1-.11-.7,1.66,1.66,0,0,1,.22-.87,2,2,0,0,1,.6-.64A2.68,2.68,0,0,1,98,21.3a3.66,3.66,0,0,1,1-.13,4,4,0,0,1,1.62.31v1.14a3.15,3.15,0,0,0-1.78-.51,2,2,0,0,0-.56.07,1.63,1.63,0,0,0-.44.2,1,1,0,0,0-.28.32.88.88,0,0,0-.1.4,1,1,0,0,0,.1.45,1,1,0,0,0,.29.33,2.31,2.31,0,0,0,.47.26l.62.25a7.3,7.3,0,0,1,.83.37,3.13,3.13,0,0,1,.63.42,1.53,1.53,0,0,1,.4.55,1.92,1.92,0,0,1-.09,1.63,1.87,1.87,0,0,1-.61.64,2.92,2.92,0,0,1-.88.37,4.44,4.44,0,0,1-1,.13A4,4,0,0,1,96.31,28.08Z" fill="#2f2f2f"/>
-      <path d="M102.24,28.08v-1.2a3.31,3.31,0,0,0,2,.67c1,0,1.47-.33,1.47-1a.9.9,0,0,0-.12-.48,1.26,1.26,0,0,0-.35-.34,2.61,2.61,0,0,0-.5-.27c-.2-.08-.4-.17-.63-.25s-.58-.25-.82-.37a2.43,2.43,0,0,1-.58-.43,1.51,1.51,0,0,1-.36-.54,1.86,1.86,0,0,1-.12-.7,1.66,1.66,0,0,1,.23-.87,2,2,0,0,1,.6-.64,2.68,2.68,0,0,1,.86-.38,3.64,3.64,0,0,1,1-.13,4,4,0,0,1,1.63.31v1.14a3.17,3.17,0,0,0-1.78-.51,2,2,0,0,0-.57.07,1.71,1.71,0,0,0-.43.2,1,1,0,0,0-.28.32.77.77,0,0,0-.1.4.88.88,0,0,0,.1.45.91.91,0,0,0,.29.33,2.07,2.07,0,0,0,.47.26l.62.25a7.3,7.3,0,0,1,.83.37,3.13,3.13,0,0,1,.63.42,1.66,1.66,0,0,1,.4.55,1.79,1.79,0,0,1,.14.73,1.74,1.74,0,0,1-.23.9A2,2,0,0,1,106,28a3,3,0,0,1-.88.37,4.51,4.51,0,0,1-1,.13A3.94,3.94,0,0,1,102.24,28.08Z" fill="#2f2f2f"/>
-      <path d="M70.37,47.33h-5.2v-9.8h5v1H66.32v3.26h3.54v1H66.32v3.43h4.05Z" fill="#2f2f2f"/>
-      <path d="M77.85,46.77q0,3.85-3.69,3.86a4.93,4.93,0,0,1-2.27-.5V49a4.64,4.64,0,0,0,2.25.66c1.73,0,2.59-.92,2.59-2.75v-.76h0a2.83,2.83,0,0,1-4.51.4,3.71,3.71,0,0,1-.79-2.5,4.37,4.37,0,0,1,.85-2.84,2.89,2.89,0,0,1,2.35-1,2.28,2.28,0,0,1,2.1,1.13h0v-1h1.12Zm-1.12-2.6v-1a2,2,0,0,0-.57-1.42,1.83,1.83,0,0,0-1.4-.6,1.94,1.94,0,0,0-1.63.76A3.37,3.37,0,0,0,72.55,44a2.88,2.88,0,0,0,.56,1.87,1.8,1.8,0,0,0,1.49.7,2,2,0,0,0,1.54-.67A2.5,2.5,0,0,0,76.73,44.17Z" fill="#2f2f2f"/>
-      <path d="M83.61,41.47a1.39,1.39,0,0,0-.85-.23,1.43,1.43,0,0,0-1.2.68,3.12,3.12,0,0,0-.48,1.84v3.57H80v-7h1.12v1.44h0a2.38,2.38,0,0,1,.73-1.15,1.69,1.69,0,0,1,1.1-.41,2,2,0,0,1,.67.09Z" fill="#2f2f2f"/>
-      <path d="M90.45,44.11H85.51a2.66,2.66,0,0,0,.63,1.81,2.17,2.17,0,0,0,1.65.63A3.47,3.47,0,0,0,90,45.77v1.06a4.13,4.13,0,0,1-2.45.67,3,3,0,0,1-2.33-1,3.91,3.91,0,0,1-.84-2.68,3.79,3.79,0,0,1,.92-2.66,3,3,0,0,1,2.3-1,2.61,2.61,0,0,1,2.13.89,3.69,3.69,0,0,1,.75,2.46Zm-1.15-1a2.24,2.24,0,0,0-.47-1.51,1.58,1.58,0,0,0-1.28-.54,1.78,1.78,0,0,0-1.34.57,2.59,2.59,0,0,0-.69,1.48Z" fill="#2f2f2f"/>
-      <path d="M91.69,47.08v-1.2a3.33,3.33,0,0,0,2,.67c1,0,1.48-.33,1.48-1a.9.9,0,0,0-.13-.48,1.37,1.37,0,0,0-.34-.34,2.7,2.7,0,0,0-.51-.27l-.62-.25c-.31-.13-.59-.25-.82-.37a2.5,2.5,0,0,1-.59-.43,1.48,1.48,0,0,1-.35-.54,1.86,1.86,0,0,1-.12-.7,1.66,1.66,0,0,1,.22-.87,2,2,0,0,1,.6-.64,2.68,2.68,0,0,1,.86-.38,3.66,3.66,0,0,1,1-.13,4,4,0,0,1,1.62.31v1.14a3.12,3.12,0,0,0-1.77-.51,2,2,0,0,0-.57.07,1.63,1.63,0,0,0-.44.2,1,1,0,0,0-.28.32.88.88,0,0,0-.1.4,1,1,0,0,0,.1.45,1,1,0,0,0,.29.33,2.31,2.31,0,0,0,.47.26l.62.25a8.42,8.42,0,0,1,.84.37,3.35,3.35,0,0,1,.62.42,1.53,1.53,0,0,1,.4.55,1.92,1.92,0,0,1-.09,1.63,1.87,1.87,0,0,1-.61.64,2.92,2.92,0,0,1-.88.37,4.42,4.42,0,0,1-1,.13A4,4,0,0,1,91.69,47.08Z" fill="#2f2f2f"/>
-      <path d="M97.62,47.08v-1.2a3.31,3.31,0,0,0,2,.67c1,0,1.47-.33,1.47-1a.9.9,0,0,0-.12-.48,1.26,1.26,0,0,0-.35-.34,2.61,2.61,0,0,0-.5-.27c-.2-.08-.4-.17-.63-.25s-.58-.25-.81-.37a2.5,2.5,0,0,1-.59-.43,1.51,1.51,0,0,1-.36-.54,1.86,1.86,0,0,1-.12-.7,1.66,1.66,0,0,1,.23-.87,2,2,0,0,1,.6-.64,2.68,2.68,0,0,1,.86-.38,3.64,3.64,0,0,1,1-.13,4,4,0,0,1,1.63.31v1.14a3.17,3.17,0,0,0-1.78-.51,2,2,0,0,0-.57.07,1.71,1.71,0,0,0-.43.2,1,1,0,0,0-.28.32.77.77,0,0,0-.1.4.88.88,0,0,0,.1.45.91.91,0,0,0,.29.33,2.07,2.07,0,0,0,.47.26l.62.25a7.3,7.3,0,0,1,.83.37,3.13,3.13,0,0,1,.63.42,1.66,1.66,0,0,1,.4.55,1.79,1.79,0,0,1,.14.73,1.74,1.74,0,0,1-.23.9,2,2,0,0,1-.61.64,2.92,2.92,0,0,1-.88.37,4.44,4.44,0,0,1-1.05.13A3.94,3.94,0,0,1,97.62,47.08Z" fill="#2f2f2f"/>
-    </g>
-    <g>
-      <path d="M275.62,53.74h-5.19v-9.8h5v1h-3.83v3.26h3.54v1h-3.54V52.7h4Z" fill="#2f2f2f"/>
-      <path d="M283.11,53.18q0,3.85-3.69,3.85a4.9,4.9,0,0,1-2.27-.49V55.42a4.61,4.61,0,0,0,2.25.66c1.72,0,2.59-.92,2.59-2.75v-.77h0a2.84,2.84,0,0,1-4.51.41,3.73,3.73,0,0,1-.8-2.5,4.37,4.37,0,0,1,.86-2.84,2.87,2.87,0,0,1,2.35-1.05,2.28,2.28,0,0,1,2.1,1.13h0v-1h1.12ZM282,50.57v-1a2,2,0,0,0-.57-1.43,1.86,1.86,0,0,0-1.4-.59,2,2,0,0,0-1.63.75,3.4,3.4,0,0,0-.59,2.12,2.88,2.88,0,0,0,.57,1.87,1.8,1.8,0,0,0,1.49.7,1.92,1.92,0,0,0,1.53-.67A2.49,2.49,0,0,0,282,50.57Z" fill="#2f2f2f"/>
-      <path d="M288.86,47.87a1.34,1.34,0,0,0-.84-.22,1.41,1.41,0,0,0-1.2.68,3.12,3.12,0,0,0-.48,1.84v3.57h-1.13v-7h1.13v1.44h0a2.54,2.54,0,0,1,.73-1.15,1.65,1.65,0,0,1,1.1-.41,1.89,1.89,0,0,1,.67.09Z" fill="#2f2f2f"/>
-      <path d="M295.71,50.52h-4.95a2.61,2.61,0,0,0,.63,1.8,2.18,2.18,0,0,0,1.66.64,3.42,3.42,0,0,0,2.17-.78v1a4,4,0,0,1-2.44.67,3,3,0,0,1-2.33-.95,3.88,3.88,0,0,1-.85-2.68,3.84,3.84,0,0,1,.93-2.67,3,3,0,0,1,2.3-1,2.65,2.65,0,0,1,2.13.88,3.74,3.74,0,0,1,.75,2.47Zm-1.15-1a2.29,2.29,0,0,0-.47-1.51,1.59,1.59,0,0,0-1.28-.54,1.81,1.81,0,0,0-1.35.57,2.55,2.55,0,0,0-.68,1.48Z" fill="#2f2f2f"/>
-      <path d="M297,53.49V52.28a3.32,3.32,0,0,0,2,.68c1,0,1.47-.33,1.47-1a.9.9,0,0,0-.12-.48,1.26,1.26,0,0,0-.35-.34,2.61,2.61,0,0,0-.5-.27c-.2-.08-.4-.17-.63-.25a7.83,7.83,0,0,1-.81-.38,2.22,2.22,0,0,1-.59-.42,1.6,1.6,0,0,1-.36-.54,1.86,1.86,0,0,1-.12-.7,1.66,1.66,0,0,1,.23-.87,1.93,1.93,0,0,1,.6-.64,2.68,2.68,0,0,1,.86-.38,3.64,3.64,0,0,1,1-.13,4,4,0,0,1,1.63.31V48a3.22,3.22,0,0,0-1.78-.5,2,2,0,0,0-.57.07,1.71,1.71,0,0,0-.43.2,1,1,0,0,0-.28.31.79.79,0,0,0-.1.4.9.9,0,0,0,.1.46,1.11,1.11,0,0,0,.29.33,2.07,2.07,0,0,0,.47.26l.62.25a7.3,7.3,0,0,1,.83.37,2.47,2.47,0,0,1,.63.42,1.66,1.66,0,0,1,.4.55,1.92,1.92,0,0,1-.09,1.63,1.84,1.84,0,0,1-.61.63,2.7,2.7,0,0,1-.88.38,4.44,4.44,0,0,1-1.05.12A4.06,4.06,0,0,1,297,53.49Z" fill="#2f2f2f"/>
-      <path d="M302.88,53.49V52.28a3.32,3.32,0,0,0,2,.68c1,0,1.48-.33,1.48-1a.82.82,0,0,0-.13-.48,1.22,1.22,0,0,0-.34-.34,2.61,2.61,0,0,0-.5-.27l-.63-.25c-.31-.13-.58-.25-.82-.38a2.4,2.4,0,0,1-.59-.42,1.73,1.73,0,0,1-.35-.54,1.86,1.86,0,0,1-.12-.7,1.66,1.66,0,0,1,.23-.87,1.93,1.93,0,0,1,.6-.64,2.59,2.59,0,0,1,.86-.38,3.64,3.64,0,0,1,1-.13,4,4,0,0,1,1.63.31V48a3.25,3.25,0,0,0-1.78-.5,2,2,0,0,0-.57.07,1.56,1.56,0,0,0-.43.2.91.91,0,0,0-.28.31.79.79,0,0,0-.1.4.9.9,0,0,0,.1.46,1,1,0,0,0,.29.33,2.22,2.22,0,0,0,.46.26l.62.25a8.42,8.42,0,0,1,.84.37,2.88,2.88,0,0,1,.63.42,1.81,1.81,0,0,1,.4.55,1.92,1.92,0,0,1-.09,1.63,1.93,1.93,0,0,1-.61.63,2.79,2.79,0,0,1-.88.38,4.57,4.57,0,0,1-1.05.12A4,4,0,0,1,302.88,53.49Z" fill="#2f2f2f"/>
-      <path d="M316.32,53.67a2.09,2.09,0,0,1-1,.22c-1.23,0-1.84-.68-1.84-2V47.7h-1.21v-1h1.21V45l1.12-.36v2.07h1.76v1h-1.76v3.94a1.65,1.65,0,0,0,.24,1,1,1,0,0,0,.79.3,1.14,1.14,0,0,0,.73-.24Z" fill="#2f2f2f"/>
-      <path d="M320.58,53.9a3.24,3.24,0,0,1-2.48-1,3.62,3.62,0,0,1-.93-2.6,3.79,3.79,0,0,1,1-2.75,3.46,3.46,0,0,1,2.6-1,3.16,3.16,0,0,1,2.45,1,3.84,3.84,0,0,1,.88,2.67,3.79,3.79,0,0,1-.95,2.69A3.32,3.32,0,0,1,320.58,53.9Zm.08-6.38a2.13,2.13,0,0,0-1.71.73,3,3,0,0,0-.63,2,2.87,2.87,0,0,0,.64,2,2.15,2.15,0,0,0,1.7.72,2,2,0,0,0,1.67-.7,3.74,3.74,0,0,0,0-4A2,2,0,0,0,320.66,47.52Z" fill="#2f2f2f"/>
-      <path d="M271.58,70.54h-1.15v-9.8h1.15Z" fill="#2f2f2f"/>
-      <path d="M279.65,70.54h-1.12v-4c0-1.49-.54-2.23-1.63-2.23a1.77,1.77,0,0,0-1.39.63,2.37,2.37,0,0,0-.55,1.6v4h-1.12v-7H275V64.7h0a2.53,2.53,0,0,1,2.3-1.32,2.11,2.11,0,0,1,1.75.74,3.27,3.27,0,0,1,.61,2.14Z" fill="#2f2f2f"/>
-      <path d="M284.88,70.47a2.09,2.09,0,0,1-1,.22c-1.23,0-1.84-.68-1.84-2V64.5h-1.21v-1H282V61.83l1.12-.36v2.07h1.76v1h-1.76v3.94a1.67,1.67,0,0,0,.24,1,1,1,0,0,0,.79.3,1.14,1.14,0,0,0,.73-.24Z" fill="#2f2f2f"/>
-      <path d="M291.87,67.32h-4.94a2.61,2.61,0,0,0,.63,1.8,2.15,2.15,0,0,0,1.66.64,3.44,3.44,0,0,0,2.17-.78v1a4.05,4.05,0,0,1-2.44.67,2.93,2.93,0,0,1-2.33-1,3.88,3.88,0,0,1-.85-2.68,3.84,3.84,0,0,1,.93-2.67,3,3,0,0,1,2.3-1,2.63,2.63,0,0,1,2.12.88,3.74,3.74,0,0,1,.75,2.47Zm-1.14-.95a2.35,2.35,0,0,0-.47-1.51,1.6,1.6,0,0,0-1.28-.54,1.81,1.81,0,0,0-1.35.57,2.49,2.49,0,0,0-.68,1.48Z" fill="#2f2f2f"/>
-      <path d="M297.21,64.67a1.39,1.39,0,0,0-.85-.22,1.41,1.41,0,0,0-1.2.68,3.12,3.12,0,0,0-.48,1.84v3.57h-1.12v-7h1.12V65h0a2.38,2.38,0,0,1,.73-1.15,1.62,1.62,0,0,1,1.1-.41,2,2,0,0,1,.67.09Z" fill="#2f2f2f"/>
-      <path d="M304.26,70.54h-1.12v-4c0-1.49-.54-2.23-1.63-2.23a1.77,1.77,0,0,0-1.39.63,2.37,2.37,0,0,0-.55,1.6v4h-1.12v-7h1.12V64.7h0a2.53,2.53,0,0,1,2.3-1.32,2.11,2.11,0,0,1,1.75.74,3.27,3.27,0,0,1,.61,2.14Z" fill="#2f2f2f"/>
-      <path d="M312,67.32h-5a2.61,2.61,0,0,0,.63,1.8,2.15,2.15,0,0,0,1.66.64,3.44,3.44,0,0,0,2.17-.78v1a4.05,4.05,0,0,1-2.44.67,2.93,2.93,0,0,1-2.33-1,3.88,3.88,0,0,1-.85-2.68,3.84,3.84,0,0,1,.93-2.67,3,3,0,0,1,2.3-1,2.63,2.63,0,0,1,2.12.88,3.74,3.74,0,0,1,.76,2.47Zm-1.15-.95a2.29,2.29,0,0,0-.47-1.51,1.6,1.6,0,0,0-1.28-.54,1.81,1.81,0,0,0-1.35.57,2.49,2.49,0,0,0-.68,1.48Z" fill="#2f2f2f"/>
-      <path d="M316.89,70.47a2.13,2.13,0,0,1-1.05.22c-1.22,0-1.84-.68-1.84-2V64.5h-1.2v-1H314V61.83l1.13-.36v2.07h1.76v1h-1.76v3.94a1.75,1.75,0,0,0,.23,1,1,1,0,0,0,.8.3,1.16,1.16,0,0,0,.73-.24Z" fill="#2f2f2f"/>
-    </g>
-    <g>
-      <path d="M181.29,53.74h-1.15v-9.8h1.15Z" fill="#2f2f2f"/>
-      <path d="M189.37,53.74h-1.12v-4c0-1.49-.54-2.23-1.63-2.23a1.77,1.77,0,0,0-1.39.63,2.32,2.32,0,0,0-.55,1.6v4h-1.12v-7h1.12V47.9h0A2.51,2.51,0,0,1,187,46.58a2.13,2.13,0,0,1,1.76.74,3.27,3.27,0,0,1,.61,2.14Z" fill="#2f2f2f"/>
-      <path d="M197.44,53.18q0,3.85-3.69,3.85a4.93,4.93,0,0,1-2.27-.49V55.42a4.65,4.65,0,0,0,2.26.66c1.72,0,2.58-.92,2.58-2.75v-.77h0a2.6,2.6,0,0,1-2.4,1.34,2.63,2.63,0,0,1-2.1-.93,3.73,3.73,0,0,1-.8-2.5,4.37,4.37,0,0,1,.86-2.84,2.86,2.86,0,0,1,2.35-1.05,2.26,2.26,0,0,1,2.09,1.13h0v-1h1.12Zm-1.12-2.61v-1a2,2,0,0,0-.56-1.43,1.89,1.89,0,0,0-1.41-.59,1.94,1.94,0,0,0-1.62.75,3.34,3.34,0,0,0-.59,2.12,2.93,2.93,0,0,0,.56,1.87,1.83,1.83,0,0,0,1.5.7,1.94,1.94,0,0,0,1.53-.67A2.53,2.53,0,0,0,196.32,50.57Z" fill="#2f2f2f"/>
-      <path d="M203.2,47.87a1.39,1.39,0,0,0-.85-.22,1.41,1.41,0,0,0-1.2.68,3.12,3.12,0,0,0-.48,1.84v3.57h-1.12v-7h1.12v1.44h0a2.46,2.46,0,0,1,.73-1.15,1.65,1.65,0,0,1,1.1-.41,1.92,1.92,0,0,1,.67.09Z" fill="#2f2f2f"/>
-      <path d="M210,50.52H205.1a2.61,2.61,0,0,0,.63,1.8,2.14,2.14,0,0,0,1.65.64,3.45,3.45,0,0,0,2.18-.78v1a4.05,4.05,0,0,1-2.44.67,2.93,2.93,0,0,1-2.33-.95,4.49,4.49,0,0,1,.07-5.35,3,3,0,0,1,2.31-1,2.63,2.63,0,0,1,2.12.88,3.74,3.74,0,0,1,.75,2.47Zm-1.15-1a2.29,2.29,0,0,0-.46-1.51,1.61,1.61,0,0,0-1.29-.54,1.81,1.81,0,0,0-1.34.57,2.56,2.56,0,0,0-.69,1.48Z" fill="#2f2f2f"/>
-      <path d="M211.28,53.49V52.28a3.34,3.34,0,0,0,2,.68c1,0,1.48-.33,1.48-1a.82.82,0,0,0-.13-.48,1.22,1.22,0,0,0-.34-.34,2.43,2.43,0,0,0-.51-.27l-.62-.25c-.31-.13-.58-.25-.82-.38a2.4,2.4,0,0,1-.59-.42,1.73,1.73,0,0,1-.35-.54,1.86,1.86,0,0,1-.12-.7,1.66,1.66,0,0,1,.22-.87,1.87,1.87,0,0,1,.61-.64,2.63,2.63,0,0,1,.85-.38,3.71,3.71,0,0,1,1-.13,4,4,0,0,1,1.62.31V48a3.19,3.19,0,0,0-1.77-.5,2,2,0,0,0-.57.07,1.56,1.56,0,0,0-.43.2.91.91,0,0,0-.28.31.79.79,0,0,0-.1.4.9.9,0,0,0,.1.46,1,1,0,0,0,.29.33,2,2,0,0,0,.46.26l.62.25a8.42,8.42,0,0,1,.84.37,2.88,2.88,0,0,1,.63.42,1.81,1.81,0,0,1,.4.55,1.92,1.92,0,0,1-.09,1.63,2,2,0,0,1-.61.63,2.75,2.75,0,0,1-.89.38,4.42,4.42,0,0,1-1,.12A4.1,4.1,0,0,1,211.28,53.49Z" fill="#2f2f2f"/>
-      <path d="M217.21,53.49V52.28a3.32,3.32,0,0,0,2,.68c1,0,1.47-.33,1.47-1a.9.9,0,0,0-.12-.48,1.37,1.37,0,0,0-.34-.34,3.05,3.05,0,0,0-.51-.27c-.19-.08-.4-.17-.63-.25s-.58-.25-.81-.38a2.22,2.22,0,0,1-.59-.42,1.6,1.6,0,0,1-.36-.54,1.86,1.86,0,0,1-.12-.7,1.66,1.66,0,0,1,.23-.87,1.93,1.93,0,0,1,.6-.64,2.68,2.68,0,0,1,.86-.38,3.64,3.64,0,0,1,1-.13,4,4,0,0,1,1.63.31V48a3.22,3.22,0,0,0-1.78-.5,2,2,0,0,0-.56.07,1.63,1.63,0,0,0-.44.2,1,1,0,0,0-.28.31.91.91,0,0,0-.1.4,1,1,0,0,0,.1.46,1.11,1.11,0,0,0,.29.33,2.31,2.31,0,0,0,.47.26l.62.25a7.3,7.3,0,0,1,.83.37,2.47,2.47,0,0,1,.63.42,1.53,1.53,0,0,1,.4.55,1.61,1.61,0,0,1,.14.73,1.68,1.68,0,0,1-.23.9,1.84,1.84,0,0,1-.61.63,2.7,2.7,0,0,1-.88.38,4.44,4.44,0,0,1-1,.12A4.06,4.06,0,0,1,217.21,53.49Z" fill="#2f2f2f"/>
-      <path d="M230.66,53.67a2.15,2.15,0,0,1-1,.22c-1.22,0-1.84-.68-1.84-2V47.7h-1.2v-1h1.2V45l1.12-.36v2.07h1.77v1h-1.77v3.94a1.65,1.65,0,0,0,.24,1,1,1,0,0,0,.8.3,1.16,1.16,0,0,0,.73-.24Z" fill="#2f2f2f"/>
-      <path d="M234.92,53.9a3.21,3.21,0,0,1-2.48-1,3.62,3.62,0,0,1-.93-2.6,3.79,3.79,0,0,1,1-2.75,3.5,3.5,0,0,1,2.61-1,3.13,3.13,0,0,1,2.44,1,3.79,3.79,0,0,1,.88,2.67,3.75,3.75,0,0,1-1,2.69A3.3,3.3,0,0,1,234.92,53.9Zm.08-6.38a2.13,2.13,0,0,0-1.71.73,3,3,0,0,0-.63,2,2.82,2.82,0,0,0,.64,2A2.15,2.15,0,0,0,235,53a2,2,0,0,0,1.67-.7,3.79,3.79,0,0,0,0-4A2.06,2.06,0,0,0,235,47.52Z" fill="#2f2f2f"/>
-      <path d="M166.52,70.54h-1.27l-1-2.75h-4.16l-1,2.75H157.8l3.76-9.8h1.19Zm-2.69-3.78-1.53-4.18a3.56,3.56,0,0,1-.16-.65h0a4.1,4.1,0,0,1-.16.65l-1.52,4.18Z" fill="#2f2f2f"/>
-      <path d="M168.94,69.53h0v4.23h-1.12V63.54h1.12v1.23h0a2.65,2.65,0,0,1,2.42-1.39,2.54,2.54,0,0,1,2.11.94,3.84,3.84,0,0,1,.76,2.51,4.35,4.35,0,0,1-.85,2.82,2.86,2.86,0,0,1-2.34,1A2.34,2.34,0,0,1,168.94,69.53Zm0-2.83v1a2.09,2.09,0,0,0,.57,1.48,1.86,1.86,0,0,0,1.43.6,1.89,1.89,0,0,0,1.6-.78,3.61,3.61,0,0,0,.57-2.17,2.81,2.81,0,0,0-.54-1.83,1.78,1.78,0,0,0-1.46-.66,2,2,0,0,0-1.57.68A2.47,2.47,0,0,0,168.91,66.7Z" fill="#2f2f2f"/>
-      <path d="M177.1,69.53h0v4.23H176V63.54h1.12v1.23h0a2.65,2.65,0,0,1,2.42-1.39,2.56,2.56,0,0,1,2.11.94,3.89,3.89,0,0,1,.76,2.51,4.35,4.35,0,0,1-.86,2.82,2.85,2.85,0,0,1-2.33,1A2.34,2.34,0,0,1,177.1,69.53Zm0-2.83v1a2.13,2.13,0,0,0,.56,1.48,1.9,1.9,0,0,0,1.44.6,1.87,1.87,0,0,0,1.59-.78,3.54,3.54,0,0,0,.58-2.17A2.81,2.81,0,0,0,180.7,65a1.79,1.79,0,0,0-1.46-.66,2,2,0,0,0-1.58.68A2.51,2.51,0,0,0,177.07,66.7Z" fill="#2f2f2f"/>
-      <path d="M195.49,69.87a6.5,6.5,0,0,1-3.28.83,4.47,4.47,0,0,1-3.39-1.35,4.94,4.94,0,0,1-1.3-3.58A5.11,5.11,0,0,1,189,62a4.93,4.93,0,0,1,3.65-1.46,6.27,6.27,0,0,1,2.68.52v1.27a5.15,5.15,0,0,0-2.81-.75,3.51,3.51,0,0,0-2.7,1.14,4.72,4.72,0,0,0-.08,5.86,3.42,3.42,0,0,0,2.65,1.06,4,4,0,0,0,2-.46V66.47H192.2v-1h3.29Z" fill="#2f2f2f"/>
-      <path d="M202.58,70.54h-1.12V69.45h0a2.36,2.36,0,0,1-2.15,1.25,2.29,2.29,0,0,1-1.64-.55,1.94,1.94,0,0,1-.59-1.47q0-2,2.31-2.28l2.1-.3c0-1.19-.48-1.78-1.45-1.78a3.47,3.47,0,0,0-2.28.86V64a4.32,4.32,0,0,1,2.38-.65c1.65,0,2.47.87,2.47,2.61ZM201.46,67l-1.69.23a2.67,2.67,0,0,0-1.18.39,1.11,1.11,0,0,0-.39,1,1.09,1.09,0,0,0,.36.84,1.46,1.46,0,0,0,1,.32,1.78,1.78,0,0,0,1.37-.58,2.07,2.07,0,0,0,.55-1.48Z" fill="#2f2f2f"/>
-      <path d="M207.84,70.47a2.15,2.15,0,0,1-1.05.22c-1.22,0-1.84-.68-1.84-2V64.5h-1.2v-1H205V61.83l1.12-.36v2.07h1.77v1h-1.77v3.94a1.67,1.67,0,0,0,.24,1,1,1,0,0,0,.8.3,1.16,1.16,0,0,0,.73-.24Z" fill="#2f2f2f"/>
-      <path d="M214.83,67.32h-4.94a2.61,2.61,0,0,0,.63,1.8,2.14,2.14,0,0,0,1.65.64,3.42,3.42,0,0,0,2.17-.78v1a4,4,0,0,1-2.44.67,3,3,0,0,1-2.33-1,3.93,3.93,0,0,1-.84-2.68,3.84,3.84,0,0,1,.92-2.67,3,3,0,0,1,2.3-1,2.63,2.63,0,0,1,2.13.88,3.74,3.74,0,0,1,.75,2.47Zm-1.15-.95a2.24,2.24,0,0,0-.47-1.51,1.58,1.58,0,0,0-1.28-.54,1.78,1.78,0,0,0-1.34.57,2.56,2.56,0,0,0-.69,1.48Z" fill="#2f2f2f"/>
-      <path d="M225.3,63.54l-2.09,7H222l-1.44-5a3.82,3.82,0,0,1-.11-.65h0a3.68,3.68,0,0,1-.15.63l-1.56,5h-1.13l-2.11-7h1.17l1.45,5.26a3,3,0,0,1,.1.63h0a3.24,3.24,0,0,1,.12-.64L220,63.54h1l1.45,5.28a3.2,3.2,0,0,1,.1.63h.06a2.86,2.86,0,0,1,.12-.63l1.42-5.28Z" fill="#2f2f2f"/>
-      <path d="M231.48,70.54h-1.12V69.45h0a2.35,2.35,0,0,1-2.15,1.25,2.29,2.29,0,0,1-1.64-.55,1.94,1.94,0,0,1-.59-1.47q0-2,2.31-2.28l2.1-.3c0-1.19-.48-1.78-1.44-1.78a3.47,3.47,0,0,0-2.29.86V64a4.32,4.32,0,0,1,2.38-.65c1.65,0,2.47.87,2.47,2.61ZM230.36,67l-1.69.23a2.67,2.67,0,0,0-1.18.39,1.11,1.11,0,0,0-.39,1,1.09,1.09,0,0,0,.36.84,1.46,1.46,0,0,0,1,.32,1.78,1.78,0,0,0,1.37-.58,2.07,2.07,0,0,0,.55-1.48Z" fill="#2f2f2f"/>
-      <path d="M239,63.54l-3.22,8.12c-.57,1.45-1.38,2.17-2.42,2.17a3,3,0,0,1-.73-.08v-1a2.1,2.1,0,0,0,.66.12,1.36,1.36,0,0,0,1.27-1l.56-1.32-2.73-7h1.24l1.9,5.39c0,.06.07.24.14.53h0c0-.11.07-.28.14-.52l2-5.4Z" fill="#2f2f2f"/>
-    </g>
-    <g>
-      <path d="M804,99.28h-1.25l-3-3.52a1.42,1.42,0,0,1-.2-.27h0v3.79h-.91v-7.7h.91V95.2h0a2,2,0,0,1,.2-.26l2.88-3.36h1.12l-3.3,3.7Z" fill="#2f2f2f"/>
-      <path d="M809.13,96.75h-3.88a2,2,0,0,0,.49,1.42,1.71,1.71,0,0,0,1.3.5,2.7,2.7,0,0,0,1.71-.61v.83a3.21,3.21,0,0,1-1.92.52,2.31,2.31,0,0,1-1.83-.75,3,3,0,0,1-.67-2.11,3,3,0,0,1,.73-2.09,2.34,2.34,0,0,1,1.81-.81,2.09,2.09,0,0,1,1.67.7,2.94,2.94,0,0,1,.59,1.94Zm-.9-.74a1.84,1.84,0,0,0-.37-1.19,1.26,1.26,0,0,0-1-.42,1.42,1.42,0,0,0-1.06.44,2,2,0,0,0-.53,1.17Z" fill="#2f2f2f"/>
-      <path d="M814.84,93.78l-2.53,6.38c-.45,1.14-1.09,1.71-1.9,1.71a2,2,0,0,1-.58-.07V101a1.53,1.53,0,0,0,.52.1,1.08,1.08,0,0,0,1-.8l.44-1-2.15-5.49h1L812.11,98s0,.19.11.41h0l.11-.4,1.56-4.25Z" fill="#2f2f2f"/>
-      <path d="M798.33,104.58l-2.85,7.7h-1l-2.8-7.7h1l2.13,6.11a3,3,0,0,1,.15.68h0a3.3,3.3,0,0,1,.17-.69l2.18-6.1Z" fill="#2f2f2f"/>
-      <path d="M802.81,112.28h-.88v-.86h0a1.84,1.84,0,0,1-1.69,1,1.81,1.81,0,0,1-1.29-.43,1.51,1.51,0,0,1-.46-1.16c0-1,.6-1.62,1.81-1.79l1.65-.23c0-.94-.38-1.4-1.13-1.4a2.72,2.72,0,0,0-1.8.67v-.9a3.46,3.46,0,0,1,1.87-.52c1.3,0,1.94.69,1.94,2.06Zm-.88-2.78-1.33.18a2.15,2.15,0,0,0-.92.31.86.86,0,0,0-.31.77.83.83,0,0,0,.29.66,1.09,1.09,0,0,0,.76.25,1.39,1.39,0,0,0,1.08-.46,1.6,1.6,0,0,0,.43-1.16Z" fill="#2f2f2f"/>
-      <path d="M808.93,112.28h-.88v-.87h0a1.79,1.79,0,0,1-1.69,1c-1.32,0-2-.78-2-2.34v-3.29h.87v3.15c0,1.16.45,1.74,1.34,1.74a1.37,1.37,0,0,0,1.06-.47,1.83,1.83,0,0,0,.41-1.25v-3.17h.88Z" fill="#2f2f2f"/>
-      <path d="M811.53,112.28h-.88v-8.14h.88Z" fill="#2f2f2f"/>
-      <path d="M815.86,112.23a1.75,1.75,0,0,1-.82.17c-1,0-1.45-.54-1.45-1.61v-3.26h-.94v-.75h.94v-1.34l.89-.28v1.62h1.38v.75h-1.38v3.1a1.31,1.31,0,0,0,.18.79.77.77,0,0,0,.63.24.92.92,0,0,0,.57-.18Z" fill="#2f2f2f"/>
-      <path d="M816.84,112.08v-.94a2.64,2.64,0,0,0,1.58.53c.78,0,1.16-.26,1.16-.77a.76.76,0,0,0-.09-.38,1.15,1.15,0,0,0-.27-.27,2.15,2.15,0,0,0-.4-.21l-.49-.2a4.32,4.32,0,0,1-.64-.29,2.17,2.17,0,0,1-.47-.33,1.47,1.47,0,0,1-.28-.42,1.6,1.6,0,0,1-.09-.56,1.3,1.3,0,0,1,.18-.68,1.5,1.5,0,0,1,.47-.5,2.15,2.15,0,0,1,.67-.3,3,3,0,0,1,.79-.11,3.2,3.2,0,0,1,1.27.25v.89a2.51,2.51,0,0,0-1.39-.39,1.55,1.55,0,0,0-.45,0,1.19,1.19,0,0,0-.34.16.83.83,0,0,0-.22.24.69.69,0,0,0-.08.32.8.8,0,0,0,.08.36.92.92,0,0,0,.23.26,2,2,0,0,0,.36.2l.49.2a5.2,5.2,0,0,1,.66.29,2.33,2.33,0,0,1,.49.33,1.34,1.34,0,0,1,.32.43,1.41,1.41,0,0,1,.11.57,1.36,1.36,0,0,1-.18.71,1.53,1.53,0,0,1-.48.5,2.47,2.47,0,0,1-.7.3,3.62,3.62,0,0,1-.82.09A3.12,3.12,0,0,1,816.84,112.08Z" fill="#2f2f2f"/>
-    </g>
-    <g>
-      <path d="M850.65,99V97.91a2.4,2.4,0,0,0,.44.29,4.35,4.35,0,0,0,.54.22c.19,0,.38.1.57.13a3.26,3.26,0,0,0,.52,0,2.06,2.06,0,0,0,1.25-.31,1,1,0,0,0,.41-.89,1.06,1.06,0,0,0-.14-.54,1.65,1.65,0,0,0-.38-.42,3.75,3.75,0,0,0-.57-.37l-.71-.36-.76-.42a3.17,3.17,0,0,1-.6-.46,2.06,2.06,0,0,1-.41-.57,1.76,1.76,0,0,1-.15-.75,1.73,1.73,0,0,1,.24-.92,1.93,1.93,0,0,1,.6-.64,2.67,2.67,0,0,1,.86-.37,4.49,4.49,0,0,1,2.64.15v1a3.06,3.06,0,0,0-1.75-.47,2.88,2.88,0,0,0-.59.06,1.77,1.77,0,0,0-.53.2,1.06,1.06,0,0,0-.37.36,1,1,0,0,0-.15.54,1.16,1.16,0,0,0,.11.51,1.19,1.19,0,0,0,.33.39,2.75,2.75,0,0,0,.52.34c.2.11.44.24.71.37s.54.28.78.43a3.81,3.81,0,0,1,.66.5,2.21,2.21,0,0,1,.44.61,1.67,1.67,0,0,1,.16.76,1.89,1.89,0,0,1-.22,1,1.76,1.76,0,0,1-.6.64,2.55,2.55,0,0,1-.88.36,4.88,4.88,0,0,1-1,.11l-.45,0-.55-.08-.53-.14A1.87,1.87,0,0,1,850.65,99Z" fill="#2f2f2f"/>
-      <path d="M861.18,96.75H857.3a2,2,0,0,0,.49,1.42,1.71,1.71,0,0,0,1.3.5,2.7,2.7,0,0,0,1.71-.61v.83a3.23,3.23,0,0,1-1.92.52,2.31,2.31,0,0,1-1.83-.75,3,3,0,0,1-.67-2.11,3,3,0,0,1,.73-2.09,2.33,2.33,0,0,1,1.81-.81,2.09,2.09,0,0,1,1.67.7,2.94,2.94,0,0,1,.59,1.94Zm-.9-.74a1.84,1.84,0,0,0-.37-1.19,1.26,1.26,0,0,0-1-.42,1.42,1.42,0,0,0-1.06.44,2,2,0,0,0-.53,1.17Z" fill="#2f2f2f"/>
-      <path d="M866.34,99a2.88,2.88,0,0,1-1.5.38,2.48,2.48,0,0,1-1.9-.76,2.8,2.8,0,0,1-.73-2,3,3,0,0,1,.78-2.18,2.74,2.74,0,0,1,2.08-.83,2.9,2.9,0,0,1,1.28.27v.91A2.21,2.21,0,0,0,865,94.4a1.77,1.77,0,0,0-1.38.6,2.29,2.29,0,0,0-.54,1.59,2.21,2.21,0,0,0,.5,1.52,1.78,1.78,0,0,0,1.37.56,2.19,2.19,0,0,0,1.35-.48Z" fill="#2f2f2f"/>
-      <path d="M872.07,99.28h-.88v-.87h0a1.8,1.8,0,0,1-1.7,1c-1.31,0-2-.78-2-2.34V93.78h.87v3.15c0,1.16.45,1.74,1.34,1.74a1.38,1.38,0,0,0,1.06-.47,1.88,1.88,0,0,0,.41-1.25V93.78h.88Z" fill="#2f2f2f"/>
-      <path d="M876.66,94.67a1.16,1.16,0,0,0-.67-.17,1.1,1.1,0,0,0-.94.53,2.47,2.47,0,0,0-.38,1.45v2.8h-.88v-5.5h.88v1.14h0a2,2,0,0,1,.58-.91,1.26,1.26,0,0,1,.86-.32,1.51,1.51,0,0,1,.53.07Z" fill="#2f2f2f"/>
-      <path d="M878.14,92.39a.58.58,0,0,1-.4-.16.57.57,0,0,1-.17-.41.55.55,0,0,1,.17-.41.54.54,0,0,1,.4-.17.57.57,0,0,1,.41.17.55.55,0,0,1,.17.41.56.56,0,0,1-.17.4A.57.57,0,0,1,878.14,92.39Zm.43,6.89h-.88v-5.5h.88Z" fill="#2f2f2f"/>
-      <path d="M882.9,99.23a1.73,1.73,0,0,1-.82.17c-1,0-1.44-.54-1.44-1.61V94.53h-.95v-.75h.95V92.44l.88-.28v1.62h1.38v.75h-1.38v3.1a1.24,1.24,0,0,0,.19.79.73.73,0,0,0,.62.24.92.92,0,0,0,.57-.18Z" fill="#2f2f2f"/>
-      <path d="M888.83,93.78l-2.53,6.38c-.45,1.14-1.08,1.71-1.9,1.71a2,2,0,0,1-.58-.07V101a1.53,1.53,0,0,0,.52.1,1.08,1.08,0,0,0,1-.8l.44-1-2.14-5.49h1L886.1,98a3.62,3.62,0,0,1,.11.41h0a3.75,3.75,0,0,1,.1-.4l1.57-4.25Z" fill="#2f2f2f"/>
-      <path d="M859.7,112a4.54,4.54,0,0,1-2.13.45,3.41,3.41,0,0,1-2.63-1.06,3.88,3.88,0,0,1-1-2.77,4.09,4.09,0,0,1,1.11-3,3.77,3.77,0,0,1,2.82-1.14,4.57,4.57,0,0,1,1.82.32v1a3.66,3.66,0,0,0-1.83-.46,2.8,2.8,0,0,0-2.15.88,3.33,3.33,0,0,0-.82,2.37,3.17,3.17,0,0,0,.77,2.25,2.62,2.62,0,0,0,2,.83,3.76,3.76,0,0,0,2-.52Z" fill="#2f2f2f"/>
-      <path d="M865.47,109.75h-3.89a2,2,0,0,0,.5,1.42,1.71,1.71,0,0,0,1.3.5,2.7,2.7,0,0,0,1.71-.61v.83a3.23,3.23,0,0,1-1.92.52,2.31,2.31,0,0,1-1.83-.75,3,3,0,0,1-.67-2.11,3,3,0,0,1,.73-2.09,2.33,2.33,0,0,1,1.81-.81,2.09,2.09,0,0,1,1.67.7,2.94,2.94,0,0,1,.59,1.94Zm-.9-.74a1.84,1.84,0,0,0-.37-1.19,1.26,1.26,0,0,0-1-.42,1.4,1.4,0,0,0-1.06.44,2.06,2.06,0,0,0-.54,1.17Z" fill="#2f2f2f"/>
-      <path d="M871.41,112.28h-.88v-3.13c0-1.17-.43-1.75-1.28-1.75a1.38,1.38,0,0,0-1.09.49,1.84,1.84,0,0,0-.43,1.26v3.13h-.88v-5.5h.88v.92h0a2,2,0,0,1,1.8-1,1.69,1.69,0,0,1,1.38.59,2.57,2.57,0,0,1,.48,1.68Z" fill="#2f2f2f"/>
-      <path d="M875.58,112.23a1.75,1.75,0,0,1-.82.17c-1,0-1.45-.54-1.45-1.61v-3.26h-.94v-.75h.94v-1.34l.88-.28v1.62h1.39v.75h-1.39v3.1a1.3,1.3,0,0,0,.19.79.74.74,0,0,0,.62.24,1,1,0,0,0,.58-.18Z" fill="#2f2f2f"/>
-      <path d="M881.13,109.75h-3.88a2,2,0,0,0,.49,1.42,1.72,1.72,0,0,0,1.3.5,2.7,2.7,0,0,0,1.71-.61v.83a3.19,3.19,0,0,1-1.92.52,2.31,2.31,0,0,1-1.83-.75,3.09,3.09,0,0,1-.67-2.11,3,3,0,0,1,.73-2.09,2.34,2.34,0,0,1,1.81-.81,2.08,2.08,0,0,1,1.67.7,2.94,2.94,0,0,1,.59,1.94Zm-.9-.74a1.84,1.84,0,0,0-.37-1.19,1.26,1.26,0,0,0-1-.42,1.4,1.4,0,0,0-1.05.44,2.06,2.06,0,0,0-.54,1.17Z" fill="#2f2f2f"/>
-      <path d="M885.38,107.67a1.16,1.16,0,0,0-.67-.17,1.11,1.11,0,0,0-.94.53,2.47,2.47,0,0,0-.38,1.45v2.8h-.88v-5.5h.88v1.14h0A2,2,0,0,1,884,107a1.26,1.26,0,0,1,.86-.32,1.47,1.47,0,0,1,.53.07Z" fill="#2f2f2f"/>
-    </g>
-    <g>
-      <path d="M638.22,99.28h-1l-.82-2.16h-3.27l-.76,2.16h-1l3-7.7h.93Zm-2.12-3L634.9,93a3.15,3.15,0,0,1-.12-.52h0a2.78,2.78,0,0,1-.13.52l-1.2,3.28Z" fill="#2f2f2f"/>
-      <path d="M640.17,98.49h0v3.32h-.88v-8h.88v1h0a2.1,2.1,0,0,1,1.91-1.1,2,2,0,0,1,1.66.74,3.09,3.09,0,0,1,.59,2,3.39,3.39,0,0,1-.67,2.21,2.25,2.25,0,0,1-1.84.83A1.86,1.86,0,0,1,640.17,98.49Zm0-2.22V97a1.6,1.6,0,0,0,.45,1.15,1.57,1.57,0,0,0,2.37-.13,2.77,2.77,0,0,0,.46-1.7,2.21,2.21,0,0,0-.42-1.44,1.43,1.43,0,0,0-1.16-.53,1.54,1.54,0,0,0-1.23.54A2,2,0,0,0,640.15,96.27Z" fill="#2f2f2f"/>
-      <path d="M646.64,98.49h0v3.32h-.88v-8h.88v1h0a2.09,2.09,0,0,1,1.9-1.1,2,2,0,0,1,1.66.74,3,3,0,0,1,.6,2,3.45,3.45,0,0,1-.67,2.21,2.25,2.25,0,0,1-1.84.83A1.86,1.86,0,0,1,646.64,98.49Zm0-2.22V97a1.63,1.63,0,0,0,.44,1.15,1.58,1.58,0,0,0,2.38-.13,2.84,2.84,0,0,0,.46-1.7,2.21,2.21,0,0,0-.43-1.44,1.39,1.39,0,0,0-1.15-.53,1.54,1.54,0,0,0-1.23.54A1.91,1.91,0,0,0,646.62,96.27Z" fill="#2f2f2f"/>
-      <path d="M653.1,99.28h-.88V91.14h.88Z" fill="#2f2f2f"/>
-      <path d="M655.26,92.39a.56.56,0,0,1-.4-.17.52.52,0,0,1-.16-.4.53.53,0,0,1,.16-.41.56.56,0,0,1,.4-.17.59.59,0,0,1,.42.17.53.53,0,0,1,.16.41.55.55,0,0,1-.16.4A.59.59,0,0,1,655.26,92.39Zm.43,6.89h-.88v-5.5h.88Z" fill="#2f2f2f"/>
-      <path d="M661.18,99a2.88,2.88,0,0,1-1.5.38,2.48,2.48,0,0,1-1.9-.76,2.8,2.8,0,0,1-.72-2,3,3,0,0,1,.78-2.18,2.73,2.73,0,0,1,2.08-.83,2.86,2.86,0,0,1,1.27.27v.9a2.25,2.25,0,0,0-1.31-.43,1.78,1.78,0,0,0-1.38.61,2.29,2.29,0,0,0-.54,1.59,2.17,2.17,0,0,0,.51,1.52,1.76,1.76,0,0,0,1.36.56,2.19,2.19,0,0,0,1.35-.48Z" fill="#2f2f2f"/>
-      <path d="M666.54,99.28h-.88v-.86h0a1.83,1.83,0,0,1-1.69,1,1.79,1.79,0,0,1-1.28-.43,1.52,1.52,0,0,1-.47-1.16c0-1,.61-1.62,1.82-1.79l1.65-.23q0-1.41-1.14-1.41a2.7,2.7,0,0,0-1.79.68v-.9a3.43,3.43,0,0,1,1.87-.52c1.29,0,1.94.69,1.94,2Zm-.88-2.78-1.33.18a2.06,2.06,0,0,0-.92.31.86.86,0,0,0-.32.77.83.83,0,0,0,.29.65,1.12,1.12,0,0,0,.77.26,1.41,1.41,0,0,0,1.08-.46,1.66,1.66,0,0,0,.43-1.16Z" fill="#2f2f2f"/>
-      <path d="M670.73,99.23a1.8,1.8,0,0,1-.83.17c-1,0-1.44-.54-1.44-1.61V94.53h-1v-.75h1V92.44l.88-.28v1.62h1.39v.75h-1.39v3.1a1.24,1.24,0,0,0,.19.79.73.73,0,0,0,.62.24,1,1,0,0,0,.58-.18Z" fill="#2f2f2f"/>
-      <path d="M672.32,92.39a.54.54,0,0,1-.4-.17.53.53,0,0,1-.17-.4.53.53,0,0,1,.17-.41.54.54,0,0,1,.4-.17.57.57,0,0,1,.41.17.53.53,0,0,1,.17.41.56.56,0,0,1-.17.4A.57.57,0,0,1,672.32,92.39Zm.43,6.89h-.88v-5.5h.88Z" fill="#2f2f2f"/>
-      <path d="M676.81,99.41a2.58,2.58,0,0,1-1.95-.77,2.86,2.86,0,0,1-.73-2,3,3,0,0,1,.76-2.17,2.74,2.74,0,0,1,2.05-.78,2.48,2.48,0,0,1,1.92.76,3,3,0,0,1,.69,2.1,2.94,2.94,0,0,1-.75,2.11A2.58,2.58,0,0,1,676.81,99.41Zm.06-5a1.7,1.7,0,0,0-1.34.58,2.38,2.38,0,0,0-.49,1.59,2.22,2.22,0,0,0,.5,1.55,1.71,1.71,0,0,0,1.33.56,1.62,1.62,0,0,0,1.32-.55,2.46,2.46,0,0,0,.46-1.58,2.51,2.51,0,0,0-.46-1.59A1.63,1.63,0,0,0,676.87,94.39Z" fill="#2f2f2f"/>
-      <path d="M685.52,99.28h-.88V96.15c0-1.17-.42-1.76-1.28-1.76a1.39,1.39,0,0,0-1.09.5,1.84,1.84,0,0,0-.43,1.26v3.13H681v-5.5h.88v.92h0a2,2,0,0,1,1.8-1,1.69,1.69,0,0,1,1.38.59,2.57,2.57,0,0,1,.48,1.68Z" fill="#2f2f2f"/>
-      <path d="M641.94,112.28H641v-7.7h.9Z" fill="#2f2f2f"/>
-      <path d="M648.34,112.28h-.88v-3.13c0-1.17-.43-1.76-1.28-1.76a1.39,1.39,0,0,0-1.09.5,1.84,1.84,0,0,0-.43,1.26v3.13h-.89v-5.5h.89v.92h0a2,2,0,0,1,1.8-1,1.69,1.69,0,0,1,1.38.59,2.57,2.57,0,0,1,.48,1.68Z" fill="#2f2f2f"/>
-      <path d="M649.69,112.08v-.94a2.64,2.64,0,0,0,1.58.53c.78,0,1.16-.26,1.16-.77a.74.74,0,0,0-.09-.38,1.15,1.15,0,0,0-.27-.27,2.15,2.15,0,0,0-.4-.21l-.49-.2a4.32,4.32,0,0,1-.64-.29,2.17,2.17,0,0,1-.47-.33,1.37,1.37,0,0,1-.27-.42,1.4,1.4,0,0,1-.1-.56,1.3,1.3,0,0,1,.18-.68,1.5,1.5,0,0,1,.47-.5,1.91,1.91,0,0,1,.68-.3,2.88,2.88,0,0,1,.78-.11,3.28,3.28,0,0,1,1.28.25v.89a2.55,2.55,0,0,0-1.4-.4,1.58,1.58,0,0,0-.45.06,1.19,1.19,0,0,0-.34.16.83.83,0,0,0-.22.24.69.69,0,0,0-.08.32.8.8,0,0,0,.08.36.92.92,0,0,0,.23.26,2,2,0,0,0,.36.2l.49.2a5.2,5.2,0,0,1,.66.29,2,2,0,0,1,.49.33,1.34,1.34,0,0,1,.32.43,1.41,1.41,0,0,1,.11.57,1.36,1.36,0,0,1-.18.71,1.53,1.53,0,0,1-.48.5,2.11,2.11,0,0,1-.7.29,3.43,3.43,0,0,1-2.29-.23Z" fill="#2f2f2f"/>
-      <path d="M655.09,105.39a.57.57,0,0,1-.41-.17.52.52,0,0,1-.16-.4.53.53,0,0,1,.16-.41.57.57,0,0,1,.41-.17.58.58,0,0,1,.41.17.53.53,0,0,1,.17.41.56.56,0,0,1-.17.4A.58.58,0,0,1,655.09,105.39Zm.42,6.89h-.88v-5.5h.88Z" fill="#2f2f2f"/>
-      <path d="M662,111.84c0,2-1,3-2.9,3a3.86,3.86,0,0,1-1.78-.39v-.88a3.6,3.6,0,0,0,1.77.52c1.35,0,2-.72,2-2.16v-.6h0a2.06,2.06,0,0,1-1.89,1,2,2,0,0,1-1.65-.73,2.93,2.93,0,0,1-.63-2,3.49,3.49,0,0,1,.67-2.23,2.27,2.27,0,0,1,1.85-.83,1.8,1.8,0,0,1,1.65.89h0v-.76H662Zm-.88-2V109a1.6,1.6,0,0,0-.44-1.12,1.49,1.49,0,0,0-1.11-.47,1.53,1.53,0,0,0-1.28.6,2.69,2.69,0,0,0-.46,1.66,2.26,2.26,0,0,0,.45,1.47,1.41,1.41,0,0,0,1.17.55,1.55,1.55,0,0,0,1.21-.53A2,2,0,0,0,661.09,109.8Z" fill="#2f2f2f"/>
-      <path d="M668.25,112.28h-.88v-3.17c0-1.14-.43-1.72-1.28-1.72a1.38,1.38,0,0,0-1.08.5,1.83,1.83,0,0,0-.44,1.28v3.11h-.89v-8.14h.89v3.56h0a2,2,0,0,1,1.8-1c1.24,0,1.86.75,1.86,2.24Z" fill="#2f2f2f"/>
-      <path d="M672.42,112.23a1.73,1.73,0,0,1-.82.17c-1,0-1.44-.54-1.44-1.61v-3.26h-.95v-.75h.95v-1.34l.88-.28v1.62h1.38v.75H671v3.1a1.31,1.31,0,0,0,.18.79.77.77,0,0,0,.63.24.92.92,0,0,0,.57-.18Z" fill="#2f2f2f"/>
-      <path d="M673.4,112.08v-.94a2.64,2.64,0,0,0,1.58.53c.78,0,1.16-.26,1.16-.77a.74.74,0,0,0-.09-.38,1.15,1.15,0,0,0-.27-.27,2.15,2.15,0,0,0-.4-.21l-.49-.2a4.32,4.32,0,0,1-.64-.29,2.17,2.17,0,0,1-.47-.33,1.37,1.37,0,0,1-.27-.42,1.4,1.4,0,0,1-.1-.56,1.3,1.3,0,0,1,.18-.68,1.5,1.5,0,0,1,.47-.5,1.91,1.91,0,0,1,.68-.3,2.88,2.88,0,0,1,.78-.11,3.28,3.28,0,0,1,1.28.25v.89a2.57,2.57,0,0,0-1.4-.4,1.58,1.58,0,0,0-.45.06,1.19,1.19,0,0,0-.34.16.83.83,0,0,0-.22.24.69.69,0,0,0-.08.32.8.8,0,0,0,.08.36.92.92,0,0,0,.23.26,2,2,0,0,0,.36.2l.49.2a5.2,5.2,0,0,1,.66.29,2,2,0,0,1,.49.33,1.34,1.34,0,0,1,.32.43,1.41,1.41,0,0,1,.11.57,1.36,1.36,0,0,1-.18.71,1.53,1.53,0,0,1-.48.5,2.11,2.11,0,0,1-.7.29,3.43,3.43,0,0,1-2.29-.23Z" fill="#2f2f2f"/>
-    </g>
-    <g>
-      <path d="M717.49,98.78h-1l-.82-2.16h-3.27l-.76,2.16h-1l3-7.7h.94Zm-2.11-3-1.21-3.28c0-.11-.07-.28-.11-.51h0a2.86,2.86,0,0,1-.13.51l-1.2,3.28Z" fill="#2f2f2f"/>
-      <path d="M722.74,93.53,719.48,98h3.23v.75h-4.52v-.27L721.44,94h-3v-.75h4.25Z" fill="#2f2f2f"/>
-      <path d="M728.37,98.78h-.88v-.87h0a1.81,1.81,0,0,1-1.7,1c-1.31,0-2-.78-2-2.34V93.28h.88v3.15c0,1.16.44,1.74,1.33,1.74a1.35,1.35,0,0,0,1.06-.47,1.84,1.84,0,0,0,.42-1.25V93.28h.88Z" fill="#2f2f2f"/>
-      <path d="M733,94.17a1.11,1.11,0,0,0-.66-.17,1.13,1.13,0,0,0-.95.53A2.47,2.47,0,0,0,731,96v2.8h-.89v-5.5H731v1.14h0a1.87,1.87,0,0,1,.57-.91,1.3,1.3,0,0,1,.87-.32,1.41,1.41,0,0,1,.52.07Z" fill="#2f2f2f"/>
-      <path d="M738.39,96.25h-3.88a2,2,0,0,0,.49,1.42,1.71,1.71,0,0,0,1.3.5,2.7,2.7,0,0,0,1.71-.61v.83a3.23,3.23,0,0,1-1.92.52,2.31,2.31,0,0,1-1.83-.75,3,3,0,0,1-.67-2.11,3,3,0,0,1,.73-2.09,2.33,2.33,0,0,1,1.81-.81,2.09,2.09,0,0,1,1.67.7,2.94,2.94,0,0,1,.59,1.94Zm-.9-.74a1.84,1.84,0,0,0-.37-1.19,1.26,1.26,0,0,0-1-.42,1.42,1.42,0,0,0-1.06.44,2,2,0,0,0-.53,1.17Z" fill="#2f2f2f"/>
-      <path d="M714,111.78h-.9v-5.16c0-.41,0-.91.08-1.5h0a7,7,0,0,1-.23.74l-2.64,5.92h-.44l-2.62-5.87a3.69,3.69,0,0,1-.23-.79h0c0,.31,0,.81,0,1.51v5.15h-.87v-7.7h1.19l2.36,5.37a6.56,6.56,0,0,1,.36.93h0c.15-.43.28-.74.37-.95l2.41-5.35H714Z" fill="#2f2f2f"/>
-      <path d="M718.18,111.91a2.55,2.55,0,0,1-1.95-.77,2.86,2.86,0,0,1-.73-2,3,3,0,0,1,.76-2.17,2.72,2.72,0,0,1,2-.78,2.48,2.48,0,0,1,1.92.76,3,3,0,0,1,.69,2.1,2.94,2.94,0,0,1-.75,2.11A2.58,2.58,0,0,1,718.18,111.91Zm.06-5a1.69,1.69,0,0,0-1.34.57,2.39,2.39,0,0,0-.49,1.6,2.21,2.21,0,0,0,.5,1.54,1.69,1.69,0,0,0,1.33.56,1.62,1.62,0,0,0,1.32-.55A2.46,2.46,0,0,0,720,109a2.51,2.51,0,0,0-.45-1.59A1.62,1.62,0,0,0,718.24,106.9Z" fill="#2f2f2f"/>
-      <path d="M726.89,111.78H726v-3.13c0-1.17-.43-1.75-1.28-1.75a1.38,1.38,0,0,0-1.09.49,1.84,1.84,0,0,0-.43,1.26v3.13h-.89v-5.5h.89v.92h0a2,2,0,0,1,1.8-1,1.69,1.69,0,0,1,1.38.59,2.57,2.57,0,0,1,.48,1.68Z" fill="#2f2f2f"/>
-      <path d="M729,104.89a.6.6,0,0,1-.41-.16.56.56,0,0,1-.16-.41.54.54,0,0,1,.16-.41.57.57,0,0,1,.41-.17.58.58,0,0,1,.41.17.55.55,0,0,1,.17.41.56.56,0,0,1-.17.4A.58.58,0,0,1,729,104.89Zm.43,6.89h-.88v-5.5h.88Z" fill="#2f2f2f"/>
-      <path d="M733.74,111.73a1.75,1.75,0,0,1-.82.17c-1,0-1.45-.54-1.45-1.61V107h-.94v-.75h.94v-1.34l.88-.28v1.62h1.39V107h-1.39v3.1a1.3,1.3,0,0,0,.19.79.77.77,0,0,0,.63.24.92.92,0,0,0,.57-.18Z" fill="#2f2f2f"/>
-      <path d="M737.14,111.91a2.51,2.51,0,0,1-1.94-.77,2.82,2.82,0,0,1-.73-2,3,3,0,0,1,.76-2.17,2.7,2.7,0,0,1,2-.78,2.48,2.48,0,0,1,1.92.76,3,3,0,0,1,.69,2.1,2.94,2.94,0,0,1-.74,2.11A2.61,2.61,0,0,1,737.14,111.91Zm.07-5a1.67,1.67,0,0,0-1.34.57,2.39,2.39,0,0,0-.5,1.6,2.26,2.26,0,0,0,.5,1.54,1.71,1.71,0,0,0,1.34.56,1.59,1.59,0,0,0,1.31-.55A2.4,2.4,0,0,0,739,109a2.45,2.45,0,0,0-.46-1.59A1.59,1.59,0,0,0,737.21,106.9Z" fill="#2f2f2f"/>
-      <path d="M744.16,107.17a1.14,1.14,0,0,0-.67-.17,1.11,1.11,0,0,0-.94.53,2.47,2.47,0,0,0-.38,1.45v2.8h-.88v-5.5h.88v1.14h0a2,2,0,0,1,.58-.91,1.28,1.28,0,0,1,.86-.32,1.47,1.47,0,0,1,.53.07Z" fill="#2f2f2f"/>
-    </g>
-    <g>
-      <path d="M950.86,99.28h-1L949,97.12h-3.26L945,99.28h-1l3-7.7h.93Zm-2.11-3L947.54,93a3.24,3.24,0,0,1-.12-.51h0a4.37,4.37,0,0,1-.12.51l-1.2,3.28Z" fill="#2f2f2f"/>
-      <path d="M956.1,94l-3.25,4.5h3.22v.75h-4.52V99l3.26-4.48h-2.95v-.75h4.24Z" fill="#2f2f2f"/>
-      <path d="M961.73,99.28h-.88v-.87h0a1.8,1.8,0,0,1-1.7,1c-1.31,0-2-.78-2-2.34V93.78H958v3.15c0,1.16.45,1.74,1.34,1.74a1.38,1.38,0,0,0,1.06-.47,1.88,1.88,0,0,0,.41-1.25V93.78h.88Z" fill="#2f2f2f"/>
-      <path d="M966.31,94.67a1.18,1.18,0,0,0-1.6.36,2.4,2.4,0,0,0-.38,1.45v2.8h-.88v-5.5h.88v1.14h0a2,2,0,0,1,.57-.91,1.3,1.3,0,0,1,.87-.32,1.41,1.41,0,0,1,.52.07Z" fill="#2f2f2f"/>
-      <path d="M971.75,96.75h-3.88a2,2,0,0,0,.49,1.42,1.72,1.72,0,0,0,1.3.5,2.7,2.7,0,0,0,1.71-.61v.83a3.19,3.19,0,0,1-1.92.52,2.31,2.31,0,0,1-1.83-.75,3.09,3.09,0,0,1-.67-2.11,3,3,0,0,1,.73-2.09,2.34,2.34,0,0,1,1.81-.81,2.08,2.08,0,0,1,1.67.7,2.94,2.94,0,0,1,.59,1.94Zm-.9-.74a1.84,1.84,0,0,0-.37-1.19,1.26,1.26,0,0,0-1-.42,1.4,1.4,0,0,0-1.05.44,2.06,2.06,0,0,0-.54,1.17Z" fill="#2f2f2f"/>
-      <path d="M939.84,112.28v-7.7H942q4.06,0,4.07,3.75a3.8,3.8,0,0,1-1.13,2.87,4.19,4.19,0,0,1-3,1.08Zm.9-6.88v6.07h1.15a3.27,3.27,0,0,0,2.36-.81,3.05,3.05,0,0,0,.84-2.3c0-2-1-3-3.14-3Z" fill="#2f2f2f"/>
-      <path d="M951.89,109.75H948a2,2,0,0,0,.49,1.42,1.72,1.72,0,0,0,1.3.5,2.7,2.7,0,0,0,1.71-.61v.83a3.19,3.19,0,0,1-1.92.52,2.34,2.34,0,0,1-1.83-.75,3.08,3.08,0,0,1-.66-2.11,3,3,0,0,1,.72-2.09,2.34,2.34,0,0,1,1.81-.81,2.08,2.08,0,0,1,1.67.7,2.88,2.88,0,0,1,.59,1.94ZM951,109a1.78,1.78,0,0,0-.37-1.19,1.26,1.26,0,0,0-1-.42,1.4,1.4,0,0,0-1.05.44A2.06,2.06,0,0,0,948,109Z" fill="#2f2f2f"/>
-      <path d="M957.56,106.78l-2.19,5.5h-.87l-2.08-5.5h1l1.4,4a3.43,3.43,0,0,1,.19.77h0a3.75,3.75,0,0,1,.18-.75l1.46-4Z" fill="#2f2f2f"/>
-      <path d="M961.9,112.41a3.39,3.39,0,0,1-2.63-1.08,4,4,0,0,1-1-2.81,4.23,4.23,0,0,1,1-3,3.51,3.51,0,0,1,2.74-1.11,3.3,3.3,0,0,1,2.57,1.08,4,4,0,0,1,1,2.8,4.26,4.26,0,0,1-1,3A3.43,3.43,0,0,1,961.9,112.41Zm.06-7.14a2.48,2.48,0,0,0-2,.87,3.89,3.89,0,0,0,0,4.59,2.4,2.4,0,0,0,1.93.87,2.48,2.48,0,0,0,2-.83,3.36,3.36,0,0,0,.74-2.31,3.56,3.56,0,0,0-.71-2.36A2.47,2.47,0,0,0,962,105.27Z" fill="#2f2f2f"/>
-      <path d="M967.92,111.49h0v3.32H967v-8h.88v1h0a2.08,2.08,0,0,1,1.9-1.1,2,2,0,0,1,1.66.74,3.09,3.09,0,0,1,.59,2,3.39,3.39,0,0,1-.67,2.21,2.22,2.22,0,0,1-1.84.83A1.83,1.83,0,0,1,967.92,111.49Zm0-2.22V110a1.64,1.64,0,0,0,.45,1.16,1.59,1.59,0,0,0,2.38-.14,2.84,2.84,0,0,0,.45-1.7,2.21,2.21,0,0,0-.42-1.44,1.41,1.41,0,0,0-1.15-.52,1.56,1.56,0,0,0-1.24.53A2,2,0,0,0,967.89,109.27Z" fill="#2f2f2f"/>
-      <path d="M973.14,112.08v-.94a2.61,2.61,0,0,0,1.58.53c.77,0,1.16-.26,1.16-.77a.67.67,0,0,0-.1-.38.87.87,0,0,0-.27-.27,1.79,1.79,0,0,0-.39-.21l-.5-.2a5.53,5.53,0,0,1-.64-.29,2.09,2.09,0,0,1-.46-.33,1.29,1.29,0,0,1-.28-.42,1.6,1.6,0,0,1-.09-.56,1.4,1.4,0,0,1,.17-.68,1.53,1.53,0,0,1,.48-.5,2,2,0,0,1,.67-.3,2.88,2.88,0,0,1,.78-.11,3.21,3.21,0,0,1,1.28.25v.89a2.52,2.52,0,0,0-1.4-.39,1.52,1.52,0,0,0-.44,0,1.07,1.07,0,0,0-.34.16.71.71,0,0,0-.22.24.69.69,0,0,0-.08.32.8.8,0,0,0,.08.36.92.92,0,0,0,.23.26,2,2,0,0,0,.36.2l.49.2a6.86,6.86,0,0,1,.66.29,2.62,2.62,0,0,1,.49.33,1.18,1.18,0,0,1,.31.43,1.26,1.26,0,0,1,.11.57,1.36,1.36,0,0,1-.18.71,1.53,1.53,0,0,1-.48.5,2.4,2.4,0,0,1-.69.3,3.68,3.68,0,0,1-.82.09A3.07,3.07,0,0,1,973.14,112.08Z" fill="#2f2f2f"/>
-    </g>
-    <g>
-      <path d="M1067.67,98.76a5.23,5.23,0,0,1-2.58.65,3.53,3.53,0,0,1-2.67-1.06,4.4,4.4,0,0,1,.12-5.75,3.83,3.83,0,0,1,2.86-1.15,4.9,4.9,0,0,1,2.11.41v1a4,4,0,0,0-2.21-.59,2.78,2.78,0,0,0-2.12.89,3.25,3.25,0,0,0-.83,2.31,3.3,3.3,0,0,0,.77,2.3,2.71,2.71,0,0,0,2.08.83,3.25,3.25,0,0,0,1.57-.36V96.08h-1.69v-.81h2.59Z" fill="#2f2f2f"/>
-      <path d="M1069.78,92.39a.58.58,0,0,1-.4-.16.53.53,0,0,1-.17-.41.52.52,0,0,1,.17-.41.54.54,0,0,1,.4-.17.57.57,0,0,1,.41.17.55.55,0,0,1,.17.41.56.56,0,0,1-.17.4A.57.57,0,0,1,1069.78,92.39Zm.43,6.89h-.88v-5.5h.88Z" fill="#2f2f2f"/>
-      <path d="M1074.54,99.23a1.75,1.75,0,0,1-.82.17c-1,0-1.44-.54-1.44-1.61V94.53h-1v-.75h1V92.44l.88-.28v1.62h1.38v.75h-1.38v3.1a1.31,1.31,0,0,0,.18.79.77.77,0,0,0,.63.24.92.92,0,0,0,.57-.18Z" fill="#2f2f2f"/>
-      <path d="M1081.58,99.28h-.91V95.77h-4v3.51h-.9v-7.7h.9V95h4V91.58h.91Z" fill="#2f2f2f"/>
-      <path d="M1087.91,99.28H1087v-.87h0a1.82,1.82,0,0,1-1.7,1c-1.31,0-2-.78-2-2.34V93.78h.88v3.15c0,1.16.44,1.74,1.33,1.74a1.37,1.37,0,0,0,1.06-.47A1.84,1.84,0,0,0,1087,97V93.78h.88Z" fill="#2f2f2f"/>
-      <path d="M1090.52,98.49h0v.79h-.88V91.14h.88v3.61h0a2.1,2.1,0,0,1,1.91-1.1,2,2,0,0,1,1.65.74,3,3,0,0,1,.6,2,3.39,3.39,0,0,1-.67,2.21,2.22,2.22,0,0,1-1.84.83A1.83,1.83,0,0,1,1090.52,98.49Zm0-2.22V97a1.64,1.64,0,0,0,.45,1.16,1.59,1.59,0,0,0,2.38-.14,2.84,2.84,0,0,0,.45-1.7,2.15,2.15,0,0,0-.43-1.44,1.38,1.38,0,0,0-1.14-.52,1.54,1.54,0,0,0-1.24.53A2,2,0,0,0,1090.5,96.27Z" fill="#2f2f2f"/>
-      <path d="M1067,112.28h-1l-.82-2.16h-3.27l-.76,2.16h-1l2.95-7.7h.94Zm-2.11-3-1.21-3.28c0-.11-.07-.28-.11-.51h0a2.86,2.86,0,0,1-.13.51l-1.2,3.28Z" fill="#2f2f2f"/>
-      <path d="M1071.7,112a2.88,2.88,0,0,1-1.5.38,2.48,2.48,0,0,1-1.9-.76,2.8,2.8,0,0,1-.72-2,3,3,0,0,1,.78-2.18,2.7,2.7,0,0,1,2.07-.83,2.87,2.87,0,0,1,1.28.27v.91a2.21,2.21,0,0,0-1.31-.43,1.77,1.77,0,0,0-1.38.6,2.29,2.29,0,0,0-.54,1.59,2.17,2.17,0,0,0,.51,1.52,1.74,1.74,0,0,0,1.36.56,2.19,2.19,0,0,0,1.35-.48Z" fill="#2f2f2f"/>
-      <path d="M1075.81,112.23a1.75,1.75,0,0,1-.82.17c-1,0-1.45-.54-1.45-1.61v-3.26h-.94v-.75h.94v-1.34l.88-.28v1.62h1.39v.75h-1.39v3.1a1.3,1.3,0,0,0,.19.79.77.77,0,0,0,.63.24.92.92,0,0,0,.57-.18Z" fill="#2f2f2f"/>
-      <path d="M1077.4,105.39a.59.59,0,0,1-.4-.16.56.56,0,0,1-.16-.41.54.54,0,0,1,.16-.41.56.56,0,0,1,.4-.17.59.59,0,0,1,.42.17.54.54,0,0,1,.16.41.55.55,0,0,1-.16.4A.59.59,0,0,1,1077.4,105.39Zm.43,6.89H1077v-5.5h.88Z" fill="#2f2f2f"/>
-      <path d="M1081.89,112.41a2.51,2.51,0,0,1-1.94-.77,2.82,2.82,0,0,1-.73-2,3,3,0,0,1,.76-2.17,2.7,2.7,0,0,1,2-.78,2.48,2.48,0,0,1,1.92.76,3,3,0,0,1,.69,2.1,2.94,2.94,0,0,1-.74,2.11A2.61,2.61,0,0,1,1081.89,112.41Zm.07-5a1.67,1.67,0,0,0-1.34.57,2.39,2.39,0,0,0-.5,1.6,2.26,2.26,0,0,0,.5,1.54,1.71,1.71,0,0,0,1.34.56,1.59,1.59,0,0,0,1.31-.55,2.4,2.4,0,0,0,.46-1.58,2.45,2.45,0,0,0-.46-1.59A1.59,1.59,0,0,0,1082,107.4Z" fill="#2f2f2f"/>
-      <path d="M1090.61,112.28h-.88v-3.13c0-1.17-.43-1.75-1.28-1.75a1.4,1.4,0,0,0-1.1.49,1.89,1.89,0,0,0-.43,1.26v3.13H1086v-5.5h.88v.92h0a2,2,0,0,1,1.81-1,1.69,1.69,0,0,1,1.38.59,2.57,2.57,0,0,1,.48,1.68Z" fill="#2f2f2f"/>
-      <path d="M1092,112.08v-.94a2.64,2.64,0,0,0,1.58.53c.77,0,1.16-.26,1.16-.77a.67.67,0,0,0-.1-.38.87.87,0,0,0-.27-.27,1.79,1.79,0,0,0-.39-.21l-.5-.2a5.53,5.53,0,0,1-.64-.29,2.36,2.36,0,0,1-.46-.33,1.29,1.29,0,0,1-.28-.42,1.6,1.6,0,0,1-.09-.56,1.4,1.4,0,0,1,.17-.68,1.53,1.53,0,0,1,.48-.5,2,2,0,0,1,.67-.3,2.88,2.88,0,0,1,.78-.11,3.21,3.21,0,0,1,1.28.25v.89a2.51,2.51,0,0,0-1.39-.39,1.55,1.55,0,0,0-.45,0,1.07,1.07,0,0,0-.34.16.71.71,0,0,0-.22.24.69.69,0,0,0-.08.32.8.8,0,0,0,.08.36.92.92,0,0,0,.23.26,2,2,0,0,0,.36.2l.49.2a6.86,6.86,0,0,1,.66.29,2.62,2.62,0,0,1,.49.33,1.18,1.18,0,0,1,.31.43,1.26,1.26,0,0,1,.11.57,1.36,1.36,0,0,1-.18.71,1.53,1.53,0,0,1-.48.5,2.4,2.4,0,0,1-.69.3,3.62,3.62,0,0,1-.82.09A3.07,3.07,0,0,1,1092,112.08Z" fill="#2f2f2f"/>
-    </g>
-    <g>
-      <path d="M1005.72,100.37a3.44,3.44,0,0,1-.58,2.13,1.84,1.84,0,0,1-1.55.76,1.75,1.75,0,0,1-.74-.13v-.89a1.23,1.23,0,0,0,.75.21c.81,0,1.22-.69,1.22-2.07V95.43h.9Z" fill="#2f2f2f"/>
-      <path d="M1012,100.6h-3.89a2.07,2.07,0,0,0,.5,1.42,1.69,1.69,0,0,0,1.3.5,2.67,2.67,0,0,0,1.7-.61v.82a3.11,3.11,0,0,1-1.91.53,2.35,2.35,0,0,1-1.84-.75,3.08,3.08,0,0,1-.66-2.11,3,3,0,0,1,.73-2.09,2.31,2.31,0,0,1,1.8-.81,2.08,2.08,0,0,1,1.67.7,2.89,2.89,0,0,1,.6,1.94Zm-.91-.74a1.73,1.73,0,0,0-.37-1.19,1.25,1.25,0,0,0-1-.43,1.41,1.41,0,0,0-1.06.45,2.06,2.06,0,0,0-.54,1.17Z" fill="#2f2f2f"/>
-      <path d="M1017.9,103.13H1017V100c0-1.16-.43-1.75-1.28-1.75a1.38,1.38,0,0,0-1.09.5,1.83,1.83,0,0,0-.44,1.25v3.14h-.88v-5.5h.88v.91h0a2,2,0,0,1,1.8-1,1.69,1.69,0,0,1,1.38.59,2.57,2.57,0,0,1,.48,1.68Z" fill="#2f2f2f"/>
-      <path d="M1024.11,103.13h-1.23l-2.43-2.64h0v2.64h-.88V95h.88v5.16h0l2.31-2.52h1.15l-2.55,2.65Z" fill="#2f2f2f"/>
-      <path d="M1025.57,96.24a.54.54,0,0,1-.4-.17.53.53,0,0,1-.17-.4.56.56,0,0,1,.57-.58.6.6,0,0,1,.41.16.57.57,0,0,1,.17.42.56.56,0,0,1-.17.4A.57.57,0,0,1,1025.57,96.24Zm.43,6.89h-.88v-5.5h.88Z" fill="#2f2f2f"/>
-      <path d="M1032.29,103.13h-.88V100c0-1.16-.43-1.75-1.28-1.75a1.38,1.38,0,0,0-1.09.5,1.83,1.83,0,0,0-.44,1.25v3.14h-.88v-5.5h.88v.91h0a2,2,0,0,1,1.8-1,1.69,1.69,0,0,1,1.38.59,2.57,2.57,0,0,1,.48,1.68Z" fill="#2f2f2f"/>
-      <path d="M1033.64,102.93V102a2.64,2.64,0,0,0,1.58.53c.78,0,1.16-.26,1.16-.77a.74.74,0,0,0-.09-.38,1.15,1.15,0,0,0-.27-.27,2.15,2.15,0,0,0-.4-.21l-.49-.2a4.32,4.32,0,0,1-.64-.29,2.17,2.17,0,0,1-.47-.33,1.62,1.62,0,0,1-.28-.42,1.6,1.6,0,0,1-.09-.56,1.28,1.28,0,0,1,.18-.68,1.5,1.5,0,0,1,.47-.5,2.16,2.16,0,0,1,.67-.31,3.49,3.49,0,0,1,.79-.1,3.2,3.2,0,0,1,1.27.25v.89a2.52,2.52,0,0,0-1.39-.4,1.53,1.53,0,0,0-.45.06,1.19,1.19,0,0,0-.34.16.83.83,0,0,0-.22.24.69.69,0,0,0-.08.32.8.8,0,0,0,.08.36.92.92,0,0,0,.23.26,2,2,0,0,0,.36.2l.49.2a5.91,5.91,0,0,1,.66.29,1.75,1.75,0,0,1,.49.33,1.24,1.24,0,0,1,.32.43,1.41,1.41,0,0,1,.11.57,1.36,1.36,0,0,1-.18.71,1.53,1.53,0,0,1-.48.5,2.3,2.3,0,0,1-.7.29,3.43,3.43,0,0,1-2.29-.23Z" fill="#2f2f2f"/>
-    </g>
-    <g>
-      <path d="M8.13,490.05a4.26,4.26,0,0,1-3.33-1.37,5.09,5.09,0,0,1-1.26-3.57,5.42,5.42,0,0,1,1.28-3.78,4.46,4.46,0,0,1,3.48-1.41,4.22,4.22,0,0,1,3.27,1.37,5.1,5.1,0,0,1,1.24,3.58,5.4,5.4,0,0,1-1.27,3.79A4.38,4.38,0,0,1,8.13,490.05ZM8.22,481a3.14,3.14,0,0,0-2.51,1.12,4.3,4.3,0,0,0-1,2.92,4.39,4.39,0,0,0,.94,2.92A3.09,3.09,0,0,0,8.13,489a3.23,3.23,0,0,0,2.55-1,4.31,4.31,0,0,0,.93-3,4.46,4.46,0,0,0-.91-3A3.1,3.1,0,0,0,8.22,481Z" fill="#2f2f2f"/>
-      <path d="M20.39,489.89H19.27v-4c0-1.49-.55-2.23-1.63-2.23a1.76,1.76,0,0,0-1.39.63,2.34,2.34,0,0,0-.55,1.6v4H14.58v-7H15.7v1.16h0a2.54,2.54,0,0,1,2.3-1.32,2.13,2.13,0,0,1,1.76.74,3.33,3.33,0,0,1,.61,2.14Z" fill="#2f2f2f"/>
-      <path d="M26,486.43H22.26v-.88H26Z" fill="#2f2f2f"/>
-      <path d="M29.05,488.88h0v4.23H27.9V482.89H29v1.23h0a2.65,2.65,0,0,1,2.42-1.39,2.56,2.56,0,0,1,2.12.94,3.9,3.9,0,0,1,.75,2.52,4.34,4.34,0,0,1-.85,2.81,2.86,2.86,0,0,1-2.34,1.05A2.35,2.35,0,0,1,29.05,488.88Zm0-2.82v1a2.09,2.09,0,0,0,.56,1.48,2,2,0,0,0,3-.18,3.61,3.61,0,0,0,.58-2.17,2.83,2.83,0,0,0-.54-1.83,1.8,1.8,0,0,0-1.47-.66,2,2,0,0,0-1.57.68A2.47,2.47,0,0,0,29,486.06Z" fill="#2f2f2f"/>
-      <path d="M39.71,484a1.31,1.31,0,0,0-.85-.23,1.45,1.45,0,0,0-1.2.68,3.12,3.12,0,0,0-.48,1.84v3.57H36.06v-7h1.12v1.44h0a2.46,2.46,0,0,1,.73-1.15,1.71,1.71,0,0,1,1.1-.41,1.92,1.92,0,0,1,.67.09Z" fill="#2f2f2f"/>
-      <path d="M46.55,486.67H41.61a2.66,2.66,0,0,0,.63,1.81,2.17,2.17,0,0,0,1.65.63,3.45,3.45,0,0,0,2.18-.78v1.05a4.05,4.05,0,0,1-2.44.67,2.93,2.93,0,0,1-2.33-.95,3.88,3.88,0,0,1-.85-2.68,3.84,3.84,0,0,1,.93-2.67,3,3,0,0,1,2.3-1,2.6,2.6,0,0,1,2.12.89,3.69,3.69,0,0,1,.75,2.46Zm-1.14-.95a2.35,2.35,0,0,0-.47-1.51,1.6,1.6,0,0,0-1.28-.54,1.81,1.81,0,0,0-1.35.57,2.52,2.52,0,0,0-.68,1.48Z" fill="#2f2f2f"/>
-      <path d="M58.18,489.89H57.06v-4a3,3,0,0,0-.36-1.68,1.37,1.37,0,0,0-1.21-.52,1.48,1.48,0,0,0-1.22.66,2.46,2.46,0,0,0-.5,1.57v4H52.65v-4.16c0-1.37-.53-2.06-1.6-2.06a1.48,1.48,0,0,0-1.21.62,2.55,2.55,0,0,0-.48,1.61v4H48.24v-7h1.12V484h0a2.36,2.36,0,0,1,2.17-1.27,2,2,0,0,1,1.25.4,1.92,1.92,0,0,1,.73,1.05,2.5,2.5,0,0,1,2.33-1.45q2.31,0,2.31,2.85Z" fill="#2f2f2f"/>
-      <path d="M60.76,481.11a.73.73,0,0,1-.51-.2.7.7,0,0,1-.21-.52.69.69,0,0,1,.21-.52.69.69,0,0,1,.51-.21.74.74,0,0,1,.53.21.69.69,0,0,1,.21.52.69.69,0,0,1-.21.51A.74.74,0,0,1,60.76,481.11Zm.55,8.78H60.19v-7h1.12Z" fill="#2f2f2f"/>
-      <path d="M63,489.64v-1.21a3.26,3.26,0,0,0,2,.68c1,0,1.47-.33,1.47-1a.9.9,0,0,0-.12-.48,1.26,1.26,0,0,0-.35-.34,2.61,2.61,0,0,0-.5-.27c-.2-.08-.4-.17-.63-.25a7.83,7.83,0,0,1-.81-.38,2.07,2.07,0,0,1-.59-.42,1.6,1.6,0,0,1-.36-.54,1.86,1.86,0,0,1-.12-.7,1.66,1.66,0,0,1,.23-.87,1.93,1.93,0,0,1,.6-.64,2.68,2.68,0,0,1,.86-.38,3.64,3.64,0,0,1,1-.13,4,4,0,0,1,1.63.31v1.14a3.17,3.17,0,0,0-1.78-.51,2,2,0,0,0-.57.07,1.71,1.71,0,0,0-.43.2,1,1,0,0,0-.28.31.79.79,0,0,0-.1.4.9.9,0,0,0,.1.46,1,1,0,0,0,.29.33,2.07,2.07,0,0,0,.47.26l.62.25a7.3,7.3,0,0,1,.83.37,2.47,2.47,0,0,1,.63.42,1.66,1.66,0,0,1,.4.55,1.92,1.92,0,0,1-.09,1.63,2.07,2.07,0,0,1-.61.64,3,3,0,0,1-.88.37,4.51,4.51,0,0,1-1,.12A4.06,4.06,0,0,1,63,489.64Z" fill="#2f2f2f"/>
-      <path d="M75,486.67H70a2.66,2.66,0,0,0,.63,1.81,2.17,2.17,0,0,0,1.65.63,3.45,3.45,0,0,0,2.18-.78v1.05a4.05,4.05,0,0,1-2.44.67,2.93,2.93,0,0,1-2.33-.95,3.88,3.88,0,0,1-.85-2.68,3.84,3.84,0,0,1,.93-2.67,3,3,0,0,1,2.3-1,2.6,2.6,0,0,1,2.12.89,3.69,3.69,0,0,1,.75,2.46Zm-1.14-.95a2.35,2.35,0,0,0-.47-1.51,1.6,1.6,0,0,0-1.28-.54,1.81,1.81,0,0,0-1.35.57,2.59,2.59,0,0,0-.69,1.48Z" fill="#2f2f2f"/>
-      <path d="M76.23,489.64v-1.21a3.25,3.25,0,0,0,2,.68c1,0,1.48-.33,1.48-1a.82.82,0,0,0-.13-.48,1.22,1.22,0,0,0-.34-.34,2.43,2.43,0,0,0-.51-.27l-.62-.25c-.31-.13-.58-.25-.82-.38a2.4,2.4,0,0,1-.59-.42,1.73,1.73,0,0,1-.35-.54,1.86,1.86,0,0,1-.12-.7,1.57,1.57,0,0,1,.23-.87,1.93,1.93,0,0,1,.6-.64,2.63,2.63,0,0,1,.85-.38,3.76,3.76,0,0,1,1-.13,4,4,0,0,1,1.63.31v1.14a3.17,3.17,0,0,0-1.78-.51,2,2,0,0,0-.57.07,1.56,1.56,0,0,0-.43.2.91.91,0,0,0-.28.31.79.79,0,0,0-.1.4.91.91,0,0,0,.39.79,2,2,0,0,0,.46.26l.62.25a8.42,8.42,0,0,1,.84.37,2.88,2.88,0,0,1,.63.42,1.81,1.81,0,0,1,.4.55,1.92,1.92,0,0,1-.09,1.63,2.07,2.07,0,0,1-.61.64,3,3,0,0,1-.89.37,4.42,4.42,0,0,1-1,.12A4,4,0,0,1,76.23,489.64Z" fill="#2f2f2f"/>
-      <path d="M92.24,489.89H91.11v-4c0-1.49-.54-2.23-1.62-2.23a1.76,1.76,0,0,0-1.39.63,2.34,2.34,0,0,0-.55,1.6v4H86.42v-7h1.13v1.16h0a2.54,2.54,0,0,1,2.3-1.32,2.13,2.13,0,0,1,1.76.74,3.33,3.33,0,0,1,.61,2.14Z" fill="#2f2f2f"/>
-      <path d="M99.94,486.67H95a2.56,2.56,0,0,0,.63,1.81,2.17,2.17,0,0,0,1.65.63,3.42,3.42,0,0,0,2.17-.78v1.05a4,4,0,0,1-2.44.67,3,3,0,0,1-2.33-.95,3.93,3.93,0,0,1-.85-2.68,3.84,3.84,0,0,1,.93-2.67,3,3,0,0,1,2.3-1,2.61,2.61,0,0,1,2.13.89,3.69,3.69,0,0,1,.75,2.46Zm-1.15-.95a2.24,2.24,0,0,0-.47-1.51,1.59,1.59,0,0,0-1.28-.54,1.81,1.81,0,0,0-1.35.57,2.58,2.58,0,0,0-.68,1.48Z" fill="#2f2f2f"/>
-      <path d="M104.86,489.82a2.09,2.09,0,0,1-1,.22c-1.23,0-1.84-.68-1.84-2.05v-4.14h-1.2v-1H102v-1.71l1.12-.36v2.07h1.76v1H103.1v3.94a1.65,1.65,0,0,0,.24,1,1,1,0,0,0,.79.3,1.2,1.2,0,0,0,.73-.23Z" fill="#2f2f2f"/>
-      <path d="M115.55,482.89l-2.1,7h-1.16l-1.44-5a3.82,3.82,0,0,1-.11-.65h0a3,3,0,0,1-.14.64l-1.57,5h-1.12l-2.12-7h1.18l1.45,5.26a3.79,3.79,0,0,1,.1.63h.05a2.65,2.65,0,0,1,.12-.64l1.62-5.25h1l1.45,5.28a3.2,3.2,0,0,1,.1.63h.06a3.49,3.49,0,0,1,.11-.63l1.43-5.28Z" fill="#2f2f2f"/>
-      <path d="M119.63,490.05a3.22,3.22,0,0,1-2.48-1,3.62,3.62,0,0,1-.93-2.6,3.79,3.79,0,0,1,1-2.75,3.46,3.46,0,0,1,2.6-1,3.16,3.16,0,0,1,2.45,1,3.83,3.83,0,0,1,.87,2.67,3.79,3.79,0,0,1-.94,2.69A3.32,3.32,0,0,1,119.63,490.05Zm.08-6.38a2.13,2.13,0,0,0-1.71.73,3,3,0,0,0-.63,2,2.82,2.82,0,0,0,.64,2,2.15,2.15,0,0,0,1.7.72,2,2,0,0,0,1.67-.7,3.74,3.74,0,0,0,0-4A2,2,0,0,0,119.71,483.67Z" fill="#2f2f2f"/>
-      <path d="M128.48,484a1.32,1.32,0,0,0-.85-.23,1.43,1.43,0,0,0-1.2.68,3.12,3.12,0,0,0-.48,1.84v3.57h-1.12v-7H126v1.44h0a2.46,2.46,0,0,1,.73-1.15,1.69,1.69,0,0,1,1.1-.41,1.92,1.92,0,0,1,.67.09Z" fill="#2f2f2f"/>
-      <path d="M135.53,489.89H134l-3.09-3.36h0v3.36h-1.12V479.53h1.12v6.57h0l2.94-3.21h1.47L132,486.27Z" fill="#2f2f2f"/>
-    </g>
-    <g>
-      <path d="M35.35,254.32a6.63,6.63,0,0,1-3.28.83,4.51,4.51,0,0,1-3.4-1.35,5,5,0,0,1-1.29-3.59,5.09,5.09,0,0,1,1.44-3.73A4.87,4.87,0,0,1,32.46,245a6.17,6.17,0,0,1,2.69.52v1.27a5.16,5.16,0,0,0-2.82-.75,3.55,3.55,0,0,0-2.7,1.13,4.74,4.74,0,0,0-.07,5.86,3.41,3.41,0,0,0,2.65,1.07,4.15,4.15,0,0,0,2-.46v-2.75H32.05v-1h3.3Z" fill="#2f2f2f"/>
-      <path d="M42.43,255H41.31v-1.1h0a2.36,2.36,0,0,1-2.16,1.26,2.33,2.33,0,0,1-1.63-.55,1.91,1.91,0,0,1-.6-1.47c0-1.31.77-2.07,2.31-2.29l2.1-.29c0-1.19-.48-1.79-1.44-1.79a3.43,3.43,0,0,0-2.28.87v-1.15a4.32,4.32,0,0,1,2.38-.66q2.46,0,2.46,2.61Zm-1.12-3.55-1.69.24a2.77,2.77,0,0,0-1.17.38,1.12,1.12,0,0,0-.4,1,1.05,1.05,0,0,0,.37.84,1.39,1.39,0,0,0,1,.33,1.8,1.8,0,0,0,1.38-.59,2.09,2.09,0,0,0,.54-1.48Z" fill="#2f2f2f"/>
-      <path d="M47.69,254.92a2.2,2.2,0,0,1-1,.22c-1.23,0-1.84-.69-1.84-2.06v-4.14H43.6V248h1.21v-1.71l1.12-.37V248h1.76v.95H45.93v3.95a1.61,1.61,0,0,0,.24,1,1,1,0,0,0,.79.3,1.14,1.14,0,0,0,.73-.23Z" fill="#2f2f2f"/>
-      <path d="M54.69,251.77H49.74a2.63,2.63,0,0,0,.63,1.8,2.18,2.18,0,0,0,1.66.64,3.42,3.42,0,0,0,2.17-.78v1a4,4,0,0,1-2.44.67,3,3,0,0,1-2.33-1,3.89,3.89,0,0,1-.85-2.69,3.82,3.82,0,0,1,.93-2.66,3,3,0,0,1,2.3-1,2.63,2.63,0,0,1,2.12.89,3.65,3.65,0,0,1,.76,2.47Zm-1.15-1a2.32,2.32,0,0,0-.47-1.52,1.64,1.64,0,0,0-1.28-.54,1.81,1.81,0,0,0-1.35.57,2.52,2.52,0,0,0-.68,1.49Z" fill="#2f2f2f"/>
-      <path d="M65.16,248l-2.1,7H61.9l-1.44-5a2.94,2.94,0,0,1-.11-.64h0a2.93,2.93,0,0,1-.14.63l-1.57,5H57.49l-2.12-7h1.18L58,253.25a3.93,3.93,0,0,1,.09.63h.06a2.56,2.56,0,0,1,.12-.64L59.88,248h1l1.45,5.27a4.17,4.17,0,0,1,.1.63h0a2.86,2.86,0,0,1,.12-.63L64.05,248Z" fill="#2f2f2f"/>
-      <path d="M71.33,255H70.21v-1.1h0a2.57,2.57,0,0,1-3.8.71,1.94,1.94,0,0,1-.59-1.47c0-1.31.77-2.07,2.31-2.29l2.1-.29c0-1.19-.48-1.79-1.44-1.79a3.43,3.43,0,0,0-2.28.87v-1.15a4.3,4.3,0,0,1,2.38-.66q2.46,0,2.46,2.61Zm-1.12-3.55-1.69.24a2.72,2.72,0,0,0-1.17.38,1.12,1.12,0,0,0-.4,1,1.05,1.05,0,0,0,.37.84,1.39,1.39,0,0,0,1,.33,1.8,1.8,0,0,0,1.38-.59,2.09,2.09,0,0,0,.54-1.48Z" fill="#2f2f2f"/>
-      <path d="M78.85,248l-3.22,8.12c-.58,1.45-1.39,2.17-2.42,2.17a2.58,2.58,0,0,1-.74-.09v-1a2.21,2.21,0,0,0,.67.12,1.38,1.38,0,0,0,1.27-1L75,255l-2.73-7h1.24l1.89,5.38c0,.07.07.25.15.54h0c0-.11.07-.29.13-.52l2-5.4Z" fill="#2f2f2f"/>
-    </g>
-  </g>
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 26.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 1124.7 498" style="enable-background:new 0 0 1124.7 498;" xml:space="preserve">
+<style type="text/css">
+	.Graphic_x0020_Style_x0020_5{fill:#FFFFFF;stroke:#83B9F9;stroke-width:0.25;}
+	.Graphic_x0020_Style_x0020_6{fill:#FFFFFF;stroke:#FFFFFF;stroke-width:0.5;}
+	.st0{fill:#FFFFFF;stroke:#FFFFFF;stroke-width:0.5;}
+	.st1{fill:#FFFFFF;}
+	.st2{opacity:7.000000e-02;fill:#505150;}
+	.st3{opacity:0.15;fill:none;stroke:#505150;}
+	.st4{opacity:0.65;fill:#505150;}
+	.st5{opacity:0.15;fill:none;stroke:#505150;stroke-width:0.8;}
+	.st6{opacity:0.15;fill:#83B9F9;}
+	.st7{fill:#83B9F9;}
+	.st8{fill:#3C3C41;}
+	.st9{fill:#A67AF4;}
+	.st10{fill:#773ADC;}
+	.st11{fill:url(#SVGID_1_);}
+	.st12{fill:url(#SVGID_00000155105546361933900350000001609767722944693685_);}
+	.st13{fill:url(#SVGID_00000165205693279249516400000008446350449305183910_);}
+	.st14{opacity:0.7;fill:#CCCCCB;}
+	.st15{fill:#0078D4;}
+	.st16{fill:#6BB9F2;}
+	.st17{fill:url(#SVGID_00000021087549538617728050000011872561146157838464_);}
+	.st18{fill:#50E6FF;}
+	.st19{fill:url(#SVGID_00000123425813544906149210000007162880905596116658_);}
+	.st20{fill:url(#SVGID_00000142871626230766392680000015790782266785779346_);}
+	.st21{fill:url(#SVGID_00000035501496320626794920000005901034511000025999_);}
+	.st22{fill:#1490DF;}
+	.st23{fill:url(#SVGID_00000030470129177053842250000006621220099656024487_);}
+	.st24{fill:url(#SVGID_00000181046826893437271090000002730350120686390963_);}
+	.st25{fill:url(#SVGID_00000008859372983110870640000004980175867850458265_);}
+	.st26{fill:url(#SVGID_00000081620098967117054690000005932967945618583176_);}
+	.st27{fill:url(#f57e105d-6d2d-4ad7-b8c3-c10684c9f9b8_00000140695283775912918650000005049364074068324502_);}
+	.st28{fill:#699CD3;}
+	.st29{fill:#CFCFCE;}
+	.st30{fill:url(#SVGID_00000083072253353963116010000001673929345113925769_);}
+	.st31{fill:url(#SVGID_00000003069403499777128800000002786524872395049609_);}
+	.st32{fill:#999999;}
+	.st33{fill:url(#aacf8311-a317-400f-b613-74bd00da5ce3_00000181801411905161186450000008046136835335200935_);}
+	.st34{fill:url(#bd983c41-db73-40ec-a4f4-da1213fc9924_00000152237734274697493020000011090485243212631199_);}
+	.st35{opacity:0.75;fill:#F7921E;enable-background:new    ;}
+	.st36{fill:url(#SVGID_00000155135721210761297980000005625314348718204575_);}
+	.st37{fill:#A5DEF3;}
+	.st38{fill:#33BEDD;}
+	.st39{fill:#74CFEB;}
+	.st40{fill:#EF404A;}
+	.st41{fill:url(#SVGID_00000003066833679634731960000009182549943747566006_);}
+	.st42{fill:#2E76BC;}
+	.st43{fill:url(#SVGID_00000123406119097188529150000012163101483936397230_);}
+	.st44{fill:#FEBD11;}
+	.st45{fill:#FEE452;}
+	.st46{opacity:0.5;fill:#FED402;enable-background:new    ;}
+	.st47{fill:url(#f57e105d-6d2d-4ad7-b8c3-c10684c9f9b8_00000110445155102417925730000004139111146243172481_);}
+	.st48{opacity:0.3;fill:#FFFFFF;}
+	.st49{fill:none;stroke:#75767A;stroke-width:0.25;stroke-miterlimit:10;}
+	.st50{fill:#207067;}
+	.st51{fill:#42E8CA;}
+	.st52{fill:#59285F;}
+	.st53{fill:#CE74B6;}
+	.st54{fill:url(#SVGID_00000137838937854620455060000006233493242182648477_);}
+	.st55{fill:#821618;}
+	.st56{fill:#E52526;}
+	.st57{fill:#F27281;}
+	.st58{fill:#D33833;}
+	.st59{fill:#EF3D3A;}
+	.st60{fill:#231F20;}
+	.st61{fill:#F0D6B7;}
+	.st62{fill:#335061;}
+	.st63{fill:#6D6B6D;}
+	.st64{fill:#DCD9D8;}
+	.st65{fill:#F7E4CD;}
+	.st66{fill:#49728B;}
+	.st67{fill:none;stroke:#D33833;stroke-width:2;}
+	.st68{fill:#81B0C4;}
+	.st69{fill:#1D1919;}
+	.st70{fill:url(#a91f0ca4-8fb7-4019-9c09-0a52e2c05754_00000066500447044003760220000001050136733703060097_);}
+	.st71{fill:url(#SVGID_00000098210024874005352190000006970742854854710691_);}
+	.st72{fill:url(#SVGID_00000132785778233835810720000003842187819659214507_);}
+	.st73{fill:#F2F2F2;}
+	.st74{fill:url(#SVGID_00000054983097516000869520000001794724303928404356_);}
+	.st75{fill:#53B0DE;}
+	.st76{fill:url(#SVGID_00000096027965922336439870000011853725622417037463_);}
+	.st77{fill:url(#SVGID_00000074404753785516608930000002523439158442924218_);}
+	.st78{fill:#1E3465;}
+	.st79{fill:url(#SVGID_00000181045466120796799550000016963566875031756976_);}
+	.st80{fill:#E8E8E8;}
+	.st81{fill:#1B8AB3;}
+	.st82{fill:url(#SVGID_00000132781031411030589830000016653853243065578372_);}
+	.st83{fill:url(#SVGID_00000033331029259217369910000013129715001438759569_);}
+	.st84{fill:none;}
+	.st85{opacity:0.6;fill:#FFFFFF;}
+	.st86{fill:url(#SVGID_00000060027446258911607860000012216855638941459124_);}
+	.st87{fill:url(#SVGID_00000144325166635088105600000011845295453406021559_);}
+	.st88{fill:url(#SVGID_00000001622415932447548100000006478701455036036010_);}
+	.st89{fill:url(#SVGID_00000062876006511904538310000004706586235393262010_);}
+	.st90{fill:url(#SVGID_00000100346044721981162240000002686547124092159923_);}
+	.st91{fill:url(#SVGID_00000052092507784788535260000004534881308305096369_);}
+	.st92{fill:url(#SVGID_00000165947542972782692630000002149845000739750019_);}
+	.st93{fill:url(#SVGID_00000029756042219877946330000000392826298944078258_);}
+	.st94{fill:url(#SVGID_00000078755325781229816440000017471924256182622608_);}
+	.st95{fill:url(#SVGID_00000072245513297233228010000002904102517180896435_);}
+	.st96{fill:#5FB832;}
+	.st97{fill:url(#SVGID_00000103255479118839370350000012683765150182953873_);}
+	.st98{opacity:0.8;fill:#FFFFFF;enable-background:new    ;}
+	.st99{fill:url(#SVGID_00000094614335448220587000000007427383778250186389_);}
+	.st100{fill:url(#SVGID_00000003790094955949886700000010998674735381617341_);}
+	.st101{fill:url(#SVGID_00000139256161823795253170000003610410723095585210_);}
+	.st102{fill:url(#SVGID_00000009582157968696774630000007504002932973409185_);}
+	.st103{fill:url(#SVGID_00000116946425100364369680000002681457733121223576_);}
+	.st104{fill:#68BD45;}
+	.st105{fill:#2F2F2F;}
+	.st106{font-family:'SegoeUI';}
+	.st107{font-size:11px;}
+	.st108{font-size:14px;}
+	.st109{font-family:'SegoeUI-Bold';}
+	.st110{font-size:15px;}
+	.st111{fill:url(#SVGID_00000016061800107041436780000012052317788948408754_);}
+	.st112{fill-rule:evenodd;clip-rule:evenodd;fill:#8E714E;}
+	.st113{fill-rule:evenodd;clip-rule:evenodd;fill:#442D22;}
+	.st114{fill-rule:evenodd;clip-rule:evenodd;fill:#FFFFFF;}
+	.st115{fill-rule:evenodd;clip-rule:evenodd;fill:#A6A385;}
+	.st116{fill-rule:evenodd;clip-rule:evenodd;fill:#499D4A;}
+	.st117{fill-rule:evenodd;clip-rule:evenodd;fill:#58AA50;}
+	.st118{fill:none;stroke:#3C3C41;stroke-miterlimit:10;}
+	.st119{fill:url(#SVGID_00000159448674924796441940000008346241230844965270_);}
+	.st120{clip-path:url(#SVGID_00000047061780673795617820000018006229297849638537_);}
+	.st121{fill:#F2F2F3;}
+	.st122{fill:url(#SVGID_00000098929880189382964700000012317708989089096881_);}
+	.st123{fill:url(#SVGID_00000020390183474292071420000017262905916636491180_);}
+	.st124{fill:url(#SVGID_00000139973923283200106780000003325596579528698045_);}
+	.st125{fill:url(#SVGID_00000044151616711212282730000007720963407589625244_);}
+	.st126{fill:#B6D43A;}
+	.st127{opacity:0.7;}
+	.st128{opacity:0.9;fill:#CCCCCB;}
+	.st129{fill:url(#SVGID_00000167388586811171593230000002828529285165249931_);}
+</style>
+<g id="Shapes">
+	<rect x="0.2" y="0.2" class="st0" width="1124.2" height="497.5"/>
+	<g>
+		<g>
+			<path class="st1" d="M1118.7,462.6c0,2.2-1.8,4-4,4H559.5c-2.2,0-4-1.8-4-4V144.3c0-2.2,1.8-4,4-4h555.2c2.2,0,4,1.8,4,4V462.6z"
+				/>
+			<path class="st2" d="M1118.7,462.6c0,2.2-1.8,4-4,4H559.5c-2.2,0-4-1.8-4-4V144.3c0-2.2,1.8-4,4-4h555.2c2.2,0,4,1.8,4,4V462.6z"
+				/>
+			<path class="st3" d="M1118.7,462.6c0,2.2-1.8,4-4,4H559.5c-2.2,0-4-1.8-4-4V144.3c0-2.2,1.8-4,4-4h555.2c2.2,0,4,1.8,4,4V462.6z"
+				/>
+		</g>
+		<path class="st4" d="M1114.7,467.1h-0.1v-1h0.1c0.2,0,0.4,0,0.6-0.1l0.2,1C1115.3,467.1,1115,467.1,1114.7,467.1z M1112.6,467.1
+			h-0.8v-1h0.8V467.1z M1109.8,467.1h-0.8v-1h0.8V467.1z M1107,467.1h-0.8v-1h0.8V467.1z M1104.2,467.1h-0.8v-1h0.8V467.1z
+			 M1101.4,467.1h-0.8v-1h0.8V467.1z M1098.6,467.1h-0.8v-1h0.8V467.1z M1095.8,467.1h-0.8v-1h0.8V467.1z M1093,467.1h-0.8v-1h0.8
+			V467.1z M1090.2,467.1h-0.8v-1h0.8V467.1z M1087.4,467.1h-0.8v-1h0.8V467.1z M1084.6,467.1h-0.8v-1h0.8V467.1z M1081.8,467.1h-0.8
+			v-1h0.8V467.1z M1079,467.1h-0.8v-1h0.8V467.1z M1076.2,467.1h-0.8v-1h0.8V467.1z M1073.4,467.1h-0.8v-1h0.8V467.1z M1070.6,467.1
+			h-0.8v-1h0.8V467.1z M1067.8,467.1h-0.8v-1h0.8V467.1z M1065,467.1h-0.8v-1h0.8V467.1z M1062.2,467.1h-0.8v-1h0.8V467.1z
+			 M1059.4,467.1h-0.8v-1h0.8V467.1z M1056.6,467.1h-0.8v-1h0.8V467.1z M1053.8,467.1h-0.8v-1h0.8V467.1z M1051,467.1h-0.8v-1h0.8
+			V467.1z M1048.2,467.1h-0.8v-1h0.8V467.1z M1045.4,467.1h-0.8v-1h0.8V467.1z M1042.6,467.1h-0.8v-1h0.8V467.1z M1039.8,467.1h-0.8
+			v-1h0.8V467.1z M1037,467.1h-0.8v-1h0.8V467.1z M1034.2,467.1h-0.8v-1h0.8V467.1z M1031.4,467.1h-0.8v-1h0.8V467.1z M1028.6,467.1
+			h-0.8v-1h0.8V467.1z M1025.8,467.1h-0.8v-1h0.8V467.1z M1023,467.1h-0.8v-1h0.8V467.1z M1020.2,467.1h-0.8v-1h0.8V467.1z
+			 M1017.4,467.1h-0.8v-1h0.8V467.1z M1014.6,467.1h-0.8v-1h0.8V467.1z M1011.9,467.1h-0.8v-1h0.8V467.1z M1009.1,467.1h-0.8v-1h0.8
+			V467.1z M1006.3,467.1h-0.8v-1h0.8V467.1z M1003.5,467.1h-0.8v-1h0.8V467.1z M1000.7,467.1h-0.8v-1h0.8V467.1z M997.9,467.1h-0.8
+			v-1h0.8V467.1z M995.1,467.1h-0.8v-1h0.8V467.1z M992.3,467.1h-0.8v-1h0.8V467.1z M989.5,467.1h-0.8v-1h0.8V467.1z M986.7,467.1
+			h-0.8v-1h0.8V467.1z M983.9,467.1h-0.8v-1h0.8V467.1z M981.1,467.1h-0.8v-1h0.8V467.1z M978.3,467.1h-0.8v-1h0.8V467.1z
+			 M975.5,467.1h-0.8v-1h0.8V467.1z M972.7,467.1h-0.8v-1h0.8V467.1z M969.9,467.1h-0.8v-1h0.8V467.1z M967.1,467.1h-0.8v-1h0.8
+			V467.1z M964.3,467.1h-0.8v-1h0.8V467.1z M961.5,467.1h-0.8v-1h0.8V467.1z M958.7,467.1h-0.8v-1h0.8V467.1z M955.9,467.1h-0.8v-1
+			h0.8V467.1z M953.1,467.1h-0.8v-1h0.8V467.1z M950.3,467.1h-0.8v-1h0.8V467.1z M947.5,467.1h-0.8v-1h0.8V467.1z M944.7,467.1h-0.8
+			v-1h0.8V467.1z M941.9,467.1h-0.8v-1h0.8V467.1z M939.1,467.1h-0.8v-1h0.8V467.1z M936.3,467.1h-0.8v-1h0.8V467.1z M933.5,467.1
+			h-0.8v-1h0.8V467.1z M930.7,467.1h-0.8v-1h0.8V467.1z M927.9,467.1h-0.8v-1h0.8V467.1z M925.1,467.1h-0.8v-1h0.8V467.1z
+			 M922.3,467.1h-0.8v-1h0.8V467.1z M919.5,467.1h-0.8v-1h0.8V467.1z M916.7,467.1h-0.8v-1h0.8V467.1z M913.9,467.1h-0.8v-1h0.8
+			V467.1z M911.1,467.1h-0.8v-1h0.8V467.1z M908.3,467.1h-0.8v-1h0.8V467.1z M905.5,467.1h-0.8v-1h0.8V467.1z M902.7,467.1h-0.8v-1
+			h0.8V467.1z M899.9,467.1h-0.8v-1h0.8V467.1z M897.1,467.1h-0.8v-1h0.8V467.1z M894.3,467.1h-0.8v-1h0.8V467.1z M891.5,467.1h-0.8
+			v-1h0.8V467.1z M888.7,467.1h-0.8v-1h0.8V467.1z M885.9,467.1h-0.8v-1h0.8V467.1z M883.1,467.1h-0.8v-1h0.8V467.1z M880.3,467.1
+			h-0.8v-1h0.8V467.1z M877.5,467.1h-0.8v-1h0.8V467.1z M874.7,467.1h-0.8v-1h0.8V467.1z M871.9,467.1h-0.8v-1h0.8V467.1z
+			 M869.1,467.1h-0.8v-1h0.8V467.1z M866.3,467.1h-0.8v-1h0.8V467.1z M863.5,467.1h-0.8v-1h0.8V467.1z M860.7,467.1h-0.8v-1h0.8
+			V467.1z M857.9,467.1h-0.8v-1h0.8V467.1z M855.1,467.1h-0.8v-1h0.8V467.1z M852.3,467.1h-0.8v-1h0.8V467.1z M849.5,467.1h-0.8v-1
+			h0.8V467.1z M846.7,467.1h-0.8v-1h0.8V467.1z M843.9,467.1h-0.8v-1h0.8V467.1z M841.1,467.1h-0.8v-1h0.8V467.1z M838.3,467.1h-0.8
+			v-1h0.8V467.1z M835.5,467.1h-0.8v-1h0.8V467.1z M832.7,467.1h-0.8v-1h0.8V467.1z M829.9,467.1h-0.8v-1h0.8V467.1z M827.1,467.1
+			h-0.8v-1h0.8V467.1z M824.3,467.1h-0.8v-1h0.8V467.1z M821.5,467.1h-0.8v-1h0.8V467.1z M818.7,467.1h-0.8v-1h0.8V467.1z
+			 M815.9,467.1h-0.8v-1h0.8V467.1z M813.1,467.1h-0.8v-1h0.8V467.1z M810.3,467.1h-0.8v-1h0.8V467.1z M807.5,467.1h-0.8v-1h0.8
+			V467.1z M804.7,467.1h-0.8v-1h0.8V467.1z M801.9,467.1h-0.8v-1h0.8V467.1z M799.1,467.1h-0.8v-1h0.8V467.1z M796.3,467.1h-0.8v-1
+			h0.8V467.1z M793.5,467.1h-0.8v-1h0.8V467.1z M790.7,467.1h-0.8v-1h0.8V467.1z M787.9,467.1h-0.8v-1h0.8V467.1z M785.1,467.1h-0.8
+			v-1h0.8V467.1z M782.3,467.1h-0.8v-1h0.8V467.1z M779.5,467.1h-0.8v-1h0.8V467.1z M776.7,467.1h-0.8v-1h0.8V467.1z M773.9,467.1
+			h-0.8v-1h0.8V467.1z M771.1,467.1h-0.8v-1h0.8V467.1z M768.3,467.1h-0.8v-1h0.8V467.1z M765.5,467.1h-0.8v-1h0.8V467.1z
+			 M762.7,467.1h-0.8v-1h0.8V467.1z M759.9,467.1h-0.8v-1h0.8V467.1z M757.1,467.1h-0.8v-1h0.8V467.1z M754.3,467.1h-0.8v-1h0.8
+			V467.1z M751.5,467.1h-0.8v-1h0.8V467.1z M748.7,467.1h-0.8v-1h0.8V467.1z M745.9,467.1h-0.8v-1h0.8V467.1z M743.1,467.1h-0.8v-1
+			h0.8V467.1z M740.3,467.1h-0.8v-1h0.8V467.1z M737.5,467.1h-0.8v-1h0.8V467.1z M734.7,467.1h-0.8v-1h0.8V467.1z M731.9,467.1h-0.8
+			v-1h0.8V467.1z M729.1,467.1h-0.8v-1h0.8V467.1z M726.3,467.1h-0.8v-1h0.8V467.1z M723.5,467.1h-0.8v-1h0.8V467.1z M720.7,467.1
+			h-0.8v-1h0.8V467.1z M717.9,467.1h-0.8v-1h0.8V467.1z M715.1,467.1h-0.8v-1h0.8V467.1z M712.3,467.1h-0.8v-1h0.8V467.1z
+			 M709.5,467.1h-0.8v-1h0.8V467.1z M706.7,467.1h-0.8v-1h0.8V467.1z M703.9,467.1h-0.8v-1h0.8V467.1z M701.1,467.1h-0.8v-1h0.8
+			V467.1z M698.3,467.1h-0.8v-1h0.8V467.1z M695.5,467.1h-0.8v-1h0.8V467.1z M692.7,467.1h-0.8v-1h0.8V467.1z M689.9,467.1h-0.8v-1
+			h0.8V467.1z M687.1,467.1h-0.8v-1h0.8V467.1z M684.3,467.1h-0.8v-1h0.8V467.1z M681.5,467.1h-0.8v-1h0.8V467.1z M678.7,467.1h-0.8
+			v-1h0.8V467.1z M675.9,467.1h-0.8v-1h0.8V467.1z M673.1,467.1h-0.8v-1h0.8V467.1z M670.3,467.1h-0.8v-1h0.8V467.1z M667.5,467.1
+			h-0.8v-1h0.8V467.1z M664.7,467.1h-0.8v-1h0.8V467.1z M661.9,467.1h-0.8v-1h0.8V467.1z M659.1,467.1h-0.8v-1h0.8V467.1z
+			 M656.3,467.1h-0.8v-1h0.8V467.1z M653.5,467.1h-0.8v-1h0.8V467.1z M650.7,467.1h-0.8v-1h0.8V467.1z M647.9,467.1h-0.8v-1h0.8
+			V467.1z M645.1,467.1h-0.8v-1h0.8V467.1z M642.3,467.1h-0.8v-1h0.8V467.1z M639.5,467.1h-0.8v-1h0.8V467.1z M636.7,467.1h-0.8v-1
+			h0.8V467.1z M633.9,467.1h-0.8v-1h0.8V467.1z M631.1,467.1h-0.8v-1h0.8V467.1z M628.3,467.1h-0.8v-1h0.8V467.1z M625.5,467.1h-0.8
+			v-1h0.8V467.1z M622.7,467.1h-0.8v-1h0.8V467.1z M619.9,467.1h-0.8v-1h0.8V467.1z M617.1,467.1h-0.8v-1h0.8V467.1z M614.3,467.1
+			h-0.8v-1h0.8V467.1z M611.5,467.1h-0.8v-1h0.8V467.1z M608.7,467.1h-0.8v-1h0.8V467.1z M605.9,467.1h-0.8v-1h0.8V467.1z
+			 M603.1,467.1h-0.8v-1h0.8V467.1z M600.3,467.1h-0.8v-1h0.8V467.1z M597.5,467.1h-0.8v-1h0.8V467.1z M594.7,467.1h-0.8v-1h0.8
+			V467.1z M564,467.1h-0.8v-1h0.8V467.1z M561.2,467.1h-0.8v-1h0.8V467.1z M558.2,466.9c-0.3-0.1-0.6-0.2-0.8-0.4l0.5-0.9
+			c0.2,0.1,0.4,0.2,0.6,0.3L558.2,466.9z M1117.5,466.1l-0.6-0.8c0.2-0.1,0.4-0.3,0.5-0.5l0.8,0.6
+			C1118,465.7,1117.8,465.9,1117.5,466.1z M555.8,465c-0.2-0.3-0.3-0.5-0.4-0.8l0.9-0.4c0.1,0.2,0.2,0.4,0.3,0.6L555.8,465z
+			 M1119.2,463.5l-1-0.2c0-0.2,0.1-0.5,0.1-0.7l1,0v0C1119.2,462.9,1119.2,463.2,1119.2,463.5z M556,462.1h-1v-0.8h1V462.1z
+			 M1119.2,460.5h-1v-0.8h1V460.5z M556,459.3h-1v-0.8h1V459.3z M1119.2,457.7h-1v-0.8h1V457.7z M556,456.5h-1v-0.8h1V456.5z
+			 M1119.2,454.9h-1v-0.8h1V454.9z M556,453.7h-1v-0.8h1V453.7z M1119.2,452.1h-1v-0.8h1V452.1z M556,450.9h-1v-0.8h1V450.9z
+			 M1119.2,449.3h-1v-0.8h1V449.3z M556,448.1h-1v-0.8h1V448.1z M1119.2,446.5h-1v-0.8h1V446.5z M556,445.3h-1v-0.8h1V445.3z
+			 M1119.2,443.7h-1v-0.8h1V443.7z M556,442.5h-1v-0.8h1V442.5z M1119.2,440.9h-1v-0.8h1V440.9z M556,439.7h-1v-0.8h1V439.7z
+			 M1119.2,438.1h-1v-0.8h1V438.1z M556,436.9h-1v-0.8h1V436.9z M1119.2,435.3h-1v-0.8h1V435.3z M556,434.1h-1v-0.8h1V434.1z
+			 M1119.2,432.5h-1v-0.8h1V432.5z M556,431.3h-1v-0.8h1V431.3z M1119.2,429.7h-1v-0.8h1V429.7z M556,428.5h-1v-0.8h1V428.5z
+			 M1119.2,426.9h-1v-0.8h1V426.9z M556,425.7h-1v-0.8h1V425.7z M1119.2,424.1h-1v-0.8h1V424.1z M556,422.9h-1v-0.8h1V422.9z
+			 M1119.2,421.3h-1v-0.8h1V421.3z M556,420.1h-1v-0.8h1V420.1z M1119.2,418.5h-1v-0.8h1V418.5z M556,417.3h-1v-0.8h1V417.3z
+			 M1119.2,415.8h-1V415h1V415.8z M556,414.5h-1v-0.8h1V414.5z M1119.2,413h-1v-0.8h1V413z M556,411.7h-1v-0.8h1V411.7z
+			 M1119.2,410.2h-1v-0.8h1V410.2z M556,408.9h-1v-0.8h1V408.9z M1119.2,407.4h-1v-0.8h1V407.4z M556,406.1h-1v-0.8h1V406.1z
+			 M1119.2,404.6h-1v-0.8h1V404.6z M556,403.3h-1v-0.8h1V403.3z M1119.2,401.8h-1V401h1V401.8z M556,400.5h-1v-0.8h1V400.5z
+			 M1119.2,399h-1v-0.8h1V399z M556,397.7h-1v-0.8h1V397.7z M1119.2,396.2h-1v-0.8h1V396.2z M556,394.9h-1v-0.8h1V394.9z
+			 M1119.2,393.4h-1v-0.8h1V393.4z M556,392.1h-1v-0.8h1V392.1z M1119.2,390.6h-1v-0.8h1V390.6z M556,389.3h-1v-0.8h1V389.3z
+			 M1119.2,387.8h-1V387h1V387.8z M556,386.5h-1v-0.8h1V386.5z M1119.2,385h-1v-0.8h1V385z M556,383.7h-1v-0.8h1V383.7z
+			 M1119.2,382.2h-1v-0.8h1V382.2z M556,380.9h-1v-0.8h1V380.9z M1119.2,379.4h-1v-0.8h1V379.4z M556,378.1h-1v-0.8h1V378.1z
+			 M1119.2,376.6h-1v-0.8h1V376.6z M556,375.3h-1v-0.8h1V375.3z M1119.2,373.8h-1V373h1V373.8z M556,372.5h-1v-0.8h1V372.5z
+			 M1119.2,371h-1v-0.8h1V371z M556,369.7h-1v-0.8h1V369.7z M1119.2,368.2h-1v-0.8h1V368.2z M556,366.9h-1v-0.8h1V366.9z
+			 M1119.2,365.4h-1v-0.8h1V365.4z M556,364.1h-1v-0.8h1V364.1z M1119.2,362.6h-1v-0.8h1V362.6z M556,361.3h-1v-0.8h1V361.3z
+			 M1119.2,359.8h-1V359h1V359.8z M556,358.5h-1v-0.8h1V358.5z M1119.2,357h-1v-0.8h1V357z M556,355.7h-1v-0.8h1V355.7z
+			 M1119.2,354.2h-1v-0.8h1V354.2z M556,352.9h-1v-0.8h1V352.9z M1119.2,351.4h-1v-0.8h1V351.4z M556,350.1h-1v-0.8h1V350.1z
+			 M1119.2,348.6h-1v-0.8h1V348.6z M556,347.3h-1v-0.8h1V347.3z M1119.2,345.8h-1V345h1V345.8z M556,344.5h-1v-0.8h1V344.5z
+			 M1119.2,343h-1v-0.8h1V343z M556,341.7h-1v-0.8h1V341.7z M1119.2,340.2h-1v-0.8h1V340.2z M556,338.9h-1v-0.8h1V338.9z
+			 M1119.2,337.4h-1v-0.8h1V337.4z M556,336.1h-1v-0.8h1V336.1z M1119.2,334.6h-1v-0.8h1V334.6z M556,333.3h-1v-0.8h1V333.3z
+			 M1119.2,331.8h-1V331h1V331.8z M556,330.5h-1v-0.8h1V330.5z M1119.2,329h-1v-0.8h1V329z M556,327.7h-1v-0.8h1V327.7z
+			 M1119.2,326.2h-1v-0.8h1V326.2z M556,324.9h-1v-0.8h1V324.9z M1119.2,323.4h-1v-0.8h1V323.4z M556,322.1h-1v-0.8h1V322.1z
+			 M1119.2,320.6h-1v-0.8h1V320.6z M556,319.3h-1v-0.8h1V319.3z M1119.2,317.8h-1V317h1V317.8z M556,316.5h-1v-0.8h1V316.5z
+			 M1119.2,315h-1v-0.8h1V315z M556,313.7h-1v-0.8h1V313.7z M1119.2,312.2h-1v-0.8h1V312.2z M556,310.9h-1v-0.8h1V310.9z
+			 M1119.2,309.4h-1v-0.8h1V309.4z M556,308.1h-1v-0.8h1V308.1z M1119.2,306.6h-1v-0.8h1V306.6z M556,305.3h-1v-0.8h1V305.3z
+			 M1119.2,303.8h-1V303h1V303.8z M556,302.5h-1v-0.8h1V302.5z M1119.2,301h-1v-0.8h1V301z M556,299.7h-1v-0.8h1V299.7z
+			 M1119.2,298.2h-1v-0.8h1V298.2z M556,296.9h-1v-0.8h1V296.9z M1119.2,295.4h-1v-0.8h1V295.4z M556,294.1h-1v-0.8h1V294.1z
+			 M1119.2,292.6h-1v-0.8h1V292.6z M556,291.3h-1v-0.8h1V291.3z M1119.2,289.8h-1V289h1V289.8z M556,288.5h-1v-0.8h1V288.5z
+			 M1119.2,287h-1v-0.8h1V287z M556,285.7h-1v-0.8h1V285.7z M1119.2,284.2h-1v-0.8h1V284.2z M556,282.9h-1v-0.8h1V282.9z
+			 M1119.2,281.4h-1v-0.8h1V281.4z M556,280.1h-1v-0.8h1V280.1z M1119.2,278.6h-1v-0.8h1V278.6z M556,277.3h-1v-0.8h1V277.3z
+			 M1119.2,275.8h-1V275h1V275.8z M556,274.5h-1v-0.8h1V274.5z M1119.2,273h-1v-0.8h1V273z M556,271.7h-1v-0.8h1V271.7z
+			 M1119.2,270.2h-1v-0.8h1V270.2z M556,268.9h-1v-0.8h1V268.9z M1119.2,267.4h-1v-0.8h1V267.4z M556,266.1h-1v-0.8h1V266.1z
+			 M1119.2,264.6h-1v-0.8h1V264.6z M556,263.3h-1v-0.8h1V263.3z M1119.2,261.8h-1V261h1V261.8z M556,260.5h-1v-0.8h1V260.5z
+			 M1119.2,259h-1v-0.8h1V259z M556,257.7h-1v-0.8h1V257.7z M1119.2,256.2h-1v-0.8h1V256.2z M556,254.9h-1v-0.8h1V254.9z
+			 M1119.2,253.4h-1v-0.8h1V253.4z M556,252.1h-1v-0.8h1V252.1z M1119.2,250.6h-1v-0.8h1V250.6z M556,249.3h-1v-0.8h1V249.3z
+			 M1119.2,247.8h-1V247h1V247.8z M556,246.5h-1v-0.8h1V246.5z M1119.2,245h-1v-0.8h1V245z M556,243.7h-1v-0.8h1V243.7z
+			 M1119.2,242.2h-1v-0.8h1V242.2z M556,240.9h-1v-0.8h1V240.9z M1119.2,239.4h-1v-0.8h1V239.4z M556,238.1h-1v-0.8h1V238.1z
+			 M1119.2,236.6h-1v-0.8h1V236.6z M556,235.3h-1v-0.8h1V235.3z M1119.2,233.8h-1V233h1V233.8z M556,232.5h-1v-0.8h1V232.5z
+			 M1119.2,231h-1v-0.8h1V231z M556,229.7h-1v-0.8h1V229.7z M1119.2,228.2h-1v-0.8h1V228.2z M556,226.9h-1v-0.8h1V226.9z
+			 M1119.2,225.4h-1v-0.8h1V225.4z M556,224.1h-1v-0.8h1V224.1z M1119.2,222.6h-1v-0.8h1V222.6z M556,221.3h-1v-0.8h1V221.3z
+			 M1119.2,219.8h-1V219h1V219.8z M556,218.5h-1v-0.8h1V218.5z M1119.2,217h-1v-0.8h1V217z M556,215.7h-1v-0.8h1V215.7z
+			 M1119.2,214.2h-1v-0.8h1V214.2z M556,212.9h-1v-0.8h1V212.9z M1119.2,211.4h-1v-0.8h1V211.4z M556,210.1h-1v-0.8h1V210.1z
+			 M1119.2,208.6h-1v-0.8h1V208.6z M556,207.3h-1v-0.8h1V207.3z M1119.2,205.8h-1V205h1V205.8z M556,204.5h-1v-0.8h1V204.5z
+			 M1119.2,203h-1v-0.8h1V203z M556,201.7h-1v-0.8h1V201.7z M1119.2,200.2h-1v-0.8h1V200.2z M556,198.9h-1v-0.8h1V198.9z
+			 M1119.2,197.4h-1v-0.8h1V197.4z M556,196.1h-1v-0.8h1V196.1z M1119.2,194.6h-1v-0.8h1V194.6z M556,193.3h-1v-0.8h1V193.3z
+			 M1119.2,191.8h-1V191h1V191.8z M556,190.5h-1v-0.8h1V190.5z M1119.2,189h-1v-0.8h1V189z M556,187.7h-1v-0.8h1V187.7z
+			 M1119.2,186.2h-1v-0.8h1V186.2z M556,184.9h-1v-0.8h1V184.9z M1119.2,183.4h-1v-0.8h1V183.4z M556,182.1h-1v-0.8h1V182.1z
+			 M1119.2,180.6h-1v-0.8h1V180.6z M556,179.3h-1v-0.8h1V179.3z M1119.2,177.8h-1V177h1V177.8z M556,176.5h-1v-0.8h1V176.5z
+			 M1119.2,175h-1v-0.8h1V175z M556,173.7h-1v-0.8h1V173.7z M1119.2,172.2h-1v-0.8h1V172.2z M556,170.9h-1v-0.8h1V170.9z
+			 M1119.2,169.4h-1v-0.8h1V169.4z M556,168.1h-1v-0.8h1V168.1z M1119.2,166.6h-1v-0.8h1V166.6z M556,165.3h-1v-0.8h1V165.3z
+			 M1119.2,163.8h-1V163h1V163.8z M556,162.5h-1v-0.8h1V162.5z M1119.2,161h-1v-0.8h1V161z M556,159.7h-1v-0.8h1V159.7z
+			 M1119.2,158.2h-1v-0.8h1V158.2z M556,156.9h-1v-0.8h1V156.9z M1119.2,155.4h-1v-0.8h1V155.4z M556,154.1h-1v-0.8h1V154.1z
+			 M1119.2,152.6h-1v-0.8h1V152.6z M556,151.3h-1v-0.8h1V151.3z M1119.2,149.8h-1V149h1V149.8z M556,148.5h-1v-0.8h1V148.5z
+			 M1119.2,147h-1v-0.8h1V147z M556,145.8h-1V145h1V145.8z M1118.2,144.2c0-0.2,0-0.5-0.1-0.7l1-0.2c0.1,0.3,0.1,0.6,0.1,0.9
+			L1118.2,144.2z M556.2,143.1l-0.9-0.3c0.1-0.3,0.2-0.6,0.4-0.8l0.9,0.5C556.4,142.7,556.3,142.9,556.2,143.1z M1117.4,142
+			c-0.2-0.2-0.3-0.3-0.5-0.5l0.6-0.8c0.2,0.2,0.5,0.4,0.7,0.6L1117.4,142z M557.8,141.3l-0.5-0.9c0.3-0.2,0.5-0.3,0.8-0.4l0.3,0.9
+			C558.2,141.1,558,141.2,557.8,141.3z M1115.2,140.9c-0.2,0-0.3,0-0.5,0h-0.2v-1h0.2c0.2,0,0.4,0,0.6,0L1115.2,140.9z
+			 M1112.5,140.8h-0.8v-1h0.8V140.8z M1109.7,140.8h-0.8v-1h0.8V140.8z M1106.9,140.8h-0.8v-1h0.8V140.8z M1104.1,140.8h-0.8v-1h0.8
+			V140.8z M1101.3,140.8h-0.8v-1h0.8V140.8z M1098.5,140.8h-0.8v-1h0.8V140.8z M1095.7,140.8h-0.8v-1h0.8V140.8z M1092.9,140.8h-0.8
+			v-1h0.8V140.8z M1090.1,140.8h-0.8v-1h0.8V140.8z M1087.3,140.8h-0.8v-1h0.8V140.8z M1084.5,140.8h-0.8v-1h0.8V140.8z
+			 M1081.7,140.8h-0.8v-1h0.8V140.8z M1078.9,140.8h-0.8v-1h0.8V140.8z M1076.1,140.8h-0.8v-1h0.8V140.8z M1073.3,140.8h-0.8v-1h0.8
+			V140.8z M1070.5,140.8h-0.8v-1h0.8V140.8z M1067.7,140.8h-0.8v-1h0.8V140.8z M1064.9,140.8h-0.8v-1h0.8V140.8z M1062.1,140.8h-0.8
+			v-1h0.8V140.8z M1059.3,140.8h-0.8v-1h0.8V140.8z M1056.5,140.8h-0.8v-1h0.8V140.8z M1053.7,140.8h-0.8v-1h0.8V140.8z
+			 M1050.9,140.8h-0.8v-1h0.8V140.8z M1048.1,140.8h-0.8v-1h0.8V140.8z M1045.3,140.8h-0.8v-1h0.8V140.8z M1042.5,140.8h-0.8v-1h0.8
+			V140.8z M1039.7,140.8h-0.8v-1h0.8V140.8z M1036.9,140.8h-0.8v-1h0.8V140.8z M1034.1,140.8h-0.8v-1h0.8V140.8z M1031.3,140.8h-0.8
+			v-1h0.8V140.8z M1028.5,140.8h-0.8v-1h0.8V140.8z M1025.7,140.8h-0.8v-1h0.8V140.8z M1022.9,140.8h-0.8v-1h0.8V140.8z
+			 M1020.1,140.8h-0.8v-1h0.8V140.8z M1017.3,140.8h-0.8v-1h0.8V140.8z M1014.5,140.8h-0.8v-1h0.8V140.8z M1011.7,140.8h-0.8v-1h0.8
+			V140.8z M1008.9,140.8h-0.8v-1h0.8V140.8z M1006.1,140.8h-0.8v-1h0.8V140.8z M1003.3,140.8h-0.8v-1h0.8V140.8z M1000.5,140.8h-0.8
+			v-1h0.8V140.8z M997.7,140.8h-0.8v-1h0.8V140.8z M994.9,140.8h-0.8v-1h0.8V140.8z M992.1,140.8h-0.8v-1h0.8V140.8z M989.3,140.8
+			h-0.8v-1h0.8V140.8z M986.5,140.8h-0.8v-1h0.8V140.8z M983.7,140.8h-0.8v-1h0.8V140.8z M980.9,140.8h-0.8v-1h0.8V140.8z
+			 M978.1,140.8h-0.8v-1h0.8V140.8z M975.3,140.8h-0.8v-1h0.8V140.8z M972.5,140.8h-0.8v-1h0.8V140.8z M969.7,140.8h-0.8v-1h0.8
+			V140.8z M966.9,140.8h-0.8v-1h0.8V140.8z M964.1,140.8h-0.8v-1h0.8V140.8z M961.3,140.8h-0.8v-1h0.8V140.8z M958.5,140.8h-0.8v-1
+			h0.8V140.8z M955.7,140.8h-0.8v-1h0.8V140.8z M952.9,140.8h-0.8v-1h0.8V140.8z M950.1,140.8h-0.8v-1h0.8V140.8z M947.3,140.8h-0.8
+			v-1h0.8V140.8z M944.6,140.8h-0.8v-1h0.8V140.8z M941.8,140.8H941v-1h0.8V140.8z M939,140.8h-0.8v-1h0.8V140.8z M936.2,140.8h-0.8
+			v-1h0.8V140.8z M933.4,140.8h-0.8v-1h0.8V140.8z M930.6,140.8h-0.8v-1h0.8V140.8z M927.8,140.8H927v-1h0.8V140.8z M925,140.8h-0.8
+			v-1h0.8V140.8z M922.2,140.8h-0.8v-1h0.8V140.8z M919.4,140.8h-0.8v-1h0.8V140.8z M916.6,140.8h-0.8v-1h0.8V140.8z M913.8,140.8
+			H913v-1h0.8V140.8z M911,140.8h-0.8v-1h0.8V140.8z M908.2,140.8h-0.8v-1h0.8V140.8z M905.4,140.8h-0.8v-1h0.8V140.8z M902.6,140.8
+			h-0.8v-1h0.8V140.8z M899.8,140.8H899v-1h0.8V140.8z M897,140.8h-0.8v-1h0.8V140.8z M894.2,140.8h-0.8v-1h0.8V140.8z M891.4,140.8
+			h-0.8v-1h0.8V140.8z M888.6,140.8h-0.8v-1h0.8V140.8z M885.8,140.8H885v-1h0.8V140.8z M883,140.8h-0.8v-1h0.8V140.8z M880.2,140.8
+			h-0.8v-1h0.8V140.8z M877.4,140.8h-0.8v-1h0.8V140.8z M874.6,140.8h-0.8v-1h0.8V140.8z M871.8,140.8H871v-1h0.8V140.8z M869,140.8
+			h-0.8v-1h0.8V140.8z M866.2,140.8h-0.8v-1h0.8V140.8z M863.4,140.8h-0.8v-1h0.8V140.8z M860.6,140.8h-0.8v-1h0.8V140.8z
+			 M857.8,140.8H857v-1h0.8V140.8z M855,140.8h-0.8v-1h0.8V140.8z M852.2,140.8h-0.8v-1h0.8V140.8z M849.4,140.8h-0.8v-1h0.8V140.8z
+			 M846.6,140.8h-0.8v-1h0.8V140.8z M843.8,140.8H843v-1h0.8V140.8z M841,140.8h-0.8v-1h0.8V140.8z M838.2,140.8h-0.8v-1h0.8V140.8z
+			 M835.4,140.8h-0.8v-1h0.8V140.8z M832.6,140.8h-0.8v-1h0.8V140.8z M829.8,140.8H829v-1h0.8V140.8z M827,140.8h-0.8v-1h0.8V140.8z
+			 M824.2,140.8h-0.8v-1h0.8V140.8z M821.4,140.8h-0.8v-1h0.8V140.8z M818.6,140.8h-0.8v-1h0.8V140.8z M815.8,140.8H815v-1h0.8
+			V140.8z M813,140.8h-0.8v-1h0.8V140.8z M810.2,140.8h-0.8v-1h0.8V140.8z M807.4,140.8h-0.8v-1h0.8V140.8z M804.6,140.8h-0.8v-1
+			h0.8V140.8z M801.8,140.8H801v-1h0.8V140.8z M799,140.8h-0.8v-1h0.8V140.8z M796.2,140.8h-0.8v-1h0.8V140.8z M793.4,140.8h-0.8v-1
+			h0.8V140.8z M790.6,140.8h-0.8v-1h0.8V140.8z M787.8,140.8H787v-1h0.8V140.8z M785,140.8h-0.8v-1h0.8V140.8z M782.2,140.8h-0.8v-1
+			h0.8V140.8z M779.4,140.8h-0.8v-1h0.8V140.8z M776.6,140.8h-0.8v-1h0.8V140.8z M773.8,140.8H773v-1h0.8V140.8z M771,140.8h-0.8v-1
+			h0.8V140.8z M768.2,140.8h-0.8v-1h0.8V140.8z M765.4,140.8h-0.8v-1h0.8V140.8z M762.6,140.8h-0.8v-1h0.8V140.8z M759.8,140.8H759
+			v-1h0.8V140.8z M757,140.8h-0.8v-1h0.8V140.8z M754.2,140.8h-0.8v-1h0.8V140.8z M751.4,140.8h-0.8v-1h0.8V140.8z M748.6,140.8
+			h-0.8v-1h0.8V140.8z M745.8,140.8H745v-1h0.8V140.8z M743,140.8h-0.8v-1h0.8V140.8z M740.2,140.8h-0.8v-1h0.8V140.8z M737.4,140.8
+			h-0.8v-1h0.8V140.8z M734.6,140.8h-0.8v-1h0.8V140.8z M731.8,140.8H731v-1h0.8V140.8z M729,140.8h-0.8v-1h0.8V140.8z M726.2,140.8
+			h-0.8v-1h0.8V140.8z M723.4,140.8h-0.8v-1h0.8V140.8z M720.6,140.8h-0.8v-1h0.8V140.8z M717.8,140.8H717v-1h0.8V140.8z M715,140.8
+			h-0.8v-1h0.8V140.8z M712.2,140.8h-0.8v-1h0.8V140.8z M709.4,140.8h-0.8v-1h0.8V140.8z M706.6,140.8h-0.8v-1h0.8V140.8z
+			 M703.8,140.8H703v-1h0.8V140.8z M701,140.8h-0.8v-1h0.8V140.8z M698.2,140.8h-0.8v-1h0.8V140.8z M695.4,140.8h-0.8v-1h0.8V140.8z
+			 M692.6,140.8h-0.8v-1h0.8V140.8z M689.8,140.8H689v-1h0.8V140.8z M687,140.8h-0.8v-1h0.8V140.8z M684.2,140.8h-0.8v-1h0.8V140.8z
+			 M681.4,140.8h-0.8v-1h0.8V140.8z M678.6,140.8h-0.8v-1h0.8V140.8z M675.8,140.8H675v-1h0.8V140.8z M673,140.8h-0.8v-1h0.8V140.8z
+			 M670.2,140.8h-0.8v-1h0.8V140.8z M667.4,140.8h-0.8v-1h0.8V140.8z M664.6,140.8h-0.8v-1h0.8V140.8z M661.8,140.8H661v-1h0.8
+			V140.8z M659,140.8h-0.8v-1h0.8V140.8z M656.2,140.8h-0.8v-1h0.8V140.8z M653.4,140.8h-0.8v-1h0.8V140.8z M650.6,140.8h-0.8v-1
+			h0.8V140.8z M647.8,140.8H647v-1h0.8V140.8z M645,140.8h-0.8v-1h0.8V140.8z M642.2,140.8h-0.8v-1h0.8V140.8z M639.4,140.8h-0.8v-1
+			h0.8V140.8z M636.6,140.8h-0.8v-1h0.8V140.8z M633.8,140.8H633v-1h0.8V140.8z M631,140.8h-0.8v-1h0.8V140.8z M628.2,140.8h-0.8v-1
+			h0.8V140.8z M625.4,140.8h-0.8v-1h0.8V140.8z M622.6,140.8h-0.8v-1h0.8V140.8z M619.8,140.8H619v-1h0.8V140.8z M617,140.8h-0.8v-1
+			h0.8V140.8z M614.2,140.8h-0.8v-1h0.8V140.8z M611.4,140.8h-0.8v-1h0.8V140.8z M608.6,140.8h-0.8v-1h0.8V140.8z M605.8,140.8H605
+			v-1h0.8V140.8z M603,140.8h-0.8v-1h0.8V140.8z M600.2,140.8h-0.8v-1h0.8V140.8z M597.4,140.8h-0.8v-1h0.8V140.8z M594.6,140.8
+			h-0.8v-1h0.8V140.8z M591.8,140.8H591v-1h0.8V140.8z M589,140.8h-0.8v-1h0.8V140.8z M586.2,140.8h-0.8v-1h0.8V140.8z M583.4,140.8
+			h-0.8v-1h0.8V140.8z M580.6,140.8h-0.8v-1h0.8V140.8z M577.8,140.8H577v-1h0.8V140.8z M575,140.8h-0.8v-1h0.8V140.8z M572.2,140.8
+			h-0.8v-1h0.8V140.8z M569.4,140.8h-0.8v-1h0.8V140.8z M566.6,140.8h-0.8v-1h0.8V140.8z M563.8,140.8H563v-1h0.8V140.8z M561,140.8
+			h-0.8v-1h0.8V140.8z"/>
+	</g>
+	<g id="Wrench_tool_x28_s_x29_">
+	</g>
+	<g id="user2">
+	</g>
+	<g id="user2_1_">
+	</g>
+	<g id="user2_4_">
+	</g>
+	<g id="user2_3_">
+	</g>
+	<g id="user2_2_">
+	</g>
+	<g id="Internet_2">
+	</g>
+	<g id="Enterprise">
+	</g>
+	<g id="Tunnel__x28_stackable_x29_">
+	</g>
+	<g id="New_Symbol">
+	</g>
+	<g id="New_Symbol_1">
+	</g>
+	<g id="Files">
+	</g>
+	<g id="BlobBlock">
+	</g>
+	<g id="E_x5F_Enterprise">
+	</g>
+	<g id="E_x5F_AD_FS">
+	</g>
+	<g id="C_x5F_Azure_Active_Directory">
+	</g>
+	<g>
+		<g>
+			<path class="st1" d="M472.8,462.5c0,2.2-1.8,4-4,4h-289c-2.2,0-4-1.8-4-4v-318c0-2.2,1.8-4,4-4h289c2.2,0,4,1.8,4,4V462.5z"/>
+			<path class="st2" d="M472.8,462.5c0,2.2-1.8,4-4,4h-289c-2.2,0-4-1.8-4-4v-318c0-2.2,1.8-4,4-4h289c2.2,0,4,1.8,4,4V462.5z"/>
+			<path class="st5" d="M472.8,462.5c0,2.2-1.8,4-4,4h-289c-2.2,0-4-1.8-4-4v-318c0-2.2,1.8-4,4-4h289c2.2,0,4,1.8,4,4V462.5z"/>
+		</g>
+		<path class="st4" d="M468.8,466.9h-0.1v-0.8h0.1c0.2,0,0.4,0,0.6-0.1l0.1,0.8C469.3,466.9,469,466.9,468.8,466.9z M466.7,466.9
+			h-0.8v-0.8h0.8V466.9z M463.9,466.9h-0.8v-0.8h0.8V466.9z M461.1,466.9h-0.8v-0.8h0.8V466.9z M458.3,466.9h-0.8v-0.8h0.8V466.9z
+			 M455.5,466.9h-0.8v-0.8h0.8V466.9z M452.7,466.9h-0.8v-0.8h0.8V466.9z M449.9,466.9h-0.8v-0.8h0.8V466.9z M447.1,466.9h-0.8v-0.8
+			h0.8V466.9z M444.3,466.9h-0.8v-0.8h0.8V466.9z M441.5,466.9h-0.8v-0.8h0.8V466.9z M438.7,466.9h-0.8v-0.8h0.8V466.9z
+			 M435.9,466.9h-0.8v-0.8h0.8V466.9z M433.1,466.9h-0.8v-0.8h0.8V466.9z M430.3,466.9h-0.8v-0.8h0.8V466.9z M427.5,466.9h-0.8v-0.8
+			h0.8V466.9z M424.7,466.9h-0.8v-0.8h0.8V466.9z M421.9,466.9h-0.8v-0.8h0.8V466.9z M419.1,466.9h-0.8v-0.8h0.8V466.9z
+			 M416.3,466.9h-0.8v-0.8h0.8V466.9z M413.5,466.9h-0.8v-0.8h0.8V466.9z M410.7,466.9h-0.8v-0.8h0.8V466.9z M407.9,466.9h-0.8v-0.8
+			h0.8V466.9z M405.1,466.9h-0.8v-0.8h0.8V466.9z M402.3,466.9h-0.8v-0.8h0.8V466.9z M399.5,466.9h-0.8v-0.8h0.8V466.9z
+			 M396.8,466.9H396v-0.8h0.8V466.9z M394,466.9h-0.8v-0.8h0.8V466.9z M391.2,466.9h-0.8v-0.8h0.8V466.9z M388.4,466.9h-0.8v-0.8
+			h0.8V466.9z M385.6,466.9h-0.8v-0.8h0.8V466.9z M382.8,466.9H382v-0.8h0.8V466.9z M380,466.9h-0.8v-0.8h0.8V466.9z M377.2,466.9
+			h-0.8v-0.8h0.8V466.9z M374.4,466.9h-0.8v-0.8h0.8V466.9z M371.6,466.9h-0.8v-0.8h0.8V466.9z M368.8,466.9H368v-0.8h0.8V466.9z
+			 M366,466.9h-0.8v-0.8h0.8V466.9z M363.2,466.9h-0.8v-0.8h0.8V466.9z M360.4,466.9h-0.8v-0.8h0.8V466.9z M357.6,466.9h-0.8v-0.8
+			h0.8V466.9z M354.8,466.9H354v-0.8h0.8V466.9z M352,466.9h-0.8v-0.8h0.8V466.9z M349.2,466.9h-0.8v-0.8h0.8V466.9z M346.4,466.9
+			h-0.8v-0.8h0.8V466.9z M343.6,466.9h-0.8v-0.8h0.8V466.9z M340.8,466.9H340v-0.8h0.8V466.9z M338,466.9h-0.8v-0.8h0.8V466.9z
+			 M335.2,466.9h-0.8v-0.8h0.8V466.9z M332.4,466.9h-0.8v-0.8h0.8V466.9z M329.6,466.9h-0.8v-0.8h0.8V466.9z M326.8,466.9H326v-0.8
+			h0.8V466.9z M324,466.9h-0.8v-0.8h0.8V466.9z M321.2,466.9h-0.8v-0.8h0.8V466.9z M318.4,466.9h-0.8v-0.8h0.8V466.9z M315.6,466.9
+			h-0.8v-0.8h0.8V466.9z M312.8,466.9H312v-0.8h0.8V466.9z M310,466.9h-0.8v-0.8h0.8V466.9z M307.2,466.9h-0.8v-0.8h0.8V466.9z
+			 M304.5,466.9h-0.8v-0.8h0.8V466.9z M301.7,466.9h-0.8v-0.8h0.8V466.9z M298.9,466.9h-0.8v-0.8h0.8V466.9z M296.1,466.9h-0.8v-0.8
+			h0.8V466.9z M293.3,466.9h-0.8v-0.8h0.8V466.9z M290.5,466.9h-0.8v-0.8h0.8V466.9z M287.7,466.9h-0.8v-0.8h0.8V466.9z
+			 M284.9,466.9h-0.8v-0.8h0.8V466.9z M282.1,466.9h-0.8v-0.8h0.8V466.9z M279.3,466.9h-0.8v-0.8h0.8V466.9z M276.5,466.9h-0.8v-0.8
+			h0.8V466.9z M273.7,466.9h-0.8v-0.8h0.8V466.9z M270.9,466.9h-0.8v-0.8h0.8V466.9z M268.1,466.9h-0.8v-0.8h0.8V466.9z
+			 M265.3,466.9h-0.8v-0.8h0.8V466.9z M262.5,466.9h-0.8v-0.8h0.8V466.9z M259.7,466.9h-0.8v-0.8h0.8V466.9z M256.9,466.9h-0.8v-0.8
+			h0.8V466.9z M254.1,466.9h-0.8v-0.8h0.8V466.9z M251.3,466.9h-0.8v-0.8h0.8V466.9z M248.5,466.9h-0.8v-0.8h0.8V466.9z
+			 M245.7,466.9h-0.8v-0.8h0.8V466.9z M242.9,466.9h-0.8v-0.8h0.8V466.9z M240.1,466.9h-0.8v-0.8h0.8V466.9z M237.3,466.9h-0.8v-0.8
+			h0.8V466.9z M234.5,466.9h-0.8v-0.8h0.8V466.9z M231.7,466.9h-0.8v-0.8h0.8V466.9z M228.9,466.9h-0.8v-0.8h0.8V466.9z
+			 M226.1,466.9h-0.8v-0.8h0.8V466.9z M223.3,466.9h-0.8v-0.8h0.8V466.9z M220.5,466.9h-0.8v-0.8h0.8V466.9z M217.7,466.9h-0.8v-0.8
+			h0.8V466.9z M214.9,466.9h-0.8v-0.8h0.8V466.9z M181.4,466.9h-0.8v-0.8h0.8V466.9z M178.5,466.7c-0.3-0.1-0.5-0.2-0.8-0.3l0.4-0.7
+			c0.2,0.1,0.4,0.2,0.7,0.3L178.5,466.7z M471.5,466l-0.5-0.6c0.2-0.1,0.4-0.3,0.5-0.5l0.6,0.5C472,465.6,471.7,465.8,471.5,466z
+			 M176.1,464.9c-0.2-0.2-0.3-0.5-0.4-0.8l0.7-0.3c0.1,0.2,0.2,0.4,0.3,0.6L176.1,464.9z M473.1,463.4l-0.8-0.2
+			c0-0.2,0.1-0.5,0.1-0.7l0.8,0v0C473.2,462.8,473.2,463.1,473.1,463.4z M176.2,462h-0.8v-0.8h0.8V462z M473.2,460.5h-0.8v-0.8h0.8
+			V460.5z M176.2,459.2h-0.8v-0.8h0.8V459.2z M473.2,457.7h-0.8v-0.8h0.8V457.7z M176.2,456.4h-0.8v-0.8h0.8V456.4z M473.2,454.9
+			h-0.8v-0.8h0.8V454.9z M176.2,453.6h-0.8v-0.8h0.8V453.6z M473.2,452.1h-0.8v-0.8h0.8V452.1z M176.2,450.8h-0.8V450h0.8V450.8z
+			 M473.2,449.3h-0.8v-0.8h0.8V449.3z M176.2,448h-0.8v-0.8h0.8V448z M473.2,446.5h-0.8v-0.8h0.8V446.5z M176.2,445.2h-0.8v-0.8h0.8
+			V445.2z M473.2,443.7h-0.8v-0.8h0.8V443.7z M176.2,442.4h-0.8v-0.8h0.8V442.4z M473.2,440.9h-0.8v-0.8h0.8V440.9z M176.2,439.6
+			h-0.8v-0.8h0.8V439.6z M473.2,438.1h-0.8v-0.8h0.8V438.1z M176.2,436.8h-0.8V436h0.8V436.8z M473.2,435.3h-0.8v-0.8h0.8V435.3z
+			 M176.2,434h-0.8v-0.8h0.8V434z M473.2,432.5h-0.8v-0.8h0.8V432.5z M176.2,431.2h-0.8v-0.8h0.8V431.2z M473.2,429.7h-0.8v-0.8h0.8
+			V429.7z M176.2,428.5h-0.8v-0.8h0.8V428.5z M473.2,426.9h-0.8v-0.8h0.8V426.9z M176.2,425.7h-0.8v-0.8h0.8V425.7z M473.2,424.1
+			h-0.8v-0.8h0.8V424.1z M176.2,422.9h-0.8v-0.8h0.8V422.9z M473.2,421.3h-0.8v-0.8h0.8V421.3z M176.2,420.1h-0.8v-0.8h0.8V420.1z
+			 M473.2,418.5h-0.8v-0.8h0.8V418.5z M176.2,417.3h-0.8v-0.8h0.8V417.3z M473.2,415.7h-0.8v-0.8h0.8V415.7z M176.2,414.5h-0.8v-0.8
+			h0.8V414.5z M473.2,412.9h-0.8v-0.8h0.8V412.9z M176.2,411.7h-0.8v-0.8h0.8V411.7z M473.2,410.1h-0.8v-0.8h0.8V410.1z
+			 M176.2,408.9h-0.8v-0.8h0.8V408.9z M473.2,407.3h-0.8v-0.8h0.8V407.3z M176.2,406.1h-0.8v-0.8h0.8V406.1z M473.2,404.5h-0.8v-0.8
+			h0.8V404.5z M176.2,403.3h-0.8v-0.8h0.8V403.3z M473.2,401.7h-0.8V401h0.8V401.7z M176.2,400.5h-0.8v-0.8h0.8V400.5z M473.2,399
+			h-0.8v-0.8h0.8V399z M176.2,397.7h-0.8v-0.8h0.8V397.7z M473.2,396.2h-0.8v-0.8h0.8V396.2z M176.2,394.9h-0.8v-0.8h0.8V394.9z
+			 M473.2,393.4h-0.8v-0.8h0.8V393.4z M176.2,392.1h-0.8v-0.8h0.8V392.1z M473.2,390.6h-0.8v-0.8h0.8V390.6z M176.2,389.3h-0.8v-0.8
+			h0.8V389.3z M473.2,387.8h-0.8V387h0.8V387.8z M176.2,386.5h-0.8v-0.8h0.8V386.5z M473.2,385h-0.8v-0.8h0.8V385z M176.2,383.7
+			h-0.8v-0.8h0.8V383.7z M473.2,382.2h-0.8v-0.8h0.8V382.2z M176.2,380.9h-0.8v-0.8h0.8V380.9z M473.2,379.4h-0.8v-0.8h0.8V379.4z
+			 M176.2,378.1h-0.8v-0.8h0.8V378.1z M473.2,376.6h-0.8v-0.8h0.8V376.6z M176.2,375.3h-0.8v-0.8h0.8V375.3z M473.2,373.8h-0.8V373
+			h0.8V373.8z M176.2,372.5h-0.8v-0.8h0.8V372.5z M473.2,371h-0.8v-0.8h0.8V371z M176.2,369.7h-0.8v-0.8h0.8V369.7z M473.2,368.2
+			h-0.8v-0.8h0.8V368.2z M176.2,366.9h-0.8v-0.8h0.8V366.9z M473.2,365.4h-0.8v-0.8h0.8V365.4z M176.2,364.1h-0.8v-0.8h0.8V364.1z
+			 M473.2,362.6h-0.8v-0.8h0.8V362.6z M176.2,361.3h-0.8v-0.8h0.8V361.3z M473.2,359.8h-0.8V359h0.8V359.8z M176.2,358.5h-0.8v-0.8
+			h0.8V358.5z M473.2,357h-0.8v-0.8h0.8V357z M176.2,355.7h-0.8v-0.8h0.8V355.7z M473.2,354.2h-0.8v-0.8h0.8V354.2z M176.2,352.9
+			h-0.8v-0.8h0.8V352.9z M473.2,351.4h-0.8v-0.8h0.8V351.4z M176.2,350.1h-0.8v-0.8h0.8V350.1z M473.2,348.6h-0.8v-0.8h0.8V348.6z
+			 M176.2,347.3h-0.8v-0.8h0.8V347.3z M473.2,345.8h-0.8V345h0.8V345.8z M176.2,344.5h-0.8v-0.8h0.8V344.5z M473.2,343h-0.8v-0.8
+			h0.8V343z M176.2,341.7h-0.8v-0.8h0.8V341.7z M473.2,340.2h-0.8v-0.8h0.8V340.2z M176.2,338.9h-0.8v-0.8h0.8V338.9z M473.2,337.4
+			h-0.8v-0.8h0.8V337.4z M176.2,336.1h-0.8v-0.8h0.8V336.1z M473.2,334.6h-0.8v-0.8h0.8V334.6z M176.2,333.4h-0.8v-0.8h0.8V333.4z
+			 M473.2,331.8h-0.8V331h0.8V331.8z M176.2,330.6h-0.8v-0.8h0.8V330.6z M473.2,329h-0.8v-0.8h0.8V329z M176.2,327.8h-0.8V327h0.8
+			V327.8z M473.2,326.2h-0.8v-0.8h0.8V326.2z M176.2,325h-0.8v-0.8h0.8V325z M473.2,323.4h-0.8v-0.8h0.8V323.4z M176.2,322.2h-0.8
+			v-0.8h0.8V322.2z M473.2,320.6h-0.8v-0.8h0.8V320.6z M176.2,319.4h-0.8v-0.8h0.8V319.4z M473.2,317.8h-0.8V317h0.8V317.8z
+			 M176.2,316.6h-0.8v-0.8h0.8V316.6z M473.2,315h-0.8v-0.8h0.8V315z M176.2,313.8h-0.8V313h0.8V313.8z M473.2,312.2h-0.8v-0.8h0.8
+			V312.2z M176.2,311h-0.8v-0.8h0.8V311z M473.2,309.4h-0.8v-0.8h0.8V309.4z M176.2,308.2h-0.8v-0.8h0.8V308.2z M473.2,306.7h-0.8
+			v-0.8h0.8V306.7z M176.2,305.4h-0.8v-0.8h0.8V305.4z M473.2,303.9h-0.8v-0.8h0.8V303.9z M176.2,302.6h-0.8v-0.8h0.8V302.6z
+			 M473.2,301.1h-0.8v-0.8h0.8V301.1z M176.2,299.8h-0.8V299h0.8V299.8z M473.2,298.3h-0.8v-0.8h0.8V298.3z M176.2,297h-0.8v-0.8
+			h0.8V297z M473.2,295.5h-0.8v-0.8h0.8V295.5z M176.2,294.2h-0.8v-0.8h0.8V294.2z M473.2,292.7h-0.8v-0.8h0.8V292.7z M176.2,291.4
+			h-0.8v-0.8h0.8V291.4z M473.2,289.9h-0.8v-0.8h0.8V289.9z M176.2,288.6h-0.8v-0.8h0.8V288.6z M473.2,287.1h-0.8v-0.8h0.8V287.1z
+			 M176.2,285.8h-0.8V285h0.8V285.8z M473.2,284.3h-0.8v-0.8h0.8V284.3z M176.2,283h-0.8v-0.8h0.8V283z M473.2,281.5h-0.8v-0.8h0.8
+			V281.5z M176.2,280.2h-0.8v-0.8h0.8V280.2z M473.2,278.7h-0.8v-0.8h0.8V278.7z M176.2,277.4h-0.8v-0.8h0.8V277.4z M473.2,275.9
+			h-0.8v-0.8h0.8V275.9z M176.2,274.6h-0.8v-0.8h0.8V274.6z M473.2,273.1h-0.8v-0.8h0.8V273.1z M176.2,271.8h-0.8V271h0.8V271.8z
+			 M473.2,270.3h-0.8v-0.8h0.8V270.3z M176.2,269h-0.8v-0.8h0.8V269z M473.2,267.5h-0.8v-0.8h0.8V267.5z M176.2,266.2h-0.8v-0.8h0.8
+			V266.2z M473.2,264.7h-0.8v-0.8h0.8V264.7z M176.2,263.4h-0.8v-0.8h0.8V263.4z M473.2,261.9h-0.8v-0.8h0.8V261.9z M176.2,260.6
+			h-0.8v-0.8h0.8V260.6z M473.2,259.1h-0.8v-0.8h0.8V259.1z M176.2,257.8h-0.8V257h0.8V257.8z M473.2,256.3h-0.8v-0.8h0.8V256.3z
+			 M176.2,255h-0.8v-0.8h0.8V255z M473.2,253.5h-0.8v-0.8h0.8V253.5z M176.2,252.2h-0.8v-0.8h0.8V252.2z M473.2,250.7h-0.8v-0.8h0.8
+			V250.7z M176.2,249.4h-0.8v-0.8h0.8V249.4z M473.2,247.9h-0.8v-0.8h0.8V247.9z M176.2,246.6h-0.8v-0.8h0.8V246.6z M473.2,245.1
+			h-0.8v-0.8h0.8V245.1z M176.2,243.8h-0.8V243h0.8V243.8z M473.2,242.3h-0.8v-0.8h0.8V242.3z M176.2,241h-0.8v-0.8h0.8V241z
+			 M473.2,239.5h-0.8v-0.8h0.8V239.5z M176.2,238.3h-0.8v-0.8h0.8V238.3z M473.2,236.7h-0.8v-0.8h0.8V236.7z M176.2,235.5h-0.8v-0.8
+			h0.8V235.5z M473.2,233.9h-0.8v-0.8h0.8V233.9z M176.2,232.7h-0.8v-0.8h0.8V232.7z M473.2,231.1h-0.8v-0.8h0.8V231.1z
+			 M176.2,229.9h-0.8v-0.8h0.8V229.9z M473.2,228.3h-0.8v-0.8h0.8V228.3z M176.2,227.1h-0.8v-0.8h0.8V227.1z M473.2,225.5h-0.8v-0.8
+			h0.8V225.5z M176.2,224.3h-0.8v-0.8h0.8V224.3z M473.2,222.7h-0.8v-0.8h0.8V222.7z M176.2,221.5h-0.8v-0.8h0.8V221.5z
+			 M473.2,219.9h-0.8v-0.8h0.8V219.9z M176.2,218.7h-0.8v-0.8h0.8V218.7z M473.2,217.1h-0.8v-0.8h0.8V217.1z M176.2,215.9h-0.8v-0.8
+			h0.8V215.9z M473.2,214.3h-0.8v-0.8h0.8V214.3z M176.2,213.1h-0.8v-0.8h0.8V213.1z M473.2,211.6h-0.8v-0.8h0.8V211.6z
+			 M176.2,210.3h-0.8v-0.8h0.8V210.3z M473.2,208.8h-0.8V208h0.8V208.8z M176.2,207.5h-0.8v-0.8h0.8V207.5z M473.2,206h-0.8v-0.8
+			h0.8V206z M176.2,204.7h-0.8v-0.8h0.8V204.7z M473.2,203.2h-0.8v-0.8h0.8V203.2z M176.2,201.9h-0.8v-0.8h0.8V201.9z M473.2,200.4
+			h-0.8v-0.8h0.8V200.4z M176.2,199.1h-0.8v-0.8h0.8V199.1z M473.2,197.6h-0.8v-0.8h0.8V197.6z M176.2,196.3h-0.8v-0.8h0.8V196.3z
+			 M473.2,194.8h-0.8V194h0.8V194.8z M176.2,193.5h-0.8v-0.8h0.8V193.5z M473.2,192h-0.8v-0.8h0.8V192z M176.2,190.7h-0.8v-0.8h0.8
+			V190.7z M473.2,189.2h-0.8v-0.8h0.8V189.2z M176.2,187.9h-0.8v-0.8h0.8V187.9z M473.2,186.4h-0.8v-0.8h0.8V186.4z M176.2,185.1
+			h-0.8v-0.8h0.8V185.1z M473.2,183.6h-0.8v-0.8h0.8V183.6z M176.2,182.3h-0.8v-0.8h0.8V182.3z M473.2,180.8h-0.8V180h0.8V180.8z
+			 M176.2,179.5h-0.8v-0.8h0.8V179.5z M473.2,178h-0.8v-0.8h0.8V178z M176.2,176.7h-0.8v-0.8h0.8V176.7z M473.2,175.2h-0.8v-0.8h0.8
+			V175.2z M176.2,173.9h-0.8v-0.8h0.8V173.9z M473.2,172.4h-0.8v-0.8h0.8V172.4z M176.2,171.1h-0.8v-0.8h0.8V171.1z M473.2,169.6
+			h-0.8v-0.8h0.8V169.6z M176.2,168.3h-0.8v-0.8h0.8V168.3z M473.2,166.8h-0.8V166h0.8V166.8z M176.2,165.5h-0.8v-0.8h0.8V165.5z
+			 M473.2,164h-0.8v-0.8h0.8V164z M176.2,162.7h-0.8v-0.8h0.8V162.7z M473.2,161.2h-0.8v-0.8h0.8V161.2z M176.2,159.9h-0.8v-0.8h0.8
+			V159.9z M473.2,158.4h-0.8v-0.8h0.8V158.4z M176.2,157.1h-0.8v-0.8h0.8V157.1z M473.2,155.6h-0.8v-0.8h0.8V155.6z M176.2,154.3
+			h-0.8v-0.8h0.8V154.3z M473.2,152.8h-0.8V152h0.8V152.8z M176.2,151.5h-0.8v-0.8h0.8V151.5z M473.2,150h-0.8v-0.8h0.8V150z
+			 M176.2,148.7h-0.8v-0.8h0.8V148.7z M473.2,147.2h-0.8v-0.8h0.8V147.2z M176.2,146h-0.8v-0.8h0.8V146z M472.4,144.4
+			c0-0.2,0-0.5-0.1-0.7l0.8-0.2c0.1,0.3,0.1,0.6,0.1,0.9L472.4,144.4z M176.4,143.3l-0.8-0.3c0.1-0.3,0.2-0.5,0.4-0.8l0.7,0.4
+			C176.6,142.9,176.5,143.1,176.4,143.3z M471.5,142.1c-0.2-0.2-0.3-0.3-0.5-0.5l0.5-0.6c0.2,0.2,0.4,0.4,0.6,0.6L471.5,142.1z
+			 M178,141.4l-0.4-0.7c0.3-0.1,0.5-0.3,0.8-0.4l0.3,0.8C178.4,141.2,178.2,141.3,178,141.4z M469.3,141c-0.2,0-0.3,0-0.5,0h-0.2
+			v-0.8h0.2c0.2,0,0.4,0,0.6,0L469.3,141z M466.6,140.9h-0.8v-0.8h0.8V140.9z M463.8,140.9H463v-0.8h0.8V140.9z M461,140.9h-0.8
+			v-0.8h0.8V140.9z M458.2,140.9h-0.8v-0.8h0.8V140.9z M455.4,140.9h-0.8v-0.8h0.8V140.9z M452.6,140.9h-0.8v-0.8h0.8V140.9z
+			 M449.8,140.9H449v-0.8h0.8V140.9z M447,140.9h-0.8v-0.8h0.8V140.9z M444.2,140.9h-0.8v-0.8h0.8V140.9z M441.4,140.9h-0.8v-0.8
+			h0.8V140.9z M438.6,140.9h-0.8v-0.8h0.8V140.9z M435.8,140.9H435v-0.8h0.8V140.9z M433,140.9h-0.8v-0.8h0.8V140.9z M430.2,140.9
+			h-0.8v-0.8h0.8V140.9z M427.4,140.9h-0.8v-0.8h0.8V140.9z M424.6,140.9h-0.8v-0.8h0.8V140.9z M421.8,140.9H421v-0.8h0.8V140.9z
+			 M419,140.9h-0.8v-0.8h0.8V140.9z M416.2,140.9h-0.8v-0.8h0.8V140.9z M413.4,140.9h-0.8v-0.8h0.8V140.9z M410.6,140.9h-0.8v-0.8
+			h0.8V140.9z M407.8,140.9H407v-0.8h0.8V140.9z M405,140.9h-0.8v-0.8h0.8V140.9z M402.2,140.9h-0.8v-0.8h0.8V140.9z M399.4,140.9
+			h-0.8v-0.8h0.8V140.9z M396.6,140.9h-0.8v-0.8h0.8V140.9z M393.8,140.9H393v-0.8h0.8V140.9z M391.1,140.9h-0.8v-0.8h0.8V140.9z
+			 M388.3,140.9h-0.8v-0.8h0.8V140.9z M385.5,140.9h-0.8v-0.8h0.8V140.9z M382.7,140.9h-0.8v-0.8h0.8V140.9z M379.9,140.9h-0.8v-0.8
+			h0.8V140.9z M377.1,140.9h-0.8v-0.8h0.8V140.9z M374.3,140.9h-0.8v-0.8h0.8V140.9z M371.5,140.9h-0.8v-0.8h0.8V140.9z
+			 M368.7,140.9h-0.8v-0.8h0.8V140.9z M365.9,140.9h-0.8v-0.8h0.8V140.9z M363.1,140.9h-0.8v-0.8h0.8V140.9z M360.3,140.9h-0.8v-0.8
+			h0.8V140.9z M357.5,140.9h-0.8v-0.8h0.8V140.9z M354.7,140.9h-0.8v-0.8h0.8V140.9z M351.9,140.9h-0.8v-0.8h0.8V140.9z
+			 M349.1,140.9h-0.8v-0.8h0.8V140.9z M346.3,140.9h-0.8v-0.8h0.8V140.9z M343.5,140.9h-0.8v-0.8h0.8V140.9z M340.7,140.9h-0.8v-0.8
+			h0.8V140.9z M337.9,140.9h-0.8v-0.8h0.8V140.9z M335.1,140.9h-0.8v-0.8h0.8V140.9z M332.3,140.9h-0.8v-0.8h0.8V140.9z
+			 M329.5,140.9h-0.8v-0.8h0.8V140.9z M326.7,140.9h-0.8v-0.8h0.8V140.9z M323.9,140.9h-0.8v-0.8h0.8V140.9z M321.1,140.9h-0.8v-0.8
+			h0.8V140.9z M318.3,140.9h-0.8v-0.8h0.8V140.9z M315.5,140.9h-0.8v-0.8h0.8V140.9z M312.7,140.9h-0.8v-0.8h0.8V140.9z
+			 M309.9,140.9h-0.8v-0.8h0.8V140.9z M307.1,140.9h-0.8v-0.8h0.8V140.9z M304.3,140.9h-0.8v-0.8h0.8V140.9z M301.5,140.9h-0.8v-0.8
+			h0.8V140.9z M298.7,140.9H298v-0.8h0.8V140.9z M296,140.9h-0.8v-0.8h0.8V140.9z M293.2,140.9h-0.8v-0.8h0.8V140.9z M290.4,140.9
+			h-0.8v-0.8h0.8V140.9z M287.6,140.9h-0.8v-0.8h0.8V140.9z M284.8,140.9H284v-0.8h0.8V140.9z M282,140.9h-0.8v-0.8h0.8V140.9z
+			 M279.2,140.9h-0.8v-0.8h0.8V140.9z M276.4,140.9h-0.8v-0.8h0.8V140.9z M273.6,140.9h-0.8v-0.8h0.8V140.9z M270.8,140.9H270v-0.8
+			h0.8V140.9z M268,140.9h-0.8v-0.8h0.8V140.9z M265.2,140.9h-0.8v-0.8h0.8V140.9z M262.4,140.9h-0.8v-0.8h0.8V140.9z M259.6,140.9
+			h-0.8v-0.8h0.8V140.9z M256.8,140.9H256v-0.8h0.8V140.9z M254,140.9h-0.8v-0.8h0.8V140.9z M251.2,140.9h-0.8v-0.8h0.8V140.9z
+			 M248.4,140.9h-0.8v-0.8h0.8V140.9z M245.6,140.9h-0.8v-0.8h0.8V140.9z M242.8,140.9H242v-0.8h0.8V140.9z M240,140.9h-0.8v-0.8
+			h0.8V140.9z M237.2,140.9h-0.8v-0.8h0.8V140.9z M234.4,140.9h-0.8v-0.8h0.8V140.9z M231.6,140.9h-0.8v-0.8h0.8V140.9z
+			 M228.8,140.9H228v-0.8h0.8V140.9z M226,140.9h-0.8v-0.8h0.8V140.9z M223.2,140.9h-0.8v-0.8h0.8V140.9z M220.4,140.9h-0.8v-0.8
+			h0.8V140.9z M217.6,140.9h-0.8v-0.8h0.8V140.9z M214.8,140.9H214v-0.8h0.8V140.9z M212,140.9h-0.8v-0.8h0.8V140.9z M209.2,140.9
+			h-0.8v-0.8h0.8V140.9z M206.4,140.9h-0.8v-0.8h0.8V140.9z M203.7,140.9h-0.8v-0.8h0.8V140.9z M200.9,140.9h-0.8v-0.8h0.8V140.9z
+			 M198.1,140.9h-0.8v-0.8h0.8V140.9z M195.3,140.9h-0.8v-0.8h0.8V140.9z M192.5,140.9h-0.8v-0.8h0.8V140.9z M189.7,140.9h-0.8v-0.8
+			h0.8V140.9z M186.9,140.9h-0.8v-0.8h0.8V140.9z M184.1,140.9h-0.8v-0.8h0.8V140.9z M181.3,140.9h-0.8v-0.8h0.8V140.9z"/>
+	</g>
+	<g>
+		<rect x="437.8" y="6.5" class="st1" width="157.8" height="53"/>
+		<rect x="437.8" y="6.5" class="st6" width="157.8" height="53"/>
+		<path class="st7" d="M595.4,6.6v52.7H437.9V6.6H595.4 M595.6,6.3h-158v53.2h158V6.3L595.6,6.3z"/>
+	</g>
+	<g>
+		<rect x="921.4" y="6.5" class="st1" width="197.8" height="114.2"/>
+		<rect x="921.4" y="6.5" class="st6" width="197.8" height="114.2"/>
+		<path class="st7" d="M1119,6.6v113.9H921.5V6.6H1119 M1119.2,6.3h-198v114.4h198V6.3L1119.2,6.3z"/>
+	</g>
+	<g>
+		<rect x="771.8" y="6.5" class="st1" width="136.1" height="114.4"/>
+		<rect x="771.8" y="6.5" class="st6" width="136.1" height="114.4"/>
+		<path class="st7" d="M907.8,6.6v114.1H771.9V6.6H907.8 M908,6.3H771.6v114.6H908V6.3L908,6.3z"/>
+	</g>
+	<g>
+		<rect x="622.2" y="6.5" class="st1" width="136.2" height="114.4"/>
+		<rect x="622.2" y="6.5" class="st6" width="136.2" height="114.4"/>
+		<path class="st7" d="M758.2,6.6v114.1H622.3V6.6H758.2 M758.4,6.3H622v114.6h136.4V6.3L758.4,6.3z"/>
+	</g>
+	<g>
+		<rect x="106.7" y="151.7" class="st8" width="17.6" height="1"/>
+		<g>
+			<polygon class="st8" points="107.8,148.5 101.3,152.2 107.8,156 			"/>
+		</g>
+	</g>
+	<g>
+		<rect x="149.3" y="151.7" class="st8" width="17" height="1"/>
+		<g>
+			<polygon class="st8" points="165.2,148.5 171.7,152.2 165.2,156 			"/>
+		</g>
+	</g>
+	<g>
+		<rect x="126.8" y="150.8" transform="matrix(0.5 -0.866 0.866 0.5 -65.0652 191.6597)" class="st9" width="13.2" height="2.8"/>
+		<rect x="141.1" y="145.8" transform="matrix(0.866 -0.5 0.5 0.866 -57.1109 91.6421)" class="st9" width="2.8" height="13.2"/>
+		<rect x="131.2" y="158.8" class="st10" width="13.2" height="2.8"/>
+		
+			<linearGradient id="SVGID_1_" gradientUnits="userSpaceOnUse" x1="133.1442" y1="156.7611" x2="137.8836" y2="152.0217" gradientTransform="matrix(1 -1.396263e-03 -1.396263e-03 -1 2.7925 298.6591)">
+			<stop  offset="0" style="stop-color:#86D633"/>
+			<stop  offset="1" style="stop-color:#5E9624"/>
+		</linearGradient>
+		<circle class="st11" cx="138.1" cy="144.1" r="3.4"/>
+		
+			<linearGradient id="SVGID_00000086675194261880175900000001980723025759281052_" gradientUnits="userSpaceOnUse" x1="144.3352" y1="142.585" x2="149.0676" y2="137.8387" gradientTransform="matrix(1 0 0 -1 0 300.1305)">
+			<stop  offset="0" style="stop-color:#86D633"/>
+			<stop  offset="1" style="stop-color:#5E9624"/>
+		</linearGradient>
+		<circle style="fill:url(#SVGID_00000086675194261880175900000001980723025759281052_);" cx="147.2" cy="160.4" r="3.4"/>
+		
+			<linearGradient id="SVGID_00000114045067912083788760000014948820005325850510_" gradientUnits="userSpaceOnUse" x1="125.9929" y1="142.5913" x2="130.7208" y2="137.8634" gradientTransform="matrix(1 0 0 -1 0 300.1305)">
+			<stop  offset="0" style="stop-color:#86D633"/>
+			<stop  offset="1" style="stop-color:#5E9624"/>
+		</linearGradient>
+		<circle style="fill:url(#SVGID_00000114045067912083788760000014948820005325850510_);" cx="128.8" cy="160.4" r="3.4"/>
+	</g>
+	<g>
+		<rect x="478.5" y="406" class="st8" width="18.1" height="1"/>
+		<g>
+			<polygon class="st8" points="479.6,402.8 473.1,406.5 479.6,410.2 			"/>
+		</g>
+	</g>
+	<g>
+		<rect x="534.7" y="406" class="st8" width="16.6" height="1"/>
+		<g>
+			<polygon class="st8" points="550.2,402.8 556.7,406.5 550.2,410.2 			"/>
+		</g>
+	</g>
+	<g>
+		<rect x="194.8" y="153.9" class="st1" width="117.5" height="124.1"/>
+		<rect x="194.8" y="153.9" class="st14" width="117.5" height="124.1"/>
+	</g>
+	<g>
+		<path class="st15" d="M208.5,432.6c0,5.9-7.2,10.7-8.7,11.6c-0.2,0.1-0.4,0.1-0.6,0c-1.6-1-8.7-5.7-8.7-11.6v-7.1
+			c0-0.3,0.2-0.6,0.6-0.6c5.6-0.1,4.3-2.6,8.4-2.6c4.2,0,2.9,2.4,8.4,2.6c0.3,0,0.6,0.3,0.6,0.6V432.6z"/>
+		<path class="st16" d="M207.8,432.7c0,5.4-6.6,9.8-8,10.7c-0.2,0.1-0.4,0.1-0.5,0c-1.4-0.9-8-5.3-8-10.7v-6.5
+			c0-0.3,0.2-0.5,0.5-0.5c5.1-0.1,3.9-2.4,7.7-2.4c3.8,0,2.7,2.2,7.7,2.4c0.3,0,0.5,0.2,0.5,0.5V432.7z"/>
+		
+			<linearGradient id="SVGID_00000026876541265092645190000001073822805202080945_" gradientUnits="userSpaceOnUse" x1="199.549" y1="-123.1135" x2="199.549" y2="-143.2829" gradientTransform="matrix(1 0 0 -1 0 300.1305)">
+			<stop  offset="0" style="stop-color:#5EA0EF"/>
+			<stop  offset="0.18" style="stop-color:#559CEC"/>
+			<stop  offset="0.47" style="stop-color:#3C91E5"/>
+			<stop  offset="0.84" style="stop-color:#1380DA"/>
+			<stop  offset="1" style="stop-color:#0078D4"/>
+		</linearGradient>
+		<path style="fill:url(#SVGID_00000026876541265092645190000001073822805202080945_);" d="M199.5,433.3v-10.1
+			c3.8,0,2.7,2.2,7.7,2.4c0.3,0,0.5,0.2,0.5,0.5v6.5c0,0.2,0,0.4,0,0.7H199.5z M199.5,433.3h-8.2c0.5,5.1,6.6,9.2,7.9,10
+			c0.1,0,0.1,0.1,0.2,0.1h0V433.3z"/>
+		<path class="st18" d="M191.8,425.6c5.1-0.1,3.9-2.4,7.7-2.4v10.1h-8.2c0-0.2,0-0.4,0-0.7v-6.5
+			C191.3,425.9,191.5,425.6,191.8,425.6z"/>
+		<path class="st18" d="M207.7,433.3h-8.2v10.1l0,0c0.1,0,0.2,0,0.2-0.1C201.2,442.5,207.3,438.4,207.7,433.3z"/>
+	</g>
+	<g>
+		
+			<linearGradient id="SVGID_00000163040989713159627260000012204692645940640641_" gradientUnits="userSpaceOnUse" x1="199.0857" y1="-165.7724" x2="201.4545" y2="-168.1412" gradientTransform="matrix(1 -1.396263e-03 -1.396263e-03 -1 2.7925 299.629)">
+			<stop  offset="0" style="stop-color:#86D633"/>
+			<stop  offset="0.24" style="stop-color:#83D232"/>
+			<stop  offset="0.5" style="stop-color:#7CC52F"/>
+			<stop  offset="0.76" style="stop-color:#6FB02A"/>
+			<stop  offset="1" style="stop-color:#5E9624"/>
+		</linearGradient>
+		<circle style="fill:url(#SVGID_00000163040989713159627260000012204692645940640641_);" cx="203.3" cy="466.3" r="1.7"/>
+		
+			<linearGradient id="SVGID_00000134959334009380089080000007623526298329369253_" gradientUnits="userSpaceOnUse" x1="193.7432" y1="-165.7723" x2="196.0968" y2="-168.1404" gradientTransform="matrix(1 -1.396263e-03 -1.396263e-03 -1 2.7925 299.629)">
+			<stop  offset="0" style="stop-color:#86D633"/>
+			<stop  offset="0.24" style="stop-color:#83D232"/>
+			<stop  offset="0.5" style="stop-color:#7CC52F"/>
+			<stop  offset="0.76" style="stop-color:#6FB02A"/>
+			<stop  offset="1" style="stop-color:#5E9624"/>
+		</linearGradient>
+		<circle style="fill:url(#SVGID_00000134959334009380089080000007623526298329369253_);" cx="197.9" cy="466.3" r="1.7"/>
+		
+			<linearGradient id="SVGID_00000161610697030923216780000016152398373088624574_" gradientUnits="userSpaceOnUse" x1="188.4043" y1="-165.7686" x2="190.7579" y2="-168.1367" gradientTransform="matrix(1 -1.396263e-03 -1.396263e-03 -1 2.7925 299.629)">
+			<stop  offset="0" style="stop-color:#86D633"/>
+			<stop  offset="0.24" style="stop-color:#83D232"/>
+			<stop  offset="0.5" style="stop-color:#7CC52F"/>
+			<stop  offset="0.76" style="stop-color:#6FB02A"/>
+			<stop  offset="1" style="stop-color:#5E9624"/>
+		</linearGradient>
+		<circle style="fill:url(#SVGID_00000161610697030923216780000016152398373088624574_);" cx="192.6" cy="466.3" r="1.7"/>
+		<path class="st18" d="M193.8,473l-1,1c-0.2,0.2-0.4,0.2-0.6,0l0,0l-7.1-7.1c-0.3-0.3-0.3-0.9,0-1.2l0,0l1-1l0,0l7.7,7.7
+			C194,472.6,194,472.8,193.8,473L193.8,473z"/>
+		<path class="st22" d="M192.7,458.7l1,1c0.2,0.2,0.2,0.4,0,0.6l-7.6,7.6l0,0l-1-1c-0.3-0.3-0.3-0.9,0-1.2h0l7-7
+			C192.3,458.5,192.5,458.5,192.7,458.7z"/>
+		<path class="st18" d="M209.7,464.7l1,1c0.3,0.3,0.3,0.9,0,1.2l0,0l-7.1,7.1c-0.2,0.2-0.4,0.2-0.6,0l0,0l-1-1
+			c-0.2-0.2-0.2-0.4,0-0.6l0,0L209.7,464.7L209.7,464.7z"/>
+		<path class="st22" d="M210.6,466.9l-1,1l0,0l-7.6-7.6c-0.2-0.2-0.2-0.4,0-0.6l0,0l1-1c0.2-0.2,0.4-0.2,0.6,0l0,0l7,7
+			C211,466,211,466.5,210.6,466.9L210.6,466.9L210.6,466.9z"/>
+	</g>
+	<g>
+		
+			<linearGradient id="SVGID_00000157989251895437243500000016270306593301272500_" gradientUnits="userSpaceOnUse" x1="516.143" y1="-108.0151" x2="518.5118" y2="-110.3839" gradientTransform="matrix(1 -1.396263e-03 -1.396263e-03 -1 2.7925 299.629)">
+			<stop  offset="0" style="stop-color:#86D633"/>
+			<stop  offset="0.24" style="stop-color:#83D232"/>
+			<stop  offset="0.5" style="stop-color:#7CC52F"/>
+			<stop  offset="0.76" style="stop-color:#6FB02A"/>
+			<stop  offset="1" style="stop-color:#5E9624"/>
+		</linearGradient>
+		<circle style="fill:url(#SVGID_00000157989251895437243500000016270306593301272500_);" cx="520.3" cy="408.1" r="1.7"/>
+		
+			<linearGradient id="SVGID_00000154391155374595774790000008900720957775785611_" gradientUnits="userSpaceOnUse" x1="510.8005" y1="-108.015" x2="513.1541" y2="-110.3831" gradientTransform="matrix(1 -1.396263e-03 -1.396263e-03 -1 2.7925 299.629)">
+			<stop  offset="0" style="stop-color:#86D633"/>
+			<stop  offset="0.24" style="stop-color:#83D232"/>
+			<stop  offset="0.5" style="stop-color:#7CC52F"/>
+			<stop  offset="0.76" style="stop-color:#6FB02A"/>
+			<stop  offset="1" style="stop-color:#5E9624"/>
+		</linearGradient>
+		<circle style="fill:url(#SVGID_00000154391155374595774790000008900720957775785611_);" cx="514.9" cy="408.1" r="1.7"/>
+		
+			<linearGradient id="SVGID_00000066501495133277152290000006347202752714110595_" gradientUnits="userSpaceOnUse" x1="505.4615" y1="-108.0113" x2="507.8152" y2="-110.3794" gradientTransform="matrix(1 -1.396263e-03 -1.396263e-03 -1 2.7925 299.629)">
+			<stop  offset="0" style="stop-color:#86D633"/>
+			<stop  offset="0.24" style="stop-color:#83D232"/>
+			<stop  offset="0.5" style="stop-color:#7CC52F"/>
+			<stop  offset="0.76" style="stop-color:#6FB02A"/>
+			<stop  offset="1" style="stop-color:#5E9624"/>
+		</linearGradient>
+		<circle style="fill:url(#SVGID_00000066501495133277152290000006347202752714110595_);" cx="509.6" cy="408.1" r="1.7"/>
+		<path class="st18" d="M510.8,414.8l-1,1c-0.2,0.2-0.4,0.2-0.6,0l0,0l-7.1-7.1c-0.3-0.3-0.3-0.9,0-1.2l0,0l1-1l0,0l7.7,7.7
+			C511,414.4,511,414.6,510.8,414.8L510.8,414.8z"/>
+		<path class="st22" d="M509.7,400.5l1,1c0.2,0.2,0.2,0.4,0,0.6l-7.6,7.6l0,0l-1-1c-0.3-0.3-0.3-0.9,0-1.2l0,0l7-7
+			C509.2,400.3,509.5,400.3,509.7,400.5z"/>
+		<path class="st18" d="M526.6,406.5l1,1c0.3,0.3,0.3,0.9,0,1.2l0,0l-7.1,7.1c-0.2,0.2-0.4,0.2-0.6,0l0,0l-1-1
+			c-0.2-0.2-0.2-0.4,0-0.6l0,0L526.6,406.5L526.6,406.5z"/>
+		<path class="st22" d="M527.6,408.7l-1,1l0,0l-7.6-7.6c-0.2-0.2-0.2-0.4,0-0.6l0,0l1-1c0.2-0.2,0.4-0.2,0.6,0l0,0l7,7
+			C527.9,407.8,527.9,408.3,527.6,408.7L527.6,408.7L527.6,408.7z"/>
+	</g>
+	<g>
+		<rect x="194.8" y="290.4" class="st1" width="117.5" height="124.1"/>
+		<rect x="194.8" y="290.4" class="st14" width="117.5" height="124.1"/>
+	</g>
+	<g>
+		<rect x="336" y="290.4" class="st1" width="117.5" height="124.1"/>
+		<rect x="336" y="290.4" class="st14" width="117.5" height="124.1"/>
+	</g>
+	<g>
+		
+			<linearGradient id="SVGID_00000078027665584391974060000013057938891709278361_" gradientUnits="userSpaceOnUse" x1="253.3842" y1="-60.3749" x2="253.3842" y2="-32.1815" gradientTransform="matrix(1 0 0 -1 -3.547359e-03 300.129)">
+			<stop  offset="0" style="stop-color:#258378"/>
+			<stop  offset="0.42" style="stop-color:#49A498"/>
+			<stop  offset="0.78" style="stop-color:#60BBAD"/>
+			<stop  offset="1" style="stop-color:#68C2B5"/>
+		</linearGradient>
+		<path style="fill:url(#SVGID_00000078027665584391974060000013057938891709278361_);" d="M238.7,344.3l14-14c0.4-0.4,1-0.4,1.4,0
+			l14,14c0.4,0.4,0.4,1,0,1.4l-14,14c-0.4,0.4-1,0.4-1.4,0l-14-14C238.3,345.3,238.3,344.7,238.7,344.3z"/>
+		<path class="st1" d="M250,337.4l3.3-3.3c0.1-0.1,0.2-0.1,0.2,0l3.4,3.3c0.1,0.1,0.1,0.2,0,0.2c0,0-0.1,0.1-0.2,0.1h-2
+			c-0.1,0-0.2,0.1-0.2,0.2l0,0v4.3c0,0.1-0.1,0.2-0.2,0.2l0,0h-2.1c-0.1,0-0.2-0.1-0.2-0.1c0,0,0,0,0,0v-4.3c0-0.1-0.1-0.2-0.2-0.2
+			h-2C250,337.6,249.9,337.5,250,337.4C249.9,337.4,249.9,337.4,250,337.4z M256.9,352.6l-3.4,3.3c-0.1,0.1-0.2,0.1-0.2,0l-3.3-3.3
+			c-0.1-0.1,0-0.2,0-0.2c0,0,0.1,0,0.1,0h2c0.1,0,0.2-0.1,0.2-0.2v-4.3c0-0.1,0.1-0.2,0.2-0.2c0,0,0,0,0,0h2.1
+			c0.1,0,0.2,0.1,0.2,0.2l0,0v4.3c0,0.1,0.1,0.2,0.2,0.2h0h1.9c0.1-0.1,0.2,0,0.2,0C257,352.4,257,352.6,256.9,352.6z M246.9,348.2
+			v-1.9c0-0.1-0.1-0.2-0.2-0.2h-4.3c-0.1,0-0.2-0.1-0.2-0.2v-2.1c0-0.1,0.1-0.2,0.2-0.2h4.3c0.1,0,0.2-0.1,0.2-0.2v-2
+			c0-0.1,0-0.2,0.1-0.2c0.1,0,0.1,0,0.2,0.1l3.3,3.4c0.1,0.1,0.1,0.2,0,0.2c0,0,0,0,0,0l-3.3,3.3c-0.1,0.1-0.2,0.1-0.2,0
+			C246.9,348.4,246.9,348.3,246.9,348.2z M259.9,341.6v2c0,0.1,0.1,0.2,0.2,0.2h4.3c0.1,0,0.2,0.1,0.2,0.2v2.1
+			c0,0.1-0.1,0.2-0.2,0.2H260c-0.1,0-0.2,0.1-0.2,0.2v1.9c0,0.1,0,0.2-0.1,0.2c-0.1,0-0.1,0-0.2-0.1l-3.3-3.4
+			c-0.1-0.1-0.1-0.2,0-0.2c0,0,0,0,0,0l3.3-3.3c0-0.1,0.1-0.1,0.2,0C259.9,341.5,259.9,341.5,259.9,341.6z"/>
+	</g>
+	<g>
+		
+			<radialGradient id="f57e105d-6d2d-4ad7-b8c3-c10684c9f9b8_00000037682626449829119780000013589083089337491374_" cx="-5966.7217" cy="-4993.124" r="30.0488" gradientTransform="matrix(0.5 0 0 0.5 3378.5818 2855.0828)" gradientUnits="userSpaceOnUse">
+			<stop  offset="0.18" style="stop-color:#699CD3"/>
+			<stop  offset="1" style="stop-color:#2E76BC"/>
+		</radialGradient>
+		
+			<path id="f57e105d-6d2d-4ad7-b8c3-c10684c9f9b8_4_" style="fill:url(#f57e105d-6d2d-4ad7-b8c3-c10684c9f9b8_00000037682626449829119780000013589083089337491374_);" d="
+			M404.1,370c-6.6,5.1-16,3.9-21.1-2.7s-3.9-16,2.7-21.1l0.2-0.1c6.6-5,16.1-3.6,21,3.1C411.7,355.8,410.5,365,404.1,370"/>
+		<path class="st28" d="M394.8,344.6c-7.5,0-13.6,6.1-13.6,13.6c0,7.5,6.1,13.6,13.6,13.6c7.5,0,13.6-6.1,13.6-13.6
+			C408.4,350.7,402.4,344.6,394.8,344.6z M404,349.1c-1.2,0.7-2.5,1.1-3.8,1.4c-0.5-1.7-1.2-3.3-2.2-4.8
+			C400.2,346.3,402.3,347.5,404,349.1z M394.8,345.3c0.6,0,1.3,0.1,1.9,0.2l0,0c1.3,1.5,2.2,3.4,2.7,5.3c-3.2,0.6-6.4,0.6-9.6,0
+			c0.5-1.9,1.4-3.7,2.7-5.2l0,0C393.3,345.4,394.1,345.3,394.8,345.3z M391.3,345.8c-1,1.4-1.8,3-2.2,4.7c-1.2-0.2-2.3-0.7-3.4-1.4
+			C387.3,347.6,389.2,346.4,391.3,345.8z M385.5,367c1-0.6,2-1.1,3.1-1.3c0.4,1.8,1.3,3.4,2.4,4.8C388.9,369.8,387,368.6,385.5,367z
+			 M396.8,370.9c-0.7,0.1-1.3,0.1-2,0.1c-0.9,0-1.7-0.1-2.5-0.3l0,0c-1.5-1.4-2.5-3.3-3-5.3c3.4-0.7,7-0.7,10.4,0
+			c-0.5,2-1.5,3.9-3,5.3L396.8,370.9z M398.1,370.6c1.2-1.4,2-3.1,2.4-4.9c1.3,0.3,2.4,0.8,3.5,1.5
+			C402.5,368.8,400.4,370,398.1,370.6L398.1,370.6z M400.8,364.9c0.1-0.6,0.3-1.3,0.4-2l-0.8,0.2c-0.1,0.5-0.2,1.1-0.3,1.6
+			c-3.6-0.7-7.2-0.7-10.8,0c-0.1-0.5-0.2-1-0.3-1.5c0-0.1,0-0.1,0-0.2l-0.8-0.2c0,0.2,0,0.3,0,0.5c0,0.6,0.2,1.1,0.3,1.6
+			c-1.3,0.3-2.5,0.8-3.5,1.5c-4-4.8-3.9-11.9,0.2-16.6c1.1,0.7,2.4,1.2,3.7,1.5c-0.1,0.4-0.2,0.9-0.3,1.3s0,0.4-0.1,0.7l0.8-0.2
+			v-0.3c0.1-0.5,0.2-0.9,0.3-1.3c1.8,0.3,3.6,0.5,5.4,0.4c1.6,0,3.3-0.2,4.9-0.5c0.1,0.5,0.2,1,0.4,1.5l0.8,0.2
+			c-0.1-0.6-0.3-1.2-0.4-1.8c1.4-0.3,2.8-0.9,4.1-1.6c4.2,4.8,4.3,11.9,0.1,16.8C403.5,365.8,402.1,365.2,400.8,364.9L400.8,364.9z"
+			/>
+		<path class="st1" d="M385.5,354.6c0.7-0.1,1.4-0.1,2.1-0.1c1.1-0.1,2.2,0.2,3,0.9c0.7,0.7,1.1,1.6,1,2.6c0.1,1.1-0.3,2.1-1.1,2.9
+			c-0.9,0.8-2.1,1.2-3.3,1.1c-0.6,0-1.2,0-1.8-0.1L385.5,354.6z M386.4,361.2c0.3,0,0.6,0,1,0c1.6,0.2,3-1,3.2-2.5
+			c0-0.2,0-0.5,0-0.7c0.1-1.5-0.9-2.7-2.4-2.9c-0.2,0-0.4,0-0.6,0c-0.4,0-0.7,0-1.1,0V361.2z"/>
+		<path class="st1" d="M392.8,361.9v-7.4h1l2.4,3.7c0.5,0.8,0.9,1.6,1.3,2.4l0,0c-0.1-1-0.1-1.9-0.1-3.1v-3.1h0.9v7.4h-1l-2.3-3.7
+			c-0.5-0.8-1-1.8-1.4-2.5l0,0c0,0.9,0,1.8,0,3.1v3.2L392.8,361.9z"/>
+		<path class="st1" d="M400,360.7c0.5,0.3,1.1,0.5,1.8,0.5c1,0,1.6-0.5,1.6-1.3c0-0.8-0.4-1.1-1.4-1.5c-1-0.4-2-1.1-2-2.1
+			c0.1-1.2,1.1-2.1,2.3-2c0,0,0.1,0,0.1,0c0.6,0,1.1,0.1,1.6,0.4l-0.3,0.8c-0.4-0.2-0.9-0.4-1.4-0.4c-1,0-1.4,0.6-1.4,1.1
+			s0.5,1,1.5,1.4c1,0.4,1.9,1.1,1.9,2.2c0,1.1-0.8,2.1-2.6,2.1c-0.7,0-1.3-0.2-1.9-0.5L400,360.7z"/>
+	</g>
+	<g>
+		<path class="st29" d="M660.9,81.8l1.4-1.5v-4.1h-7.1v4.1l1.4,1.5c0.1,0.1,0.2,0.2,0.3,0.2h3.5C660.7,82,660.8,81.9,660.9,81.8z"/>
+		
+			<radialGradient id="SVGID_00000091709538566842987750000015452103810439842987_" cx="658.7664" cy="236.0605" r="11.3217" gradientTransform="matrix(1 0 0 -1 0 300.1305)" gradientUnits="userSpaceOnUse">
+			<stop  offset="0" style="stop-color:#9F7DB8"/>
+			<stop  offset="0.21" style="stop-color:#9B7BB7"/>
+			<stop  offset="0.43" style="stop-color:#9074B4"/>
+			<stop  offset="0.65" style="stop-color:#8068AE"/>
+			<stop  offset="0.88" style="stop-color:#6C5FAA"/>
+			<stop  offset="1" style="stop-color:#6059A7"/>
+		</radialGradient>
+		<path style="fill:url(#SVGID_00000091709538566842987750000015452103810439842987_);" d="M658.8,52c-5.7-0.1-10.4,4.5-10.5,10.3
+			c0,0.4,0,0.9,0.1,1.3c0.5,4.4,4.6,6.4,5.8,11.9c0.1,0.4,0.4,0.7,0.8,0.7h7.6c0.4,0,0.7-0.3,0.8-0.7c1.2-5.5,5.3-7.6,5.8-11.9
+			c0.7-5.7-3.4-10.9-9.1-11.5C659.6,52,659.2,52,658.8,52z"/>
+		
+			<linearGradient id="SVGID_00000168111632774469730080000013582021337142470333_" gradientUnits="userSpaceOnUse" x1="658.7916" y1="242.1306" x2="658.8975" y2="228.7544" gradientTransform="matrix(1 0 0 -1 0 300.1305)">
+			<stop  offset="0" style="stop-color:#F2F2F3"/>
+			<stop  offset="0.23" style="stop-color:#F2F1F2;stop-opacity:0.99"/>
+			<stop  offset="0.37" style="stop-color:#EDEDF0;stop-opacity:0.95"/>
+			<stop  offset="0.48" style="stop-color:#E7E5EF;stop-opacity:0.89"/>
+			<stop  offset="0.58" style="stop-color:#DEDBEE;stop-opacity:0.81"/>
+			<stop  offset="0.67" style="stop-color:#D4CEE7;stop-opacity:0.7"/>
+			<stop  offset="0.76" style="stop-color:#C4BDDE;stop-opacity:0.57"/>
+			<stop  offset="0.84" style="stop-color:#B5ABD4;stop-opacity:0.41"/>
+			<stop  offset="0.92" style="stop-color:#A094C7;stop-opacity:0.22"/>
+			<stop  offset="0.99" style="stop-color:#877CBA;stop-opacity:2.000000e-02"/>
+			<stop  offset="1" style="stop-color:#847AB9;stop-opacity:0"/>
+		</linearGradient>
+		<path style="fill:url(#SVGID_00000168111632774469730080000013582021337142470333_);" d="M663.1,57.8c-1.4,0-2.4,1.2-2.4,2.5v1.4
+			H657v-1.4c0-1.4-1.1-2.5-2.4-2.5c0,0,0,0-0.1,0c-1.4,0-2.4,1.2-2.4,2.5c0,1.4,1,2.5,2.4,2.6h1.1v10.6c0,0.4,0.3,0.6,0.6,0.6
+			c0.4,0,0.6-0.3,0.6-0.6V62.9h3.8v10.6c0,0.4,0.3,0.6,0.6,0.6s0.6-0.3,0.6-0.6V62.9h1.1c1.4,0,2.4-1.2,2.4-2.6c0,0,0,0,0,0
+			C665.5,59,664.5,57.8,663.1,57.8z M655.6,61.7h-1.2c-0.7-0.1-1.2-0.7-1.2-1.4c0-0.7,0.5-1.3,1.2-1.4c0.7,0.1,1.2,0.7,1.2,1.4V61.7
+			z M663.2,61.7H662v-1.4c-0.1-0.7,0.4-1.3,1-1.3c0.7-0.1,1.3,0.4,1.3,1c0,0.1,0,0.2,0,0.3C664.5,61,663.9,61.6,663.2,61.7
+			C663.2,61.7,663.2,61.7,663.2,61.7z"/>
+		<polygon class="st32" points="655.2,79 662.4,77.6 662.4,76.8 655.2,78.2 		"/>
+		<polygon class="st32" points="662.4,79.5 662.4,78.8 655.2,80.2 655.2,80.3 655.7,80.9 		"/>
+	</g>
+	<g>
+		
+			<radialGradient id="aacf8311-a317-400f-b613-74bd00da5ce3_00000016041005811377325380000003250970071478572478_" cx="805.0439" cy="233.1488" r="15" gradientTransform="matrix(1 0 0 -1 0 300.1305)" gradientUnits="userSpaceOnUse">
+			<stop  offset="0.18" style="stop-color:#699CD3"/>
+			<stop  offset="0.56" style="stop-color:#669CD3"/>
+			<stop  offset="0.69" style="stop-color:#6198D1"/>
+			<stop  offset="0.78" style="stop-color:#5793CE"/>
+			<stop  offset="0.86" style="stop-color:#4A8CCA"/>
+			<stop  offset="0.93" style="stop-color:#3B83C5"/>
+			<stop  offset="0.99" style="stop-color:#3078BE"/>
+			<stop  offset="1" style="stop-color:#2E76BC"/>
+		</radialGradient>
+		
+			<path id="aacf8311-a317-400f-b613-74bd00da5ce3_1_" style="fill:url(#aacf8311-a317-400f-b613-74bd00da5ce3_00000016041005811377325380000003250970071478572478_);" d="
+			M805,52c-8.3,0-15,6.7-15,15s6.7,15,15,15c8.3,0,15-6.7,15-15C820,58.7,813.3,52,805,52z M805,79.9c-7.2,0-13-5.8-13-13
+			s5.8-13,13-13c7.2,0,13,5.8,13,13l0,0C818,74.1,812.2,79.9,805,79.9z"/>
+		<circle class="st1" cx="805" cy="67" r="13"/>
+		<g>
+			
+				<radialGradient id="bd983c41-db73-40ec-a4f4-da1213fc9924_00000027579383873338592020000012730484709629486213_" cx="889.5504" cy="41.57" r="17.4353" gradientTransform="matrix(0.94 0 0 -0.94 -33.0694 104.1266)" gradientUnits="userSpaceOnUse">
+				<stop  offset="0.27" style="stop-color:#FED70A"/>
+				<stop  offset="0.49" style="stop-color:#FFCC12"/>
+				<stop  offset="0.88" style="stop-color:#FBAC1D"/>
+				<stop  offset="1" style="stop-color:#F9A120"/>
+			</radialGradient>
+			
+				<path id="bd983c41-db73-40ec-a4f4-da1213fc9924_1_" style="fill:url(#bd983c41-db73-40ec-a4f4-da1213fc9924_00000027579383873338592020000012730484709629486213_);" d="
+				M812.9,64c1.3-1.3,1.3-3.3,0-4.6l0,0l-5.6-5.6c-1.3-1.3-3.3-1.3-4.6,0l0,0l-5.6,5.6c-1.3,1.3-1.3,3.3,0,4.6l4.6,4.7
+				c0.2,0.2,0.3,0.4,0.3,0.6V78c0,0.3,0.1,0.6,0.3,0.8l2.1,2.1c0.3,0.3,0.7,0.3,1,0c0,0,0,0,0,0l2-2l0,0l1.2-1.2
+				c0.2-0.2,0.2-0.4,0-0.6l-0.9-0.9c-0.2-0.2-0.2-0.5,0-0.7l0.9-0.9c0.2-0.2,0.2-0.4,0-0.6l-0.9-0.9c-0.2-0.2-0.2-0.5,0-0.7l0.9-0.9
+				c0.2-0.2,0.2-0.4,0-0.6l-1.2-1.2v-0.4L812.9,64z M805,55.2c1,0,1.8,0.8,1.8,1.8s-0.8,1.8-1.8,1.8s-1.8-0.8-1.8-1.8
+				S804,55.2,805,55.2z"/>
+			<path id="ad2e7e44-9bfd-4775-8bf4-8ef26a544921_1_" class="st35" d="M803.6,78.1L803.6,78.1c0.2,0.1,0.4,0.1,0.6,0
+				c0.1-0.1,0.1-0.2,0.1-0.3v-7.1c0-0.1-0.1-0.3-0.2-0.4l0,0c-0.2-0.1-0.4-0.1-0.5,0.1c0,0.1-0.1,0.2-0.1,0.2v7.1
+				C803.5,77.9,803.5,78,803.6,78.1z"/>
+			<path id="a996fbff-3936-4b24-b407-369336c143ba_1_" class="st35" d="M801.1,61.3h8.1c0.3,0,0.5,0.2,0.5,0.5v0.1
+				c0,0.3-0.2,0.5-0.5,0.5h-8.1c-0.3,0-0.5-0.2-0.5-0.5v-0.1C800.6,61.5,800.8,61.3,801.1,61.3z"/>
+			<path id="bb12d31c-3352-4a18-87dd-a169a4a8721d_1_" class="st35" d="M801.1,63.1h8.1c0.3,0,0.5,0.2,0.5,0.5v0.1
+				c0,0.3-0.2,0.5-0.5,0.5h-8.1c-0.3,0-0.5-0.2-0.5-0.5v-0.1C800.6,63.3,800.8,63.1,801.1,63.1z"/>
+		</g>
+	</g>
+	<g>
+		
+			<radialGradient id="SVGID_00000144318842606373014550000011212420978441455508_" cx="713.5839" cy="238.1766" r="14.908" gradientTransform="matrix(1.01 0 0 -1.01 3.9566 307.1011)" gradientUnits="userSpaceOnUse">
+			<stop  offset="0.18" style="stop-color:#699CD3"/>
+			<stop  offset="0.56" style="stop-color:#669CD3"/>
+			<stop  offset="0.69" style="stop-color:#6198D1"/>
+			<stop  offset="0.78" style="stop-color:#5793CE"/>
+			<stop  offset="0.86" style="stop-color:#4A8CCA"/>
+			<stop  offset="0.93" style="stop-color:#3B83C5"/>
+			<stop  offset="0.99" style="stop-color:#3078BE"/>
+			<stop  offset="1" style="stop-color:#2E76BC"/>
+		</radialGradient>
+		
+			<ellipse style="fill:url(#SVGID_00000144318842606373014550000011212420978441455508_);" cx="724.7" cy="66.5" rx="15.1" ry="15"/>
+		<ellipse class="st1" cx="724.7" cy="66.5" rx="13.1" ry="13.1"/>
+		<path class="st37" d="M713.6,67.3c0.2,2.7,1.3,5.2,3.2,7.1l3.5-3.5c-1-1-1.6-2.2-1.8-3.5H713.6z"/>
+		<path class="st38" d="M732,58.1c-1.8-1.6-4.1-2.5-6.5-2.7v4.9c1.1,0.1,2.2,0.6,3,1.2L732,58.1z"/>
+		<path class="st38" d="M717.4,58.1l3.5,3.5c0.9-0.7,1.9-1.1,3-1.2v-5C721.5,55.6,719.2,56.5,717.4,58.1z"/>
+		<path class="st38" d="M729.6,62.7c0.7,0.9,1.1,1.9,1.3,3h4.9c-0.2-2.4-1.1-4.7-2.7-6.5L729.6,62.7z"/>
+		<path class="st39" d="M719.8,62.7l-3.5-3.5c-1.6,1.8-2.5,4.1-2.7,6.6h4.9C718.6,64.6,719.1,63.6,719.8,62.7z"/>
+		<path class="st40" d="M733.8,62.9c-0.2-0.4-0.6-0.6-1-0.4l-7.3,2.9l0.6,1.4l7.3-2.9C733.7,63.8,733.9,63.4,733.8,62.9
+			C733.8,63,733.8,63,733.8,62.9z"/>
+		
+			<radialGradient id="SVGID_00000111160242622033539520000005026711599212882875_" cx="785.3464" cy="25.8783" r="4.7847" gradientTransform="matrix(0.95 0 0 -0.95 -21.4028 87.8172)" gradientUnits="userSpaceOnUse">
+			<stop  offset="0.19" style="stop-color:#8C8E90"/>
+			<stop  offset="0.35" style="stop-color:#848688"/>
+			<stop  offset="0.6" style="stop-color:#6E7071"/>
+			<stop  offset="0.91" style="stop-color:#4A4B4D"/>
+			<stop  offset="1" style="stop-color:#3E403F"/>
+		</radialGradient>
+		
+			<ellipse style="fill:url(#SVGID_00000111160242622033539520000005026711599212882875_);" cx="724.7" cy="66.5" rx="2.1" ry="2.1"/>
+	</g>
+	<g>
+		<path class="st42" d="M881.9,66c0,8.1-9.9,14.6-12.1,15.9c-0.2,0.2-0.6,0.2-0.8,0C866.9,80.6,857,74.1,857,66v-9.7
+			c0-0.4,0.3-0.8,0.8-0.8c7.7-0.2,5.9-3.5,11.7-3.5c5.8,0,4,3.3,11.7,3.5c0.4,0,0.8,0.4,0.8,0.8V66z"/>
+		
+			<linearGradient id="SVGID_00000061463359000943203870000004437168694417968555_" gradientUnits="userSpaceOnUse" x1="869.4387" y1="219.4138" x2="869.4387" y2="246.8963" gradientTransform="matrix(1 0 0 -1 0 300.1305)">
+			<stop  offset="0" style="stop-color:#2E76BC"/>
+			<stop  offset="6.000000e-02" style="stop-color:#3179BE"/>
+			<stop  offset="0.34" style="stop-color:#4288C8"/>
+			<stop  offset="0.59" style="stop-color:#5693CE"/>
+			<stop  offset="0.82" style="stop-color:#639BD2"/>
+			<stop  offset="1" style="stop-color:#699CD3"/>
+		</linearGradient>
+		<path style="fill:url(#SVGID_00000061463359000943203870000004437168694417968555_);" d="M880.9,66.1c0,7.4-9.1,13.4-11.1,14.6
+			c-0.2,0.1-0.5,0.1-0.7,0c-2-1.2-11.1-7.1-11.1-14.6v-8.8c-0.1-0.4,0.2-0.8,0.6-0.8c0,0,0.1,0,0.1,0c7.1-0.1,5.5-3.2,10.8-3.2
+			c5.3,0,3.7,3,10.8,3.2c0.4,0,0.7,0.3,0.7,0.7V66.1z"/>
+		<path class="st44" d="M874.5,64.6h-0.7v-2.5c0-1.2-0.4-2.3-1.2-3.2c-1.6-1.7-4.2-1.8-5.9-0.2c-0.1,0.1-0.2,0.2-0.2,0.2
+			c-0.8,0.9-1.2,2-1.2,3.2v2.5h-0.7c-0.3,0-0.6,0.2-0.6,0.5c0,0,0,0.1,0,0.1v6.5c0,0.3,0.3,0.6,0.6,0.6c0,0,0,0,0,0h10.1
+			c0.3,0,0.6-0.2,0.6-0.5c0,0,0,0,0,0v-6.5C875.1,64.9,874.8,64.6,874.5,64.6C874.5,64.6,874.5,64.6,874.5,64.6z M871.7,64.6h-4.6
+			v-2.5c0-0.7,0.3-1.3,0.7-1.8c0.8-0.9,2.1-0.9,3-0.2c0.1,0.1,0.1,0.1,0.2,0.2c0.1,0.1,0.2,0.2,0.3,0.4l0,0c0.3,0.4,0.4,0.9,0.4,1.4
+			V64.6z"/>
+		<path class="st45" d="M864.4,64.6h10.1c0.1,0,0.3,0.1,0.4,0.1L864,72.1c-0.1-0.1-0.2-0.3-0.2-0.4v-6.5
+			C863.8,64.9,864.1,64.6,864.4,64.6C864.4,64.6,864.4,64.6,864.4,64.6z"/>
+		<path class="st46" d="M874.5,64.6h-10.1c-0.1,0-0.3,0.1-0.4,0.1l10.8,7.3c0.1-0.1,0.2-0.3,0.2-0.4v-6.5
+			C875.1,64.9,874.8,64.6,874.5,64.6C874.5,64.6,874.5,64.6,874.5,64.6z"/>
+	</g>
+	<g>
+		<rect x="462.3" y="139.2" class="st8" width="1" height="1.5"/>
+		<path class="st8" d="M463.3,136.2h-1v-3h1V136.2z M570.3,136.2h-1v-3h1V136.2z M463.3,130.1h-1v-3h1V130.1z M570.3,130.1h-1v-3h1
+			V130.1z M463.3,124h-1v-3h1V124z M570.3,124h-1v-3h1V124z M463.3,118h-1v-3h1V118z M570.3,118h-1v-3h1V118z M463.3,111.9h-1v-3h1
+			V111.9z M570.3,111.9h-1v-3h1V111.9z M463.3,105.8h-1v-3h1V105.8z M570.3,105.8h-1v-3h1V105.8z M463.3,99.8h-1v-3h1V99.8z
+			 M570.3,99.7h-1v-3h1V99.7z M463.3,93.7h-1v-3h1V93.7z M570.3,93.7h-1v-3h1V93.7z M463.3,87.6h-1v-0.4c0-1,0.3-2,1-2.8l0.8,0.6
+			c-0.5,0.6-0.7,1.4-0.7,2.1V87.6z M570.3,87.6h-1v-0.4c0-0.8-0.3-1.5-0.8-2.2l0.8-0.6c0.6,0.8,1,1.8,1,2.8V87.6z M466.3,83.8
+			l-0.2-1c0.2,0,0.4-0.1,0.7-0.1h2.4v1h-2.4C466.6,83.7,466.4,83.7,466.3,83.8z M566.3,83.8c-0.2,0-0.3,0-0.5,0h-2.5v-1h2.5
+			c0.2,0,0.4,0,0.6,0L566.3,83.8z M560.3,83.7h-3v-1h3V83.7z M554.2,83.7h-3v-1h3V83.7z M548.2,83.7h-3v-1h3V83.7z M542.1,83.7h-3
+			v-1h3V83.7z M536,83.7h-3v-1h3V83.7z M529.9,83.7h-3v-1h3V83.7z M523.9,83.7h-3v-1h3V83.7z M517.8,83.7h-3v-1h3V83.7z M511.7,83.7
+			h-3v-1h3V83.7z M505.7,83.7h-3v-1h3V83.7z M499.6,83.7h-3v-1h3V83.7z M493.5,83.7h-3v-1h3V83.7z M487.4,83.7h-3v-1h3V83.7z
+			 M481.4,83.7h-3v-1h3V83.7z M475.3,83.7h-3v-1h3V83.7z"/>
+	</g>
+	<g>
+		
+			<radialGradient id="f57e105d-6d2d-4ad7-b8c3-c10684c9f9b8_00000005962405810911912250000003313529984840225956_" cx="-5722.7822" cy="-5563.5493" r="34.0553" gradientTransform="matrix(0.5 0 0 0.5 3378.5818 2855.0828)" gradientUnits="userSpaceOnUse">
+			<stop  offset="0.18" style="stop-color:#699CD3"/>
+			<stop  offset="1" style="stop-color:#2E76BC"/>
+		</radialGradient>
+		
+			<path id="f57e105d-6d2d-4ad7-b8c3-c10684c9f9b8_3_" style="fill:url(#f57e105d-6d2d-4ad7-b8c3-c10684c9f9b8_00000005962405810911912250000003313529984840225956_);" d="
+			M527.2,86.4c-7.4,5.8-18.1,4.4-23.9-3c-5.8-7.4-4.4-18.1,3-23.9l0.2-0.1c7.5-5.6,18.2-4.1,23.8,3.5
+			C535.9,70.2,534.5,80.7,527.2,86.4"/>
+		<path class="st28" d="M516.8,57.5c-8.5,0-15.4,6.9-15.4,15.4s6.9,15.4,15.4,15.4c8.5,0,15.4-6.9,15.4-15.4
+			C532.2,64.4,525.3,57.5,516.8,57.5z M527.1,62.7c-1.3,0.8-2.8,1.3-4.3,1.6c-0.5-1.9-1.4-3.8-2.5-5.4
+			C522.9,59.5,525.2,60.8,527.1,62.7z M516.8,58.4c0.7,0,1.5,0.1,2.2,0.2l0,0c1.5,1.7,2.5,3.8,3.1,6c-3.6,0.7-7.3,0.7-10.9,0
+			c0.6-2.2,1.6-4.2,3-5.9l0,0C515,58.5,515.9,58.4,516.8,58.4z M512.8,58.9c-1.1,1.6-2,3.4-2.5,5.4c-1.4-0.3-2.6-0.8-3.8-1.5
+			C508.2,60.9,510.4,59.6,512.8,58.9z M506.2,82.9c1.1-0.7,2.3-1.2,3.6-1.5c0.5,2,1.4,3.8,2.7,5.4C510.1,86.1,507.9,84.7,506.2,82.9
+			z M519,87.3c-0.8,0.1-1.5,0.1-2.3,0.1c-1,0-1.9-0.1-2.9-0.3l0,0c-1.7-1.6-2.8-3.7-3.3-6c3.9-0.8,7.9-0.8,11.8,0
+			c-0.5,2.3-1.7,4.4-3.4,6L519,87.3z M520.5,87c1.3-1.6,2.3-3.6,2.8-5.6c1.4,0.3,2.8,0.9,4,1.7C525.4,84.9,523.1,86.3,520.5,87
+			L520.5,87z M523.5,80.5c0.2-0.7,0.3-1.5,0.4-2.2l-0.9,0.2c-0.1,0.6-0.2,1.2-0.3,1.8c-4-0.8-8.2-0.8-12.2,0
+			c-0.1-0.5-0.2-1.1-0.3-1.7c0-0.1,0-0.1,0-0.2l-0.9-0.3c0,0.2,0,0.4,0,0.6c0,0.6,0.2,1.2,0.3,1.8c-1.4,0.3-2.8,0.9-4,1.7
+			c-4.6-5.5-4.5-13.5,0.2-18.8c1.3,0.8,2.7,1.4,4.2,1.7c-0.1,0.5-0.3,1-0.4,1.5c-0.1,0.5,0,0.5-0.2,0.7l0.9-0.2v-0.3
+			c0.1-0.5,0.2-1,0.4-1.5c2,0.4,4.1,0.5,6.1,0.5c1.9,0,3.7-0.2,5.6-0.5c0.1,0.5,0.3,1.1,0.4,1.7l0.9,0.2c-0.1-0.7-0.3-1.4-0.5-2
+			c1.6-0.4,3.2-1,4.6-1.8c4.8,5.4,4.8,13.5,0.1,19C526.5,81.5,525,80.9,523.5,80.5L523.5,80.5z"/>
+		<path class="st1" d="M506.1,68.9c0.8-0.1,1.5-0.2,2.3-0.2c1.2-0.1,2.5,0.3,3.4,1c0.8,0.8,1.2,1.8,1.2,2.9c0.1,1.2-0.4,2.4-1.2,3.3
+			c-1,0.9-2.4,1.3-3.7,1.2c-0.7,0-1.3,0-2-0.1L506.1,68.9z M507.2,76.4c0.4,0,0.7,0,1.1,0c1.8,0.2,3.4-1.1,3.6-2.9
+			c0-0.3,0-0.5,0-0.8c0.2-1.7-1.1-3.1-2.7-3.3c-0.2,0-0.5,0-0.7,0c-0.4,0-0.8,0-1.3,0V76.4z"/>
+		<path class="st1" d="M514.5,77.1v-8.4h1.2l2.7,4.2c0.6,0.9,1.1,1.8,1.5,2.7l0,0c-0.1-1.1-0.1-2.1-0.1-3.5v-3.5h1v8.4h-1.1
+			l-2.6-4.2c-0.6-0.9-1.1-2-1.6-2.8l0,0c0,1.1,0,2,0,3.5v3.6L514.5,77.1z"/>
+		<path class="st1" d="M522.6,75.8c0.6,0.4,1.3,0.5,2,0.5c1.1,0,1.8-0.6,1.8-1.4c0-0.9-0.4-1.2-1.6-1.7c-1.1-0.4-2.2-1.2-2.2-2.4
+			c0.1-1.3,1.2-2.4,2.6-2.3c0.1,0,0.1,0,0.2,0c0.6,0,1.3,0.1,1.9,0.4l-0.3,0.9c-0.5-0.3-1-0.4-1.6-0.4c-1.2,0-1.6,0.7-1.6,1.3
+			s0.5,1.2,1.7,1.6c1.2,0.4,2.2,1.2,2.2,2.5c0,1.2-1,2.4-3,2.4c-0.7,0-1.5-0.2-2.1-0.5L522.6,75.8z"/>
+	</g>
+	<g>
+		<rect x="1017.5" y="120.6" class="st8" width="1" height="14"/>
+		<g>
+			<polygon class="st8" points="1014.3,133.5 1018,140 1021.8,133.5 			"/>
+		</g>
+	</g>
+	<g>
+		<rect x="837.6" y="120.6" class="st8" width="1" height="13.6"/>
+		<g>
+			<polygon class="st8" points="834.4,133.1 838.1,139.6 841.9,133.1 			"/>
+		</g>
+	</g>
+	<g>
+		<rect x="686.6" y="126" class="st8" width="1" height="14"/>
+		<g>
+			<polygon class="st8" points="683.4,127.1 687.1,120.6 690.9,127.1 			"/>
+		</g>
+	</g>
+	<g>
+		<rect x="6.8" y="6.1" class="st48" width="131" height="55"/>
+		<rect x="6.8" y="6.1" class="st49" width="131" height="55"/>
+	</g>
+	<g>
+		<g>
+			<rect x="20.2" y="42" class="st50" width="26.4" height="3"/>
+			<g>
+				<polygon class="st50" points="56.2,43.5 42.8,38 46,43.5 42.8,49 				"/>
+			</g>
+		</g>
+		<path class="st51" d="M46.7,44.3h-4v-1.5h4V44.3z M40.7,44.3h-4v-1.5h4V44.3z M34.7,44.3h-4v-1.5h4V44.3z M28.7,44.3h-4v-1.5h4
+			V44.3z M22.7,44.3h-2.4v-1.5h2.4V44.3z"/>
+	</g>
+	<g>
+		<g>
+			<rect x="20.2" y="22.4" class="st52" width="26.4" height="3"/>
+			<g>
+				<polygon class="st52" points="44.9,17.9 55.3,23.9 44.9,29.9 				"/>
+			</g>
+		</g>
+		<g>
+			<rect x="46.2" y="22.9" class="st53" width="0.5" height="2"/>
+			<polygon class="st53" points="44.2,24.9 44.2,24.9 44.2,22.9 			"/>
+			<path class="st53" d="M44.3,24.9l-1.1,0l0-2l1,0.1V24.9z M41.4,24.9l-1.1,0l0.1-2l1,0.1V24.9z M38.4,24.9l-1.1,0l0.1-2l1,0.1
+				V24.9z M35.5,24.9l-1.1,0l0.1-2l1,0.1V24.9z M32.6,24.9l-1.1,0l0-2l1,0.1V24.9z M29.7,24.9l-1.1,0l0-2l1,0.1V24.9z M26.7,24.9
+				l-1.1,0l0-2l1,0.1V24.9z M23.8,24.9l-1.1,0l0-2l1,0.1V24.9z M20.9,24.9l-0.2,0l0.1-2l0.1,0.1V24.9z"/>
+			<rect x="20.2" y="22.9" class="st53" width="0.5" height="2"/>
+		</g>
+	</g>
+	<g>
+		<g>
+			<rect x="280.3" y="88.7" class="st50" width="3" height="66.3"/>
+			<g>
+				<polygon class="st50" points="281.8,79.2 287.3,92.6 281.8,89.4 276.3,92.6 				"/>
+			</g>
+		</g>
+		<path class="st51" d="M282.5,155H281v-4h1.5V155z M282.5,149H281v-4h1.5V149z M282.5,143H281v-4h1.5V143z M282.5,137H281v-4h1.5
+			V137z M282.5,131H281v-4h1.5V131z M282.5,125H281v-4h1.5V125z M282.5,119H281v-4h1.5V119z M282.5,113H281v-4h1.5V113z M282.5,107
+			H281v-4h1.5V107z M282.5,101H281v-4h1.5V101z M282.5,95H281v-4h1.5V95z M282.5,89H281v-0.3h1.5V89z"/>
+	</g>
+	<g>
+		<g>
+			<rect x="224.2" y="78.5" class="st52" width="3" height="67.4"/>
+			<g>
+				<polygon class="st52" points="231.7,144.1 225.7,154.5 219.7,144.1 				"/>
+			</g>
+		</g>
+		<g>
+			<rect x="224.7" y="145.4" class="st53" width="2" height="0.5"/>
+			<polygon class="st53" points="224.7,143.4 224.7,143.3 226.7,143.3 			"/>
+			<path class="st53" d="M226.7,143.3h-2v-1h2V143.3z M224.7,140.3v-1h2v1L224.7,140.3z M224.7,137.2v-1h2v1L224.7,137.2z
+				 M224.7,134.2v-1h2v1L224.7,134.2z M224.7,131.1v-1h2v1L224.7,131.1z M224.7,128v-1h2v1L224.7,128z M224.7,125v-1h2v1L224.7,125z
+				 M224.7,121.9v-1h2v1L224.7,121.9z M224.7,118.9v-1h2v1L224.7,118.9z M224.7,115.8v-1h2v1L224.7,115.8z M224.7,112.7v-1h2v1
+				L224.7,112.7z M224.7,109.7v-1h2v1L224.7,109.7z M224.7,106.6v-1h2v1L224.7,106.6z M224.7,103.5v-1h2v1L224.7,103.5z
+				 M224.7,100.5v-1h2v1L224.7,100.5z M224.7,97.4v-1h2v1L224.7,97.4z M224.7,94.4v-1h2v1L224.7,94.4z M224.7,91.3v-1h2v1
+				L224.7,91.3z M224.7,88.2v-1h2v1L224.7,88.2z M224.7,85.2v-1h2v1L224.7,85.2z M224.7,82.1v-1h2v1L224.7,82.1z M224.7,79L224.7,79
+				l2,0L224.7,79z"/>
+			<rect x="224.7" y="78.5" class="st53" width="2" height="0.5"/>
+		</g>
+	</g>
+	<g>
+		
+			<linearGradient id="SVGID_00000114772276784045378700000006896399709726260911_" gradientUnits="userSpaceOnUse" x1="254.1045" y1="72.6206" x2="254.1045" y2="96.1033" gradientTransform="matrix(1 0 0 -1 0 300.1305)">
+			<stop  offset="0" style="stop-color:#2E76BC"/>
+			<stop  offset="0.82" style="stop-color:#699CD3"/>
+		</linearGradient>
+		<path style="fill:url(#SVGID_00000114772276784045378700000006896399709726260911_);" d="M270.7,220.1c-0.1-3.6-2.8-6.7-6.5-7.2
+			c-0.2-5.1-4.5-9.1-9.7-9c-4.1-0.1-7.8,2.4-9.2,6.3c-4.4,0.5-7.7,4.2-7.8,8.5c0.2,5,4.4,8.8,9.3,8.7h0.8h15.1c0.1,0,0.3,0,0.4,0
+			C267.3,227.5,270.6,224.2,270.7,220.1z"/>
+		<path class="st55" d="M263.8,222.1c0-0.4-0.4-0.8-0.8-0.8h-17.9c-0.4,0-0.8,0.3-0.8,0.8v9.2c0,0.4,0.4,0.8,0.8,0.8h17.9
+			c0.4,0,0.8-0.3,0.8-0.8V222.1z"/>
+		<rect x="245.5" y="222.4" class="st56" width="5.3" height="2.3"/>
+		<rect x="251.5" y="222.4" class="st57" width="5.3" height="2.3"/>
+		<rect x="257.6" y="222.4" class="st56" width="5.3" height="2.3"/>
+		<rect x="245.5" y="225.5" class="st56" width="2.2" height="2.3"/>
+		<rect x="260.7" y="225.5" class="st57" width="2.2" height="2.3"/>
+		<rect x="248.4" y="225.5" class="st57" width="5.3" height="2.3"/>
+		<rect x="254.5" y="225.5" class="st56" width="5.3" height="2.3"/>
+		<rect x="245.5" y="228.6" class="st56" width="5.3" height="2.3"/>
+		<rect x="251.5" y="228.6" class="st57" width="5.3" height="2.3"/>
+		<rect x="257.6" y="228.6" class="st56" width="5.3" height="2.3"/>
+	</g>
+	<g>
+		<path class="st58" d="M1030.8,66.4c0,5.9-4.7,10.8-10.5,10.8c-5.8,0-10.5-4.8-10.5-10.8s4.7-10.8,10.5-10.8
+			C1026.1,55.7,1030.8,60.5,1030.8,66.4"/>
+		<path class="st59" d="M1010.2,69.1c0,0-0.8-11.2,9.6-11.5l-0.7-1.2l-5.6,1.9l-1.6,1.8l-1.4,2.7l-0.8,3.1l0.2,2.1"/>
+		<path class="st60" d="M1013,59.1c-1.9,2-3,4.6-3,7.4l0,0c0,2.8,1.1,5.4,3,7.4l0,0c1.9,2,4.5,3.1,7.2,3.1l0,0
+			c2.7,0,5.3-1.1,7.2-3.1l0,0c1.9-2,3-4.6,3-7.4l0,0c0-2.8-1.1-5.4-3-7.4l0,0c-1.9-2-4.5-3.1-7.2-3.1l0,0
+			C1017.5,56,1014.9,57.1,1013,59.1z M1012.6,74.3c-2-2.1-3.2-4.9-3.2-7.8l0,0c0-2.9,1.1-5.7,3.2-7.8l0,0c2-2.1,4.8-3.2,7.7-3.3l0,0
+			c2.9,0,5.7,1.2,7.7,3.3l0,0c2,2.1,3.2,4.9,3.2,7.8l0,0c0,2.9-1.1,5.7-3.2,7.8l0,0c-2,2.1-4.8,3.2-7.7,3.3l0,0
+			C1017.4,77.6,1014.6,76.4,1012.6,74.3L1012.6,74.3"/>
+		<path class="st61" d="M1024.7,66.5l-1.6,0.2l-2.2,0.2l-1.4,0l-1.4,0l-1-0.3l-0.9-1l-0.7-2l-0.2-0.4l-1-0.3l-0.6-0.9l-0.4-1.3
+			l0.4-1.2l1-0.4l0.8,0.4l0.4,0.9l0.5-0.1l0.2-0.2l-0.2-0.9l0-1.2l0.2-1.6l0-0.9l0.7-1.2l1.3-0.9l2.2-1l2.5,0.4l2.2,1.6l1,1.6
+			l0.6,1.2l0.2,2.9l-0.5,2.5l-0.9,2.2l-0.8,1.2"/>
+		<path class="st62" d="M1023.3,73.4l-5.7,0.2v1l0.5,3.4l-0.2,0.3l-4-1.4l-0.3-0.5l-0.4-4.5l-0.9-2.7l-0.2-0.6l3.2-2.2l1-0.4
+			l0.9,1.1l0.8,0.7l0.9,0.3l0.4,0.1l0.5,2.1l0.4,0.4l0.9-0.3l-0.6,1.2l3.5,1.6L1023.3,73.4"/>
+		<path class="st63" d="M1013.8,59.4l1-0.4l0.8,0.4l0.4,0.9l0.5-0.1l0.1-0.5l-0.2-0.9l0.2-2.2l-0.2-1.2l0.7-0.8l1.6-1.2l-0.4-0.6
+			l-2.2,1.1l-0.9,0.7l-0.5,1.1l-0.8,1.1l-0.2,1.3L1013.8,59.4"/>
+		<path class="st64" d="M1015.5,55.7c0,0,0.6-1.5,3-2.2c2.4-0.7,0.1-0.5,0.1-0.5l-2.6,1l-1,1l-0.4,0.8L1015.5,55.7"/>
+		<path class="st64" d="M1014.3,59.2c0,0-0.8-2.8,2.4-3.2l-0.1-0.5l-2.2,0.5l-0.6,2.1l0.2,1.4L1014.3,59.2"/>
+		<path class="st65" d="M1015.5,62.9l0.5-0.5c0.2,0,0.3,0.2,0.3,0.3c0,0.3,0.2,2.8,1.9,4.2c0.2,0.1-1.3-0.2-1.3-0.2l-1.3-2"/>
+		<path class="st65" d="M1022.9,62.1c0,0,0.1-1.2,0.4-1.1c0.2,0.1,0.3,0.2,0.3,0.4C1023.7,61.4,1022.9,61.9,1022.9,62.1"/>
+		<path class="st65" d="M1026.2,57.7c0,0-0.7,0.1-0.7,0.7s0.7,0.1,0.8,0.1"/>
+		<path class="st65" d="M1021.4,57.7c0,0-0.9,0.1-0.9,0.7s1,0.5,1.3,0.3"/>
+		<path class="st65" d="M1015.9,60.3c0,0-1.5-0.9-1.7,0c-0.2,0.9-0.5,1.5,0.2,2.4l-0.5-0.2l-0.5-1.2l-0.2-1.2l0.9-1l1,0.1l0.6,0.5
+			L1015.9,60.3"/>
+		<path class="st65" d="M1016.7,57.8c0,0,0.7-3.5,4.1-4.2c2.8-0.6,4.3,0.1,4.9,0.8c0,0-2.5-3-4.9-2.1c-2.4,0.9-4.2,2.6-4.1,3.7
+			C1016.7,57.8,1016.7,57.8,1016.7,57.8"/>
+		<path class="st65" d="M1026,54.8c0,0-1.2,0-1.2,1c0,0.1,0,0.2,0.1,0.3c0,0,0.9-1,1.5-0.5"/>
+		<path class="st65" d="M1020.9,56.2c0,0-0.2-1.6-1.6-0.7c-0.9,0.6-0.8,1.4-0.6,1.6c0.2,0.2,0.1,0.5,0.2,0.3s0.1-0.9,0.5-1.1
+			C1019.9,56,1020.6,55.8,1020.9,56.2"/>
+		<path class="st66" d="M1017.1,67l-3.8,1.7c0,0,1.6,6.2,0.8,8.1l-0.6-0.2l0-2.4l-1-4.5l-0.4-1.2l3.9-2.6L1017.1,67"/>
+		<path class="st66" d="M1017.5,70.5l0.5,0.7v2.4h-0.6c0,0-0.1-1.7-0.1-1.9s0.1-0.9,0.1-0.9"/>
+		<path class="st66" d="M1017.5,73.9l-1.8,0.1l0.5,0.4l1.3,0.2"/>
+		<path class="st62" d="M1023.7,73.5l1.5,0l0.4,3.7l-1.5,0.2L1023.7,73.5"/>
+		<path class="st62" d="M1024.1,73.5l2.2-0.1c0,0,0.9-2.3,0.9-2.4s0.8-3.4,0.8-3.4l-1.8-1.9l-0.4-0.3l-1,1V70L1024.1,73.5"/>
+		<path class="st66" d="M1025.1,73.2l-1.4,0.3l0.2,1.1c0.5,0.2,1.4-0.4,1.4-0.4"/>
+		<path class="st66" d="M1025.1,66.2l2.8,2.1l0.1-1l-2.1-2L1025.1,66.2"/>
+		<path class="st1" d="M1018.9,81.4l-0.8-3.4l-0.4-2.5l-0.1-1.8l3.8-0.2h2.3l-0.2,4.2l0.4,3.2l0,0.6l-3,0.2L1018.9,81.4"/>
+		<path class="st64" d="M1023.2,73.4c0,0-0.2,4.2,0.4,7.1c-0.9,0.5-1.9,0.8-3,1l3.4-0.1l0.4-0.2l-0.5-6.6l-0.1-1.4"/>
+		<path class="st1" d="M1025.6,76.8l1.6-0.4l3-0.2l0.4-1.4l-0.8-2.4l-0.9-0.1l-1.3,0.4l-1.2,0.6l-0.7-0.1l-0.5,0.2"/>
+		<path class="st64" d="M1025.6,76c0,0,1-0.5,1.2-0.4l-0.4-2.2l0.5-0.2c0,0,0.4,2.1,0.4,2.3c0,0,2.2,0.1,2.4,0.1
+			c0,0,0.5-0.9,0.4-1.9l0.4,1.3l0,0.7l-0.6,1l-0.7,0.2l-1.2,0l-0.4-0.5l-1.4,0.2l-0.4,0.2"/>
+		<path class="st1" d="M1024,73.2l-0.9-2.2l-0.9-1.3c0,0,0.2-0.6,0.5-0.6h0.9l0.9,0.3l-0.1,1.5L1024,73.2"/>
+		<path class="st64" d="M1024.2,72.4c0,0-1.1-2.2-1.1-2.5c0,0,0.2-0.5,0.5-0.4c0.3,0.1,0.9,0.4,0.9,0.4v-0.8l-1.4-0.3l-0.9,0.1
+			l1.6,3.7l0.3,0"/>
+		<path class="st1" d="M1019.3,67.1l-1.1-0.1l-1-0.3V67l0.5,0.6l1.6,0.7"/>
+		<path class="st64" d="M1017.5,67.2c0,0,1.2,0.5,1.6,0.4l0,0.5l-1.1-0.2l-0.7-0.5L1017.5,67.2"/>
+		<path class="st58" d="M1025.6,69.2c-0.6,0-1.2-0.1-1.8-0.3c0-0.2,0-0.4,0-0.6c0.2-0.1,0.4-0.1,0.6-0.1c-0.2-0.1-0.5-0.1-0.7-0.1
+			c0-0.2-0.1-0.2-0.1-0.4c0.4-0.1,1.3-1,1.8-0.7c0.2,0.1,0.3,0.9,0.4,1.3C1025.8,68.7,1025.7,69,1025.6,69.2"/>
+		<path class="st67" d="M1025.6,69.2c-0.6,0-1.2-0.1-1.8-0.3c0-0.2,0-0.4,0-0.6c0.2-0.1,0.4-0.1,0.6-0.1c-0.2-0.1-0.5-0.1-0.7-0.1
+			c0-0.2-0.1-0.2-0.1-0.4c0.4-0.1,1.3-1,1.8-0.7c0.2,0.1,0.3,0.9,0.4,1.3C1025.8,68.7,1025.7,69,1025.6,69.2z"/>
+		<path class="st58" d="M1022.3,68c0,0.1,0,0.1,0,0.2c-0.2,0.1-0.6,0.1-0.8,0.3c0.3,0,0.6,0.1,0.8,0.2c0,0.1,0,0.3,0,0.4
+			c-0.4,0.3-0.7,0.7-1.2,0.9c-0.2,0.1-1,0.4-1.2,0.4c-0.1,0-0.1-0.2-0.2-0.3c-0.1-0.3-0.4-0.8-0.4-1.3c0-0.6-0.1-1.7,0.6-1.5
+			c0.6,0.1,1.1,0.3,1.6,0.6C1021.8,67.8,1021.9,68,1022.3,68"/>
+		<path class="st67" d="M1022.3,68c0,0.1,0,0.1,0,0.2c-0.2,0.1-0.6,0.1-0.8,0.3c0.3,0,0.6,0.1,0.8,0.2c0,0.1,0,0.3,0,0.4
+			c-0.4,0.3-0.7,0.7-1.2,0.9c-0.2,0.1-1,0.4-1.2,0.4c-0.1,0-0.1-0.2-0.2-0.3c-0.1-0.3-0.4-0.8-0.4-1.3c0-0.6-0.1-1.7,0.6-1.5
+			c0.6,0.1,1.1,0.3,1.6,0.6C1021.8,67.8,1021.9,68,1022.3,68z"/>
+		<path class="st58" d="M1022.7,68.8c-0.1-0.3-0.1-0.4-0.1-0.7C1023.5,67.5,1023.7,69.1,1022.7,68.8"/>
+		<path class="st67" d="M1022.7,68.8c-0.1-0.3-0.1-0.4-0.1-0.7C1023.5,67.5,1023.7,69.1,1022.7,68.8z"/>
+		<path class="st59" d="M1024,69.1c0,0-0.3-0.4-0.1-0.5s0.4,0,0.5-0.2s0-0.3,0-0.6s0.2-0.3,0.4-0.3c0.2,0,0.8-0.1,0.8,0.1l-0.2-0.7
+			l-0.5-0.2l-1.5,0.9l-0.1,0.4v0.9"/>
+		<path class="st59" d="M1019.8,70.4c0-0.6-0.1-1.3-0.2-1.9c-0.1-0.9,0.2-0.8,1-0.8c0.1,0,0.8,0.1,0.8,0.2c0.2,0.4-0.4,0.3,0.3,0.7
+			c0.5,0.3,1.4-0.2,1.2-0.8c-0.1-0.1-0.6,0-0.8-0.1l-0.9-0.5c-0.4-0.2-1.3-0.5-1.7-0.2c-1.1,0.7,0.1,2.6,0.5,3.3"/>
+		<path class="st60" d="M1020.9,56.2c-1.1-0.3-1.6,0.5-2,1.2c-0.3-0.1-0.2-0.5-0.1-0.7c0.2-0.5,1-1.3,1.6-1.2
+			C1020.7,55.6,1021.1,55.8,1020.9,56.2"/>
+		<path class="st60" d="M1026.2,57.4L1026.2,57.4c0.3,0.5,0.5,1.1,0.8,1.5c-0.2,0.5-1.6,0.9-1.6,0c0.3-0.1,0.8,0,1.1-0.2
+			C1026.4,58.4,1026.2,58,1026.2,57.4"/>
+		<path class="st60" d="M1021.4,57.4c0.2,0.4,0.3,0.9,0.6,1.2c0.1,0.1,0.4,0.3,0.3,0.7c0,0.1-0.3,0.3-0.4,0.4
+			c-0.5,0.2-1.7,0-1.3-0.6c0.4,0,1,0.3,1.3,0C1021.7,58.7,1021.3,57.9,1021.4,57.4"/>
+		<path class="st60" d="M1026,61.8c-0.8,0.5-1.7,1.1-2.9,0.9c-0.3-0.3-0.4-0.8-0.1-1.1c0.1,0.2,0.1,0.7,0.4,0.7
+			c0.7,0.1,1.6-0.4,2.1-0.6c0.3-0.5,0-0.7-0.3-1.1c-0.6-0.7-1.4-1.6-1.4-2.7c0.2-0.2,0.3,0.3,0.3,0.3c0.3,0.7,1.1,1.7,1.7,2.3
+			c0.1,0.2,0.4,0.3,0.4,0.4C1026.2,61.3,1026,61.6,1026,61.8"/>
+		<path class="st60" d="M1015.7,61.3c-0.2-0.1-0.3-0.8-0.6-0.8c-0.4,0-0.3,0.8-0.3,1.3c-0.3-0.3-0.3-1.1-0.1-1.5
+			c-0.2-0.1-0.3,0.1-0.5,0.2C1014.3,59.3,1015.9,60,1015.7,61.3"/>
+		<path class="st60" d="M1026.5,62.3c-0.4,0.7-0.9,1.5-2,1.5c0-0.2,0-0.6,0-0.7C1025.4,63,1025.9,62.6,1026.5,62.3"/>
+		<path class="st60" d="M1021.4,62.8c0.7,0.4,1.9,0.4,2.9,0.4c0,0.2,0.1,0.5,0.1,0.7C1023.1,63.9,1021.7,63.6,1021.4,62.8"/>
+		<path class="st60" d="M1021.2,63.4c0.5,1.2,2.1,1,3.5,1c-0.1,0.2-0.2,0.3-0.4,0.4c-0.4,0.2-1.6,0.3-2.3,0
+			c-0.4-0.2-0.6-0.7-0.8-0.9C1021.1,63.8,1020.6,63.4,1021.2,63.4"/>
+		<path class="st68" d="M1025.9,70c-0.6,0.9-1.1,1.9-1.7,2.8c0.3-0.8,0.4-2.2,0.4-3.2C1025.2,69.3,1025.7,69.6,1025.9,70"/>
+		<path class="st60" d="M1028.9,73.4c-0.6,0.1-1.1,0.7-1.7,0.7C1027.6,73.6,1028.2,73.4,1028.9,73.4"/>
+		<path class="st60" d="M1029.2,74.4c-0.5,0.1-1.1,0.1-1.6,0.1C1027.8,74.1,1028.8,74.2,1029.2,74.4"/>
+		<path class="st60" d="M1029.4,75.2c-0.6,0-1.3,0-1.8,0C1027.9,74.8,1029,75,1029.4,75.2"/>
+		<path class="st64" d="M1024.9,77.5c0.1,0.7,0.4,1.4,0.3,2.2c-0.3,0.1-0.5,0.2-0.9,0.2c0-0.7-0.1-1.7-0.1-2.3
+			C1024.4,77.6,1024.7,77.4,1024.9,77.5"/>
+		<path class="st61" d="M1024,67c-0.3,0.2-0.5,0.4-0.8,0.6c-0.6,0-0.9,0-1.4-0.4c0,0,0.1,0,0.1,0C1022.5,67.4,1023.3,67,1024,67"/>
+		<path class="st68" d="M1020.5,71.4c0.2-0.8,0.9-1.2,1.5-1.6c0.7,0.8,1.1,1.9,1.5,2.9C1022.5,72.4,1021.4,71.9,1020.5,71.4"/>
+		<path class="st60" d="M1024.2,77.6c0,0.6,0.1,1.6,0.1,2.3c0.4,0,0.6-0.1,0.9-0.2c0-0.8-0.2-1.5-0.3-2.2
+			C1024.7,77.4,1024.4,77.6,1024.2,77.6z M1017.6,74c0.3,2.6,0.7,4.7,1.4,7c1.6,0.5,3.6,0.5,5.1,0.1c-0.3-1.3-0.1-2.8-0.3-4.2
+			c-0.1-1-0.1-2.1-0.2-3.1C1021.8,73.4,1019.4,73.7,1017.6,74z M1024,73.8c0,1.1,0,2.2,0.1,3.3c0.4-0.1,0.7-0.1,1.1-0.2
+			c-0.1-1.1-0.1-2.2-0.4-3.2C1024.6,73.7,1024.3,73.7,1024,73.8L1024,73.8z M1026.1,73.6c-0.2,0-0.4,0-0.6,0
+			c0.1,0.9,0.3,1.9,0.4,2.8c0.3,0,0.5-0.1,0.7-0.2C1026.6,75.4,1026.5,74.3,1026.1,73.6L1026.1,73.6z M1029.4,76.5
+			c0.6-0.2,1-0.9,0.8-1.7c-0.1-0.5-0.3-1.5-0.6-1.9c-0.2-0.3-0.6-0.6-1-0.3c-0.6,0.4-1.6,0.5-2,0.9c0.2,0.7,0.3,1.7,0.4,2.6
+			c0.7,0,1.6-0.2,2.2,0.1c-0.4,0.1-1,0.1-1.3,0.3C1028.2,76.7,1028.9,76.7,1029.4,76.5L1029.4,76.5z M1023.5,72.7
+			c-0.4-1-0.8-2.1-1.5-2.9c-0.6,0.4-1.3,0.8-1.5,1.6C1021.4,71.9,1022.5,72.4,1023.5,72.7L1023.5,72.7z M1024.6,69.5
+			c0,1-0.2,2.4-0.4,3.2c0.7-0.8,1.2-1.8,1.7-2.8C1025.7,69.6,1025.2,69.3,1024.6,69.5z M1023.4,69.1c-0.2,0-0.5,0.3-0.8,0.2
+			c-0.1,0.1-0.1,0.2-0.2,0.3c0.7,0.9,1,2.1,1.6,3.1c0.3-1,0.3-2,0.3-3.1C1023.9,69.5,1023.7,69.1,1023.4,69.1z M1022.6,68.1
+			c0,0.3,0,0.4,0.1,0.7C1023.7,69.1,1023.5,67.5,1022.6,68.1L1022.6,68.1z M1021.5,67.7c-0.5-0.3-1-0.5-1.6-0.6
+			c-0.7-0.1-0.6,0.9-0.6,1.5c0,0.5,0.3,1,0.4,1.3c0.1,0.2,0.1,0.3,0.2,0.3c0.2,0.1,1-0.3,1.2-0.4c0.5-0.3,0.8-0.6,1.2-0.9
+			c0-0.1,0-0.3,0-0.4c-0.3-0.1-0.6-0.2-0.8-0.2c0.2-0.1,0.6-0.1,0.8-0.3c0-0.1,0-0.1,0-0.2C1021.9,68,1021.8,67.8,1021.5,67.7z
+			 M1017.5,67c-0.3,0.4,1,0.8,1.4,0.9c0-0.2,0.1-0.4,0.1-0.6C1018.5,67.2,1017.9,67.2,1017.5,67L1017.5,67z M1021.8,67.1
+			C1021.8,67.2,1021.8,67.2,1021.8,67.1c0.4,0.4,0.7,0.5,1.3,0.4c0.3-0.2,0.5-0.4,0.8-0.6C1023.3,67,1022.5,67.4,1021.8,67.1
+			L1021.8,67.1z M1025.7,68.3c0-0.4-0.1-1.2-0.4-1.3c-0.5-0.3-1.4,0.6-1.8,0.7c0,0.1,0.1,0.2,0.1,0.4c0.2-0.1,0.5,0,0.7,0.1
+			c-0.2,0-0.5,0-0.6,0.1c-0.1,0.2,0,0.4,0,0.6c0.6,0.2,1.2,0.2,1.8,0.3C1025.7,69,1025.8,68.7,1025.7,68.3z M1017,67.3
+			c-0.1-0.1-0.8-1-0.9-1c-1.3,0.5-2.6,1.4-3.7,2.3c1.1,2.3,1.5,5.1,1.6,7.8c1.2,0.6,2.3,1.4,3.9,1.5c-0.2-1.4-0.4-2.6-0.5-3.8
+			c-0.4-0.2-1,0-1.4-0.1c0-0.5,0.6-0.2,0.6-0.5c0-0.2-0.3-0.3-0.2-0.6c0.3,0.1,0.5,0.4,0.8,0.4c0.3-0.6,0-1.8,0-2.3
+			c0-0.1,0.1-0.6,0.3-0.5c0.2,0.1,0,1.2,0,1.7c0,0.5-0.1,0.9,0.1,1.2c1.6-0.2,3.3-0.4,4.9-0.4c-0.4-0.2-0.8-0.3-1.3-0.6
+			c-0.3-0.2-1.1-0.5-1.2-0.7c-0.1-0.4,0.3-0.6,0.4-1c-0.8,0.4-1-0.4-1.2-1c-0.1-0.4-0.2-0.8-0.3-1.3
+			C1018.3,68.1,1017.6,67.7,1017,67.3L1017,67.3z M1025,66.4c1.1-0.5,1.3,2,0.9,2.8c0.1,0.2,0.3,0.3,0.4,0.6
+			c-0.6,1.1-1.3,2.1-1.9,3.2c0.5-0.3,1.1-0.1,1.7-0.3c0.2-0.1,0.3-0.5,0.5-0.9c0.4-1,0.9-2.3,1.1-3.3c0-0.2,0.2-0.7,0.1-0.9
+			c0-0.4-0.5-0.6-0.8-0.8c-0.4-0.4-0.7-0.8-1.2-1.1C1025.6,66,1025.2,66.2,1025,66.4L1025,66.4z M1014.4,56.6
+			c-0.5,0.6-0.4,1.7-0.4,2.5c1-0.6,2.2,0,2.2,1.1c0.5,0,0.2-0.6,0.1-0.9c-0.3-1.2,0.5-2.5,0-3.5C1015.6,55.7,1014.9,56,1014.4,56.6
+			L1014.4,56.6z M1018.2,53.2c-1.2,0.3-2.7,1.2-3.2,2.3c0.4-0.1,0.6-0.2,1-0.3c0.1,0,0.3,0.1,0.5,0c0.3-0.1,0.6-0.8,0.8-1.1
+			c0.2-0.3,0.5-0.4,0.7-0.6c0.1-0.1,0.3-0.1,0.3-0.2C1018.3,53.2,1018.3,53.2,1018.2,53.2z M1024.4,53.5c-1.2-0.7-3.4-1.2-4.7-0.6
+			c-1.1,0.5-2.5,1.4-3,2.5c0.5,1.1-0.1,2.1-0.2,3.2c0,0.6,0.3,1.1,0.3,1.7c-0.2,0.3-0.6,0.3-1,0.3c-0.1-0.6-0.3-1.2-0.9-1.3
+			c-0.8-0.1-1.4,0.6-1.5,1.3c0,0.8,0.6,2.2,1.6,2.1c0.4,0,0.5-0.4,0.9-0.4c0.2,0.4-0.3,0.6-0.4,0.9c0,0.2,0,0.4,0.1,0.5
+			c0.2,0.7,0.6,1.7,1,2.2c0.5,0.7,1.4,0.8,2.5,0.9c0.2-0.4,0.9-0.4,1.3-0.3c-0.5-0.2-1-0.7-1.4-1.2c-0.5-0.5-0.9-1.1-1-1.8
+			c0.9,1.2,1.6,2.3,3.2,2.8c1.2,0.4,2.6-0.2,3.6-0.8c0.4-0.3,0.6-0.7,0.9-1.1c1-1.5,1.5-3.6,1.4-5.7c0-0.9,0-1.7-0.3-2.3
+			c-0.3-0.6-1.3-1.1-1.9-0.6c-0.1-0.6,0.5-0.9,1.2-0.7C1025.7,54.7,1025.2,53.9,1024.4,53.5z M1026.8,72.7c1-0.5,2.8-1.3,3.4,0
+			c0.3,0.6,0.5,1.2,0.6,1.8c0.2,0.7-0.2,2.2-0.9,2.4c-0.6,0.2-1.4,0.2-2.1,0c-0.1-0.1-0.2-0.2-0.3-0.3c-0.5,0-1.1,0-1.5,0.3
+			c0,0.4-0.2,0.5-0.5,0.6c-0.2,0.8,0.4,1.7,0.2,2.4c-0.1,0.5-0.7,0.6-1.1,0.7c0,0.2,0,0.5,0,0.7c-0.1,0.4-0.6,0.6-1,0.6
+			c-1.4,0.2-3.6,0.2-4.9-0.2c-0.4-0.9-0.7-2.1-1-3.1c-1.3,0.1-2.4-0.6-3.4-1c-0.4-0.2-0.8-0.3-1-0.5c-0.1-0.3-0.1-0.8-0.1-1.3
+			c-0.1-1.2-0.1-2.5-0.5-3.7c-0.1-0.6-0.4-1.1-0.6-1.6c-0.2-0.5-0.5-1.1-0.5-1.7c-0.1-0.8,0.6-0.8,1.1-1.1c0.7-0.5,1.3-0.8,2-1.2
+			c0.2-0.1,0.9-0.5,1-0.6c0.2-0.3-0.3-0.8-0.4-1c-0.2-0.3-0.3-0.7-0.3-1.1c-0.6-0.1-1.1-0.4-1.4-0.9c-0.5-0.7-0.8-2-0.4-3
+			c0-0.1,0.2-0.2,0.2-0.4c0-0.2-0.1-0.6-0.1-0.8c0-1.3,0.2-2.4,1.1-2.8c0.4-1.4,1.6-1.9,2.8-2.6c0.4-0.3,0.9-0.4,1.5-0.6
+			c1.8-0.7,4.6-0.5,6.2,0.6c0.6,0.5,1.7,1.5,2,2.3c1,2,0.9,5.2,0.2,7.6c-0.1,0.4-0.2,0.8-0.4,1.2c-0.1,0.3-0.5,0.8-0.5,1
+			c0.1,0.2,0.9,0.9,1.1,1.1c0.3,0.3,1,0.7,1,1.2c0.1,0.4-0.2,1-0.3,1.4C1027.6,70.2,1027.2,71.5,1026.8,72.7"/>
+		<path class="st65" d="M1020.3,63.1c0.1-0.1,0.3-0.2,0.7,0c0,0-0.5,0.1-0.4,0.9l-0.2,0C1020.4,63.9,1020.2,63.2,1020.3,63.1"/>
+		<path class="st69" d="M1023.8,70c0,0.1-0.1,0.2-0.2,0.2s-0.2-0.1-0.2-0.2c0-0.1,0.1-0.2,0.2-0.2S1023.8,69.8,1023.8,70L1023.8,70"
+			/>
+		<path class="st69" d="M1024,71c0,0.1-0.1,0.2-0.2,0.2s-0.2-0.1-0.2-0.2c0-0.1,0.1-0.2,0.2-0.2S1024,70.9,1024,71L1024,71"/>
+	</g>
+	
+		<linearGradient id="a91f0ca4-8fb7-4019-9c09-0a52e2c05754_00000081636326823834409920000010539802630586082191_" gradientUnits="userSpaceOnUse" x1="394.0387" y1="452.2424" x2="394.0387" y2="482.0926" gradientTransform="matrix(1 0 0 -1 564 534.1305)">
+		<stop  offset="0" style="stop-color:#0078D4"/>
+		<stop  offset="0.16" style="stop-color:#1380DA"/>
+		<stop  offset="0.53" style="stop-color:#3C91E5"/>
+		<stop  offset="0.82" style="stop-color:#559CEC"/>
+		<stop  offset="1" style="stop-color:#5EA0EF"/>
+	</linearGradient>
+	
+		<path id="a91f0ca4-8fb7-4019-9c09-0a52e2c05754_1_" style="fill:url(#a91f0ca4-8fb7-4019-9c09-0a52e2c05754_00000081636326823834409920000010539802630586082191_);" d="
+		M973,57.6v18.2l-7.5,6.1l-11.6-4.2v4.2l-6.6-8.6l19.2,1.5V58.4L973,57.6z M966.6,58.5L955.9,52v4.3l-9.9,2.9l-3,3.8v8.6l4.2,1.9
+		V62.4L966.6,58.5z"/>
+	<g>
+		<g>
+			<path class="st1" d="M98.4,462.5c0,2.2-1.8,4-4,4h-83c-2.2,0-4-1.8-4-4V144.8c0-2.2,1.8-4,4-4h83c2.2,0,4,1.8,4,4V462.5z"/>
+			<path class="st2" d="M98.4,462.5c0,2.2-1.8,4-4,4h-83c-2.2,0-4-1.8-4-4V144.8c0-2.2,1.8-4,4-4h83c2.2,0,4,1.8,4,4V462.5z"/>
+			<path class="st5" d="M98.4,462.5c0,2.2-1.8,4-4,4h-83c-2.2,0-4-1.8-4-4V144.8c0-2.2,1.8-4,4-4h83c2.2,0,4,1.8,4,4V462.5z"/>
+		</g>
+		<path class="st4" d="M94.4,467.1h-0.1V466h0.1c0.2,0,0.4,0,0.6-0.1l0.1,1.1C94.9,467,94.7,467.1,94.4,467.1z M92.3,467.1h-0.8V466
+			h0.8V467.1z M89.5,467.1h-0.8V466h0.8V467.1z M86.7,467.1h-0.8V466h0.8V467.1z M83.9,467.1h-0.8V466h0.8V467.1z M81.1,467.1h-0.8
+			V466h0.8V467.1z M78.3,467.1h-0.8V466h0.8V467.1z M75.5,467.1h-0.8V466h0.8V467.1z M72.7,467.1h-0.8V466h0.8V467.1z M69.9,467.1
+			h-0.8V466h0.8V467.1z M67.1,467.1h-0.8V466h0.8V467.1z M64.4,467.1h-0.8V466h0.8V467.1z M61.6,467.1h-0.8V466h0.8V467.1z
+			 M58.8,467.1H58V466h0.8V467.1z M56,467.1h-0.8V466H56V467.1z M53.2,467.1h-0.8V466h0.8V467.1z M50.4,467.1h-0.8V466h0.8V467.1z
+			 M47.6,467.1h-0.8V466h0.8V467.1z M44.8,467.1H44V466h0.8V467.1z M42,467.1h-0.8V466H42V467.1z M39.2,467.1h-0.8V466h0.8V467.1z
+			 M36.4,467.1h-0.8V466h0.8V467.1z M33.6,467.1h-0.8V466h0.8V467.1z M30.8,467.1H30V466h0.8V467.1z M28,467.1h-0.8V466H28V467.1z
+			 M25.2,467.1h-0.8V466h0.8V467.1z M22.4,467.1h-0.8V466h0.8V467.1z M19.6,467.1h-0.8V466h0.8V467.1z M16.8,467.1h-0.8V466h0.8
+			V467.1z M14.1,467.1h-0.8V466h0.8V467.1z M11.2,467.1c-0.3,0-0.6-0.1-0.9-0.2l0.2-1.1c0.2,0.1,0.5,0.1,0.7,0.1L11.2,467.1z
+			 M97.1,465.8l-0.5-0.9c0.2-0.2,0.4-0.4,0.5-0.7l0.6,0.7C97.6,465.2,97.4,465.5,97.1,465.8z M8.5,465.5c-0.2-0.3-0.4-0.6-0.6-0.9
+			l0.6-0.7c0.1,0.3,0.3,0.5,0.5,0.7L8.5,465.5z M98.7,462.2l-0.8-0.2c0-0.3,0.1-0.6,0.1-1l0.8-0.1v0.1
+			C98.8,461.4,98.8,461.8,98.7,462.2z M7,461.9c0-0.3,0-0.6,0-0.8v-0.3h0.8v0.3c0,0.2,0,0.5,0,0.7L7,461.9z M98.8,458.2H98v-1.1h0.8
+			V458.2z M7.8,458H7v-1.1h0.8V458z M98.8,454.4H98v-1.1h0.8V454.4z M7.8,454.2H7v-1.1h0.8V454.2z M98.8,450.6H98v-1.1h0.8V450.6z
+			 M7.8,450.3H7v-1.1h0.8V450.3z M98.8,446.8H98v-1.1h0.8V446.8z M7.8,446.5H7v-1.1h0.8V446.5z M98.8,443H98v-1.1h0.8V443z
+			 M7.8,442.7H7v-1.1h0.8V442.7z M98.8,439.1H98V438h0.8V439.1z M7.8,438.9H7v-1.1h0.8V438.9z M98.8,435.3H98v-1.1h0.8V435.3z
+			 M7.8,435H7v-1.1h0.8V435z M98.8,431.5H98v-1.1h0.8V431.5z M7.8,431.2H7v-1.1h0.8V431.2z M98.8,427.7H98v-1.1h0.8V427.7z
+			 M7.8,427.4H7v-1.1h0.8V427.4z M98.8,423.8H98v-1.1h0.8V423.8z M7.8,423.6H7v-1.1h0.8V423.6z M98.8,420H98v-1.1h0.8V420z
+			 M7.8,419.7H7v-1.1h0.8V419.7z M98.8,416.2H98v-1.1h0.8V416.2z M7.8,415.9H7v-1.1h0.8V415.9z M98.8,412.4H98v-1.1h0.8V412.4z
+			 M7.8,412.1H7V411h0.8V412.1z M98.8,408.5H98v-1.1h0.8V408.5z M7.8,408.3H7v-1.1h0.8V408.3z M98.8,404.7H98v-1.1h0.8V404.7z
+			 M7.8,404.4H7v-1.1h0.8V404.4z M98.8,400.9H98v-1.1h0.8V400.9z M7.8,400.6H7v-1.1h0.8V400.6z M98.8,397.1H98V396h0.8V397.1z
+			 M7.8,396.8H7v-1.1h0.8V396.8z M98.8,393.2H98v-1.1h0.8V393.2z M7.8,393H7v-1.1h0.8V393z M98.8,389.4H98v-1.1h0.8V389.4z
+			 M7.8,389.1H7v-1.1h0.8V389.1z M98.8,385.6H98v-1.1h0.8V385.6z M7.8,385.3H7v-1.1h0.8V385.3z M98.8,381.8H98v-1.1h0.8V381.8z
+			 M7.8,381.5H7v-1.1h0.8V381.5z M98.8,377.9H98v-1.1h0.8V377.9z M7.8,377.7H7v-1.1h0.8V377.7z M98.8,374.1H98V373h0.8V374.1z
+			 M7.8,373.9H7v-1.1h0.8V373.9z M98.8,370.3H98v-1.1h0.8V370.3z M7.8,370H7v-1.1h0.8V370z M98.8,366.5H98v-1.1h0.8V366.5z
+			 M7.8,366.2H7v-1.1h0.8V366.2z M98.8,362.6H98v-1.1h0.8V362.6z M7.8,362.4H7v-1.1h0.8V362.4z M98.8,358.8H98v-1.1h0.8V358.8z
+			 M7.8,358.6H7v-1.1h0.8V358.6z M98.8,355H98v-1.1h0.8V355z M7.8,354.7H7v-1.1h0.8V354.7z M98.8,351.2H98v-1.1h0.8V351.2z
+			 M7.8,350.9H7v-1.1h0.8V350.9z M98.8,347.4H98v-1.1h0.8V347.4z M7.8,347.1H7V346h0.8V347.1z M98.8,343.5H98v-1.1h0.8V343.5z
+			 M7.8,343.3H7v-1.1h0.8V343.3z M98.8,339.7H98v-1.1h0.8V339.7z M7.8,339.4H7v-1.1h0.8V339.4z M98.8,335.9H98v-1.1h0.8V335.9z
+			 M7.8,335.6H7v-1.1h0.8V335.6z M98.8,332.1H98V331h0.8V332.1z M7.8,331.8H7v-1.1h0.8V331.8z M98.8,328.2H98v-1.1h0.8V328.2z
+			 M7.8,328H7v-1.1h0.8V328z M98.8,324.4H98v-1.1h0.8V324.4z M7.8,324.1H7V323h0.8V324.1z M98.8,320.6H98v-1.1h0.8V320.6z
+			 M7.8,320.3H7v-1.1h0.8V320.3z M98.8,316.8H98v-1.1h0.8V316.8z M7.8,316.5H7v-1.1h0.8V316.5z M98.8,312.9H98v-1.1h0.8V312.9z
+			 M7.8,312.7H7v-1.1h0.8V312.7z M98.8,309.1H98V308h0.8V309.1z M7.8,308.8H7v-1.1h0.8V308.8z M98.8,305.3H98v-1.1h0.8V305.3z
+			 M7.8,305H7v-1.1h0.8V305z M98.8,301.5H98v-1.1h0.8V301.5z M7.8,301.2H7v-1.1h0.8V301.2z M98.8,297.6H98v-1.1h0.8V297.6z
+			 M7.8,297.4H7v-1.1h0.8V297.4z M98.8,293.8H98v-1.1h0.8V293.8z M7.8,293.5H7v-1.1h0.8V293.5z M98.8,290H98v-1.1h0.8V290z
+			 M7.8,289.7H7v-1.1h0.8V289.7z M98.8,286.2H98v-1.1h0.8V286.2z M7.8,285.9H7v-1.1h0.8V285.9z M98.8,282.3H98v-1.1h0.8V282.3z
+			 M7.8,282.1H7V281h0.8V282.1z M98.8,278.5H98v-1.1h0.8V278.5z M7.8,278.2H7v-1.1h0.8V278.2z M98.8,274.7H98v-1.1h0.8V274.7z
+			 M7.8,274.4H7v-1.1h0.8V274.4z M98.8,270.9H98v-1.1h0.8V270.9z M7.8,270.6H7v-1.1h0.8V270.6z M98.8,267H98V266h0.8V267z
+			 M7.8,266.8H7v-1.1h0.8V266.8z M98.8,263.2H98v-1.1h0.8V263.2z M7.8,263H7v-1.1h0.8V263z M98.8,259.4H98v-1.1h0.8V259.4z
+			 M7.8,259.1H7V258h0.8V259.1z M98.8,255.6H98v-1.1h0.8V255.6z M7.8,255.3H7v-1.1h0.8V255.3z M98.8,251.7H98v-1.1h0.8V251.7z
+			 M7.8,251.5H7v-1.1h0.8V251.5z M98.8,247.9H98v-1.1h0.8V247.9z M7.8,247.7H7v-1.1h0.8V247.7z M98.8,244.1H98V243h0.8V244.1z
+			 M7.8,243.8H7v-1.1h0.8V243.8z M98.8,240.3H98v-1.1h0.8V240.3z M7.8,240H7v-1.1h0.8V240z M98.8,236.5H98v-1.1h0.8V236.5z
+			 M7.8,236.2H7v-1.1h0.8V236.2z M98.8,232.6H98v-1.1h0.8V232.6z M7.8,232.4H7v-1.1h0.8V232.4z M98.8,228.8H98v-1.1h0.8V228.8z
+			 M7.8,228.5H7v-1.1h0.8V228.5z M98.8,225H98v-1.1h0.8V225z M7.8,224.7H7v-1.1h0.8V224.7z M98.8,221.2H98v-1.1h0.8V221.2z
+			 M7.8,220.9H7v-1.1h0.8V220.9z M98.8,217.3H98v-1.1h0.8V217.3z M7.8,217.1H7V216h0.8V217.1z M98.8,213.5H98v-1.1h0.8V213.5z
+			 M7.8,213.2H7v-1.1h0.8V213.2z M98.8,209.7H98v-1.1h0.8V209.7z M7.8,209.4H7v-1.1h0.8V209.4z M98.8,205.9H98v-1.1h0.8V205.9z
+			 M7.8,205.6H7v-1.1h0.8V205.6z M98.8,202H98v-1.1h0.8V202z M7.8,201.8H7v-1.1h0.8V201.8z M98.8,198.2H98v-1.1h0.8V198.2z
+			 M7.8,197.9H7v-1.1h0.8V197.9z M98.8,194.4H98v-1.1h0.8V194.4z M7.8,194.1H7V193h0.8V194.1z M98.8,190.6H98v-1.1h0.8V190.6z
+			 M7.8,190.3H7v-1.1h0.8V190.3z M98.8,186.7H98v-1.1h0.8V186.7z M7.8,186.5H7v-1.1h0.8V186.5z M98.8,182.9H98v-1.1h0.8V182.9z
+			 M7.8,182.6H7v-1.1h0.8V182.6z M98.8,179.1H98V178h0.8V179.1z M7.8,178.8H7v-1.1h0.8V178.8z M98.8,175.3H98v-1.1h0.8V175.3z
+			 M7.8,175H7v-1.1h0.8V175z M98.8,171.4H98v-1.1h0.8V171.4z M7.8,171.2H7v-1.1h0.8V171.2z M98.8,167.6H98v-1.1h0.8V167.6z
+			 M7.8,167.4H7v-1.1h0.8V167.4z M98.8,163.8H98v-1.1h0.8V163.8z M7.8,163.5H7v-1.1h0.8V163.5z M98.8,160H98v-1.1h0.8V160z
+			 M7.8,159.7H7v-1.1h0.8V159.7z M98.8,156.1H98v-1.1h0.8V156.1z M7.8,155.9H7v-1.1h0.8V155.9z M98.8,152.3H98v-1.1h0.8V152.3z
+			 M7.8,152.1H7V151h0.8V152.1z M98.8,148.5H98v-1.1h0.8V148.5z M7.8,148.2H7v-1.1h0.8V148.2z M97.8,144.9c-0.1-0.3-0.2-0.6-0.3-0.9
+			l0.7-0.5c0.1,0.4,0.3,0.7,0.3,1.1L97.8,144.9z M8,144.6l-0.8-0.4c0.1-0.4,0.2-0.7,0.4-1.1l0.7,0.6C8.2,144,8.1,144.3,8,144.6z
+			 M96.4,142.2c-0.2-0.2-0.4-0.3-0.6-0.5l0.3-1c0.3,0.1,0.5,0.3,0.8,0.6L96.4,142.2z M9.6,142l-0.4-0.9c0.3-0.2,0.5-0.4,0.8-0.5
+			l0.3,1C10,141.7,9.8,141.9,9.6,142z M93.9,141.4h-0.8v-1.1h0.8V141.4z M91.1,141.4h-0.8v-1.1h0.8V141.4z M88.3,141.4h-0.8v-1.1
+			h0.8V141.4z M85.5,141.4h-0.8v-1.1h0.8V141.4z M82.7,141.4h-0.8v-1.1h0.8V141.4z M79.9,141.4h-0.8v-1.1h0.8V141.4z M77.1,141.4
+			h-0.8v-1.1h0.8V141.4z M74.4,141.4h-0.8v-1.1h0.8V141.4z M71.6,141.4h-0.8v-1.1h0.8V141.4z M68.8,141.4H68v-1.1h0.8V141.4z
+			 M66,141.4h-0.8v-1.1H66V141.4z M63.2,141.4h-0.8v-1.1h0.8V141.4z M60.4,141.4h-0.8v-1.1h0.8V141.4z M57.6,141.4h-0.8v-1.1h0.8
+			V141.4z M54.8,141.4H54v-1.1h0.8V141.4z M52,141.4h-0.8v-1.1H52V141.4z M49.2,141.4h-0.8v-1.1h0.8V141.4z M46.4,141.4h-0.8v-1.1
+			h0.8V141.4z M43.6,141.4h-0.8v-1.1h0.8V141.4z M40.8,141.4H40v-1.1h0.8V141.4z M38,141.4h-0.8v-1.1H38V141.4z M35.2,141.4h-0.8
+			v-1.1h0.8V141.4z M32.4,141.4h-0.8v-1.1h0.8V141.4z M29.6,141.4h-0.8v-1.1h0.8V141.4z M26.8,141.4h-0.8v-1.1h0.8V141.4z
+			 M24.1,141.4h-0.8v-1.1h0.8V141.4z M21.3,141.4h-0.8v-1.1h0.8V141.4z M18.5,141.4h-0.8v-1.1h0.8V141.4z M15.7,141.4h-0.8v-1.1h0.8
+			V141.4z M12.9,141.4h-0.8v-1.1h0.8V141.4z"/>
+	</g>
+	<g>
+		
+			<linearGradient id="SVGID_00000078014895067798646240000013053299665887075496_" gradientUnits="userSpaceOnUse" x1="52.8281" y1="63.0287" x2="52.8281" y2="91.2221" gradientTransform="matrix(1 0 0 -1 -3.547359e-03 300.129)">
+			<stop  offset="0" style="stop-color:#258277"/>
+			<stop  offset="0.42" style="stop-color:#49A498"/>
+			<stop  offset="0.78" style="stop-color:#60BAAD"/>
+			<stop  offset="1" style="stop-color:#68C2B5"/>
+		</linearGradient>
+		<path style="fill:url(#SVGID_00000078014895067798646240000013053299665887075496_);" d="M38.1,220.9l14-14c0.4-0.4,1-0.4,1.4,0
+			l14,14c0.4,0.4,0.4,1,0,1.4l-14,14c-0.4,0.4-1,0.4-1.4,0l-14-14C37.7,221.9,37.7,221.3,38.1,220.9z"/>
+		<path class="st1" d="M49.4,214l3.3-3.3c0.1-0.1,0.2-0.1,0.2,0l3.4,3.3c0.1,0.1,0.1,0.2,0,0.2c0,0-0.1,0.1-0.2,0.1h-2
+			c-0.1,0-0.2,0.1-0.2,0.2l0,0v4.3c0,0.1-0.1,0.2-0.2,0.2l0,0h-2.1c-0.1,0-0.2-0.1-0.2-0.1c0,0,0,0,0,0v-4.3c0-0.1-0.1-0.2-0.2-0.2
+			h-2C49.4,214.2,49.4,214.1,49.4,214C49.4,214,49.4,214,49.4,214z M56.4,229.2l-3.4,3.3c-0.1,0.1-0.2,0.1-0.2,0l-3.3-3.3
+			c-0.1-0.1,0-0.2,0-0.2c0,0,0.1,0,0.1,0h2c0.1,0,0.2-0.1,0.2-0.2v-4.3c0-0.1,0.1-0.2,0.2-0.2c0,0,0,0,0,0h2.1
+			c0.1,0,0.2,0.1,0.2,0.2l0,0v4.3c0,0.1,0.1,0.2,0.2,0.2l0,0h1.9c0.1-0.1,0.2,0,0.2,0C56.5,229,56.4,229.2,56.4,229.2z M46.4,224.8
+			v-1.9c0-0.1-0.1-0.2-0.2-0.2h-4.3c-0.1,0-0.2-0.1-0.2-0.2v-2.1c0-0.1,0.1-0.2,0.2-0.2h4.3c0.1,0,0.2-0.1,0.2-0.2v-2
+			c0-0.1,0-0.2,0.1-0.2c0.1,0,0.1,0,0.2,0.1l3.3,3.4c0.1,0.1,0.1,0.2,0,0.2c0,0,0,0,0,0l-3.3,3.3c-0.1,0.1-0.2,0.1-0.2,0
+			C46.4,224.9,46.4,224.9,46.4,224.8z M59.3,218.2v2c0,0.1,0.1,0.2,0.2,0.2h4.3c0.1,0,0.2,0.1,0.2,0.2v2.1c0,0.1-0.1,0.2-0.2,0.2
+			h-4.3c-0.1,0-0.2,0.1-0.2,0.2v1.9c0,0.1,0,0.2-0.1,0.2c-0.1,0-0.1,0-0.2-0.1l-3.3-3.4c-0.1-0.1-0.1-0.2,0-0.2c0,0,0,0,0,0l3.3-3.3
+			c0-0.1,0.1-0.1,0.2,0C59.3,218,59.3,218.1,59.3,218.2z"/>
+	</g>
+	<g>
+		
+			<linearGradient id="SVGID_00000038413308202140087390000016238787342882781092_" gradientUnits="userSpaceOnUse" x1="13.2893" y1="-147.6012" x2="13.2893" y2="-172.6012" gradientTransform="matrix(1 0 0 -1 0 300.1305)">
+			<stop  offset="0" style="stop-color:#5EA0EF"/>
+			<stop  offset="0.18" style="stop-color:#559CEC"/>
+			<stop  offset="0.47" style="stop-color:#3C91E5"/>
+			<stop  offset="0.84" style="stop-color:#1380DA"/>
+			<stop  offset="1" style="stop-color:#0078D4"/>
+		</linearGradient>
+		<path style="fill:url(#SVGID_00000038413308202140087390000016238787342882781092_);" d="M20.6,448.6v23.3c0,0.5-0.4,0.8-0.8,0.8
+			c0,0,0,0,0,0h-13c-0.5,0-0.8-0.4-0.8-0.8c0,0,0,0,0,0v-23.3c0-0.5,0.4-0.8,0.8-0.8c0,0,0,0,0,0h13
+			C20.3,447.7,20.6,448.1,20.6,448.6C20.6,448.6,20.6,448.6,20.6,448.6z"/>
+		<path id="a1bc77ea-5288-41a0-8f9a-2d282cf54a86_2_" class="st73" d="M7.9,450.3h2.5c0.1,0,0.2,0.1,0.2,0.2v3.1
+			c0,0.1-0.1,0.2-0.2,0.2H7.9c-0.1,0-0.2-0.1-0.2-0.2v-3.1C7.7,450.4,7.8,450.3,7.9,450.3z M12.1,450.3h2.4c0.1,0,0.2,0.1,0.2,0.2
+			l0,0v3.1c0,0.1-0.1,0.2-0.2,0.2l0,0h-2.4c-0.1,0-0.2-0.1-0.2-0.2l0,0v-3.1C11.9,450.4,12,450.3,12.1,450.3L12.1,450.3z
+			 M16.3,450.3h2.4c0.1,0,0.2,0.1,0.2,0.2v3.1c0,0.1-0.1,0.2-0.2,0.2h-2.4c-0.1,0-0.2-0.1-0.2-0.2l0,0v-3.1
+			C16.1,450.4,16.2,450.3,16.3,450.3L16.3,450.3z M7.9,455.9h2.5c0.1,0,0.2,0.1,0.2,0.2v3.1c0,0.1-0.1,0.2-0.2,0.2H7.9
+			c-0.1,0-0.2-0.1-0.2-0.2v-3.1C7.7,456,7.8,455.9,7.9,455.9z M12.1,455.9h2.4c0.1,0,0.2,0.1,0.2,0.2l0,0v3.1c0,0.1-0.1,0.2-0.2,0.2
+			h-2.4c-0.1,0-0.2-0.1-0.2-0.2v-3.1C11.9,456,12,455.9,12.1,455.9L12.1,455.9z M16.3,455.9h2.4c0.1,0,0.2,0.1,0.2,0.2v3.1
+			c0,0.1-0.1,0.2-0.2,0.2h-2.4c-0.1,0-0.2-0.1-0.2-0.2v-3.1C16.1,456,16.2,455.9,16.3,455.9L16.3,455.9z M7.9,461.6h2.5
+			c0.1,0,0.2,0.1,0.2,0.2l0,0v3.1c0,0.1-0.1,0.2-0.2,0.2l0,0H7.9c-0.1,0-0.2-0.1-0.2-0.2v-3.1C7.7,461.6,7.8,461.5,7.9,461.6z
+			 M12.1,461.6h2.4c0.1,0,0.2,0,0.3,0.1c0,0,0,0,0,0v3.1c0,0.1-0.1,0.2-0.2,0.2h0h-2.5c-0.1,0-0.2-0.1-0.2-0.2l0,0v-3.1
+			C11.9,461.6,12,461.6,12.1,461.6z M12.1,467.2h2.4c0.1,0,0.2,0.1,0.2,0.2l0,0v4.6c0,0.1-0.1,0.2-0.2,0.2h-2.4
+			c-0.1,0-0.2-0.1-0.2-0.2v-4.6C11.9,467.3,12,467.2,12.1,467.2z M16.3,461.6h2.4c0.1,0,0.2,0.1,0.2,0.2v3.1c0,0.1-0.1,0.2-0.2,0.2
+			h-2.4c-0.1,0-0.2-0.1-0.2-0.2l0,0v-3.1C16.1,461.6,16.2,461.6,16.3,461.6z"/>
+	</g>
+	<g>
+		<g>
+			<polygon class="st39" points="56.2,326 69.7,334.8 83.5,325.9 85.2,327.9 69.7,337.9 54.4,327.9 			"/>
+			<polygon class="st1" points="57.2,324.8 69.7,309.9 82.5,324.9 69.7,332.9 			"/>
+			<polygon class="st39" points="69.7,309.9 69.7,332.9 57.2,324.8 			"/>
+			
+				<linearGradient id="SVGID_00000049942956843508854500000016463791339323836816_" gradientUnits="userSpaceOnUse" x1="77.1019" y1="-30.6686" x2="69.1874" y2="-15.6771" gradientTransform="matrix(1 0 0 -1 0 300.1305)">
+				<stop  offset="0" style="stop-color:#3085C7"/>
+				<stop  offset="0.9" style="stop-color:#5FABDF"/>
+			</linearGradient>
+			<polygon style="fill:url(#SVGID_00000049942956843508854500000016463791339323836816_);" points="69.7,309.9 69.7,332.9 
+				82.5,324.9 			"/>
+			<polygon class="st75" points="69.7,321.8 82.5,324.9 69.7,332.9 			"/>
+			<polygon class="st37" points="69.7,332.9 57.2,324.8 69.7,321.8 			"/>
+			
+				<linearGradient id="SVGID_00000166675143265080832160000015442196173097219506_" gradientUnits="userSpaceOnUse" x1="73.6945" y1="-26.3125" x2="79.1646" y2="-35.7484" gradientTransform="matrix(1 0 0 -1 0 300.1305)">
+				<stop  offset="0.1" style="stop-color:#5FABDF"/>
+				<stop  offset="0.29" style="stop-color:#5AA8DD"/>
+				<stop  offset="0.51" style="stop-color:#4DA0D8"/>
+				<stop  offset="0.74" style="stop-color:#3B90CE"/>
+				<stop  offset="0.88" style="stop-color:#3085C7"/>
+			</linearGradient>
+			<polygon style="fill:url(#SVGID_00000166675143265080832160000015442196173097219506_);" points="69.7,337.9 85.2,327.9 
+				83.5,325.9 69.7,334.8 			"/>
+		</g>
+		<g>
+			<g>
+				<g>
+					
+						<linearGradient id="SVGID_00000059281072635833241270000014026696084014255509_" gradientUnits="userSpaceOnUse" x1="36.1231" y1="21.3228" x2="36.1231" y2="-1.9128" gradientTransform="matrix(1 0 0 -1 0 300.1305)">
+						<stop  offset="0" style="stop-color:#B3B2B4"/>
+						<stop  offset="0.38" style="stop-color:#B0AEAF"/>
+						<stop  offset="0.76" style="stop-color:#A2A1A1"/>
+						<stop  offset="1" style="stop-color:#979797"/>
+					</linearGradient>
+					<path style="fill:url(#SVGID_00000059281072635833241270000014026696084014255509_);" d="M43.7,301.3c0,0.5-0.4,0.8-0.9,0.8
+						H29.4c-0.5,0-0.8-0.3-0.9-0.8v-21.7c0-0.5,0.4-0.8,0.9-0.8h13.3c0.5,0,0.8,0.3,0.9,0.8V301.3z"/>
+					<path class="st78" d="M30.8,288.7c0-0.9,0.7-1.8,1.6-1.8h7.5c0.9,0.1,1.7,0.9,1.6,1.8l0,0c0.1,0.9-0.6,1.8-1.6,1.9
+						c0,0,0,0-0.1,0h-7.5C31.5,290.6,30.8,289.8,30.8,288.7L30.8,288.7z"/>
+					<path class="st78" d="M30.8,283.4c0-0.9,0.7-1.7,1.6-1.8h7.5c0.9,0.1,1.7,0.9,1.6,1.8l0,0c0,0.9-0.7,1.8-1.6,1.8h-7.5
+						C31.5,285.1,30.8,284.3,30.8,283.4L30.8,283.4z"/>
+					<circle class="st39" cx="32.9" cy="283.4" r="1.2"/>
+					<circle class="st39" cx="32.9" cy="288.7" r="1.2"/>
+				</g>
+			</g>
+			<g>
+				
+					<linearGradient id="SVGID_00000116914586477945409800000011745250989581032586_" gradientUnits="userSpaceOnUse" x1="38.2649" y1="-0.5338" x2="48.9914" y2="-0.5338" gradientTransform="matrix(1 0 0 -1 0 300.1305)">
+					<stop  offset="0" style="stop-color:#005CA1"/>
+					<stop  offset="7.000000e-02" style="stop-color:#0161AA"/>
+					<stop  offset="0.36" style="stop-color:#2571B8"/>
+					<stop  offset="0.52" style="stop-color:#2E76BC"/>
+					<stop  offset="0.64" style="stop-color:#2973BA"/>
+					<stop  offset="0.82" style="stop-color:#166BB5"/>
+					<stop  offset="1" style="stop-color:#005CA1"/>
+				</linearGradient>
+				<path style="fill:url(#SVGID_00000116914586477945409800000011745250989581032586_);" d="M43.7,296.5c-2.9,0-5.4-0.9-5.4-1.9
+					v10.3c0,1.1,2.4,2,5.3,2h0.1c2.9,0,5.4-0.9,5.4-2v-10.3C49,295.6,46.6,296.5,43.7,296.5z"/>
+				<path class="st80" d="M49,294.5c0,1.1-2.4,2-5.4,2s-5.4-0.9-5.4-2s2.5-1.9,5.4-1.9S49,293.4,49,294.5"/>
+				<path class="st39" d="M47.7,294.4c0,0.7-1.8,1.2-4.1,1.2s-4.1-0.5-4.1-1.2s1.8-1.2,4.2-1.2C46,293.1,47.8,293.7,47.7,294.4"/>
+				<path class="st81" d="M43.7,294.6c-1.1,0-2.2,0.1-3.2,0.5c1,0.3,2.1,0.5,3.2,0.5c1.1,0,2.2-0.1,3.3-0.5
+					C45.9,294.8,44.8,294.6,43.7,294.6z"/>
+			</g>
+		</g>
+		<g>
+			
+				<linearGradient id="SVGID_00000119803398391099002090000001908476143358285246_" gradientUnits="userSpaceOnUse" x1="43.9161" y1="-76.6236" x2="43.9161" y2="-50.1788" gradientTransform="matrix(1 0 0 -1 0 300.1305)">
+				<stop  offset="5.000000e-02" style="stop-color:#949494"/>
+				<stop  offset="0.36" style="stop-color:#979797"/>
+				<stop  offset="0.54" style="stop-color:#9F9E9E"/>
+				<stop  offset="0.69" style="stop-color:#AEADAE"/>
+				<stop  offset="0.73" style="stop-color:#B3B4B4"/>
+			</linearGradient>
+			<path style="fill:url(#SVGID_00000119803398391099002090000001908476143358285246_);" d="M51.7,375.9c0,0.5-0.4,0.9-0.9,0.9
+				c0,0,0,0,0,0H37c-0.5,0-0.9-0.4-0.9-0.9c0,0,0,0,0,0v-24.7c0-0.5,0.4-0.9,0.9-0.9c0,0,0,0,0,0h13.8c0.5,0,0.9,0.4,0.9,0.9
+				c0,0,0,0,0,0L51.7,375.9z"/>
+			<path class="st78" d="M38.4,359.6c0-0.9,0.8-1.7,1.7-1.7c0,0,0.1,0,0.1,0h7.8c0.9,0,1.6,0.8,1.6,1.7l0,0c0,0.9-0.7,1.7-1.7,1.7
+				c0,0,0,0,0,0h-7.8C39.1,361.3,38.4,360.5,38.4,359.6C38.4,359.6,38.4,359.6,38.4,359.6z"/>
+			<path class="st78" d="M38.4,354.6c0-0.9,0.8-1.7,1.7-1.7c0,0,0,0,0.1,0h7.8c0.9,0,1.6,0.8,1.6,1.7l0,0c0,0.9-0.8,1.7-1.7,1.7l0,0
+				h-7.8C39.1,356.3,38.4,355.5,38.4,354.6C38.4,354.6,38.4,354.6,38.4,354.6z"/>
+			<circle class="st39" cx="40.2" cy="354.6" r="1.1"/>
+			<circle class="st39" cx="40.2" cy="359.6" r="1.1"/>
+			
+				<linearGradient id="SVGID_00000109008045260797170710000010435489860147965599_" gradientUnits="userSpaceOnUse" x1="51.6706" y1="-58.7657" x2="51.6706" y2="-80.0612" gradientTransform="matrix(1 0 0 -1 0 300.1305)">
+				<stop  offset="0.18" style="stop-color:#699CD3"/>
+				<stop  offset="1" style="stop-color:#2E76BC"/>
+			</linearGradient>
+			<path style="fill:url(#SVGID_00000109008045260797170710000010435489860147965599_);" d="M62.3,371.9c-0.1-2.4-1.8-4.3-4.2-4.7
+				c-0.1-3.3-2.9-6-6.2-5.9c-2.7,0-5.1,1.6-6,4.1c-2.8,0.4-4.9,2.7-5,5.6c0.1,3.2,2.8,5.8,6,5.7h0.5h9.7h0.3
+				C60.2,376.7,62.3,374.6,62.3,371.9z"/>
+			<rect x="35.2" y="349.5" class="st84" width="28" height="28"/>
+		</g>
+	</g>
+	<g>
+		<path d="M1076.8,69.3c-0.2,0-0.3-0.1-0.4-0.2l-0.9-0.9c-0.2-0.2-0.3-0.6,0-0.9s0.6-0.3,0.9,0c0,0,0,0,0,0l0.5,0.5l1.5-1.5
+			c0.2-0.2,0.6-0.2,0.9,0s0.2,0.6,0,0.9l0,0l-1.9,1.9C1077.1,69.2,1076.9,69.3,1076.8,69.3z M1088.5,69.1l1.9-1.9
+			c0.2-0.2,0.2-0.6,0-0.9c-0.2-0.2-0.6-0.2-0.9,0l-1.5,1.5l-0.5-0.5c-0.2-0.2-0.6-0.3-0.9,0s-0.3,0.6,0,0.9c0,0,0,0,0,0l0.9,0.9
+			C1087.8,69.3,1088.2,69.3,1088.5,69.1C1088.5,69.1,1088.5,69.1,1088.5,69.1z M1068.7,61.3l3.2-2c0.6-0.4,0.8-1.1,0.4-1.7
+			c-0.1-0.2-0.2-0.3-0.4-0.4l-3.2-2c-0.6-0.4-1.4-0.2-1.7,0.4c-0.1,0.2-0.2,0.4-0.2,0.7v4c0,0.7,0.6,1.3,1.3,1.2
+			C1068.3,61.5,1068.5,61.4,1068.7,61.3z M1071.2,58.3l-3.2,2v-4L1071.2,58.3z M1093,67.6c0,2.4-2,4.4-4.4,4.4c-2.2,0-4-1.6-4.3-3.8
+			h-2.6c-0.3,2.1-2.2,3.7-4.3,3.8c-2.2,0-4-1.6-4.3-3.8h-0.7c-1.2,0-2.3-0.5-3.1-1.3v6.3c0,2.1,1.7,3.8,3.8,3.8h0.1
+			c0.3-2.1,2.1-3.8,4.3-3.8c2.4,0,4.4,2,4.4,4.4s-2,4.4-4.4,4.4c-2.2,0-4-1.6-4.3-3.8h-0.1c-2.8,0-5-2.2-5-5v-8.9
+			c-2.9-0.6-5-3.2-5-6.1c0-3.4,2.8-6.2,6.2-6.2s6.2,2.8,6.2,6.2c0,3.4-2.8,6.2-6.2,6.2c0.3,1.5,1.6,2.5,3,2.5h0.7
+			c0.3-2.1,2.1-3.8,4.3-3.8c2.2,0,4,1.6,4.3,3.8h2.6c0.3-2.1,2.2-3.7,4.3-3.8C1091.1,63.2,1093,65.2,1093,67.6z M1074.3,77.6
+			c0,1.7,1.4,3.1,3.1,3.1s3.1-1.4,3.1-3.1c0-1.7-1.4-3.1-3.1-3.1S1074.3,75.9,1074.3,77.6z M1069.3,63.2c2.8,0,5-2.2,5-5
+			c0-2.8-2.2-5-5-5s-5,2.2-5,5C1064.3,61,1066.5,63.2,1069.3,63.2z M1080.5,67.6c0-1.7-1.4-3.1-3.1-3.1s-3.1,1.4-3.1,3.1
+			c0,1.7,1.4,3.1,3.1,3.1S1080.5,69.3,1080.5,67.6z M1091.8,67.6c0-1.7-1.4-3.1-3.1-3.1s-3.1,1.4-3.1,3.1c0,1.7,1.4,3.1,3.1,3.1
+			S1091.8,69.3,1091.8,67.6z M1075.5,77.6c0,0.3,0.3,0.6,0.6,0.6s0.6-0.3,0.6-0.6s-0.3-0.6-0.6-0.6S1075.5,77.3,1075.5,77.6z
+			 M1078,77.6c0,0.3,0.3,0.6,0.6,0.6s0.6-0.3,0.6-0.6s-0.3-0.6-0.6-0.6S1078,77.3,1078,77.6z M1093,77.6c0,2.4-2,4.4-4.4,4.4
+			c-2.2,0-4-1.6-4.3-3.8c0,0,0,0,0,0l-0.6,0h0c-0.3,0-0.6-0.3-0.6-0.6c0-0.3,0.3-0.6,0.6-0.6l0.6,0c0,0,0,0,0.1,0
+			c0.3-2.2,2.1-3.8,4.3-3.8C1091.1,73.2,1093,75.2,1093,77.6z M1091.8,77.6c0-1.7-1.4-3.1-3.1-3.1s-3.1,1.4-3.1,3.1
+			c0,1.7,1.4,3.1,3.1,3.1S1091.8,79.3,1091.8,77.6z"/>
+	</g>
+	<g>
+		<rect x="571.2" y="154.3" class="st1" width="386.6" height="124"/>
+		<rect x="571.2" y="154.3" class="st14" width="386.6" height="124"/>
+	</g>
+	<g>
+		<rect x="571.2" y="309.3" class="st1" width="386.6" height="124"/>
+		<rect x="571.2" y="309.3" class="st14" width="386.6" height="124"/>
+	</g>
+	<circle class="st85" cx="800.5" cy="295.4" r="35"/>
+	<g>
+		
+			<linearGradient id="SVGID_00000160899146653809792200000018138605418442801807_" gradientUnits="userSpaceOnUse" x1="800.4731" y1="25.1914" x2="800.4731" y2="-14.8086" gradientTransform="matrix(1 0 0 -1 0 300.1305)">
+			<stop  offset="0" style="stop-color:#008BF1"/>
+			<stop  offset="0.2215" style="stop-color:#0086EC"/>
+			<stop  offset="0.4939" style="stop-color:#0078DD"/>
+			<stop  offset="0.7916" style="stop-color:#0061C4"/>
+			<stop  offset="1" style="stop-color:#004DAE"/>
+		</linearGradient>
+		<path style="fill:url(#SVGID_00000160899146653809792200000018138605418442801807_);" d="M799.1,293.6h-18.7v-18.7h18.7V293.6z
+			 M783.6,290.5H796v-12.4h-12.4V290.5z M820.5,293.6h-18.7v-18.7h18.7V293.6z M804.9,290.5h12.4v-12.4h-12.4V290.5z M820.5,314.9
+			h-18.7v-18.7h18.7V314.9z M799.1,314.9h-18.7v-18.7h18.7V314.9z M804.9,311.8h12.4v-12.4h-12.4V311.8z M783.6,311.8H796v-12.4
+			h-12.4V311.8z"/>
+		
+			<linearGradient id="SVGID_00000049936511769197781880000006239635325505681311_" gradientUnits="userSpaceOnUse" x1="803.6527" y1="7.4136" x2="816.4731" y2="7.4136" gradientTransform="matrix(1 0 0 -1 0 300.1305)">
+			<stop  offset="0" style="stop-color:#000000;stop-opacity:0.64"/>
+			<stop  offset="0.5677" style="stop-color:#000000;stop-opacity:0.22"/>
+			<stop  offset="1" style="stop-color:#FFFFFF;stop-opacity:0"/>
+		</linearGradient>
+		<path style="fill:url(#SVGID_00000049936511769197781880000006239635325505681311_);" d="M816.5,291.4v2.7h-12.8v-2.7H816.5z"/>
+		
+			<linearGradient id="SVGID_00000126284746850572386110000000078902662734180992_" gradientUnits="userSpaceOnUse" x1="804.9531" y1="8.0803" x2="820.4731" y2="8.0803" gradientTransform="matrix(1 0 0 -1 0 300.1305)">
+			<stop  offset="0" style="stop-color:#00315C"/>
+			<stop  offset="0.785" style="stop-color:#0080E5"/>
+		</linearGradient>
+		<path style="fill:url(#SVGID_00000126284746850572386110000000078902662734180992_);" d="M820.5,293.6v-3.1h-15.6v3.1H820.5z"/>
+		
+			<linearGradient id="SVGID_00000001642772595214493250000018300688448261437104_" gradientUnits="userSpaceOnUse" x1="795.9933" y1="8.0803" x2="780.4731" y2="8.0803" gradientTransform="matrix(1 0 0 -1 0 300.1305)">
+			<stop  offset="0" style="stop-color:#00315C"/>
+			<stop  offset="0.785" style="stop-color:#0080E5"/>
+		</linearGradient>
+		<path style="fill:url(#SVGID_00000001642772595214493250000018300688448261437104_);" d="M780.5,293.6v-3.1H796v3.1H780.5z"/>
+		
+			<linearGradient id="SVGID_00000136398142802677095460000007435224606162223005_" gradientUnits="userSpaceOnUse" x1="804.9531" y1="2.3025" x2="820.4731" y2="2.3025" gradientTransform="matrix(1 0 0 -1 0 300.1305)">
+			<stop  offset="0" style="stop-color:#00315C"/>
+			<stop  offset="0.5792" style="stop-color:#0E71C7"/>
+			<stop  offset="1" style="stop-color:#0A75D5"/>
+		</linearGradient>
+		<path style="fill:url(#SVGID_00000136398142802677095460000007435224606162223005_);" d="M820.5,296.3v3.1h-15.6v-3.1H820.5z"/>
+		
+			<linearGradient id="SVGID_00000000912075543524609620000004330376834094452926_" gradientUnits="userSpaceOnUse" x1="795.9932" y1="2.3025" x2="780.4731" y2="2.3025" gradientTransform="matrix(1 0 0 -1 0 300.1305)">
+			<stop  offset="0" style="stop-color:#00315C"/>
+			<stop  offset="0.5792" style="stop-color:#0E71C7"/>
+			<stop  offset="1" style="stop-color:#0A75D5"/>
+		</linearGradient>
+		<path style="fill:url(#SVGID_00000000912075543524609620000004330376834094452926_);" d="M780.5,299.4v-3.1H796v3.1H780.5z"/>
+		
+			<linearGradient id="SVGID_00000109012815408877501040000007778626247578716807_" gradientUnits="userSpaceOnUse" x1="797.5843" y1="9.6358" x2="797.5843" y2="23.2106" gradientTransform="matrix(1 0 0 -1 0 300.1305)">
+			<stop  offset="0" style="stop-color:#00315C"/>
+			<stop  offset="0.785" style="stop-color:#008AF0"/>
+		</linearGradient>
+		<path style="fill:url(#SVGID_00000109012815408877501040000007778626247578716807_);" d="M796,274.9h3.1v15.6H796V274.9z"/>
+		
+			<linearGradient id="SVGID_00000112613744030261687930000010797037013502529705_" gradientUnits="userSpaceOnUse" x1="803.3621" y1="9.6358" x2="803.3621" y2="23.2106" gradientTransform="matrix(1 0 0 -1 0 300.1305)">
+			<stop  offset="0" style="stop-color:#00315C"/>
+			<stop  offset="0.785" style="stop-color:#008AF0"/>
+		</linearGradient>
+		<path style="fill:url(#SVGID_00000112613744030261687930000010797037013502529705_);" d="M801.8,274.9h3.1v15.6h-3.1V274.9z"/>
+		
+			<linearGradient id="SVGID_00000170241006264219897460000015276179757795971203_" gradientUnits="userSpaceOnUse" x1="803.3621" y1="0.2978" x2="803.3621" y2="-15.0003" gradientTransform="matrix(1 0 0 -1 0 300.1305)">
+			<stop  offset="0" style="stop-color:#00294F"/>
+			<stop  offset="0.704" style="stop-color:#005BA6"/>
+			<stop  offset="0.828" style="stop-color:#0457AC"/>
+			<stop  offset="1" style="stop-color:#0050B2"/>
+		</linearGradient>
+		<path style="fill:url(#SVGID_00000170241006264219897460000015276179757795971203_);" d="M804.9,314.9h-3.1v-15.6h3.1V314.9z"/>
+		
+			<linearGradient id="SVGID_00000138534734544036253390000003923062125090800316_" gradientUnits="userSpaceOnUse" x1="797.5843" y1="0.2978" x2="797.5843" y2="-15.0003" gradientTransform="matrix(1 0 0 -1 0 300.1305)">
+			<stop  offset="0" style="stop-color:#00294F"/>
+			<stop  offset="0.704" style="stop-color:#005BA6"/>
+			<stop  offset="0.828" style="stop-color:#0457AC"/>
+			<stop  offset="1" style="stop-color:#0050B2"/>
+		</linearGradient>
+		<path style="fill:url(#SVGID_00000138534734544036253390000003923062125090800316_);" d="M799.1,314.9H796v-15.6h3.1V314.9z"/>
+		<path class="st96" d="M813.8,294.7c0-3.1-0.9-7-2.4-11.6c-0.3,0.9-0.9,1.7-1.3,2.3c-2.6-2.4-5.9-3.9-9.6-3.9
+			c-7.3,0-13.3,6-13.3,13.3c0,7.3,6,13.3,13.3,13.3c7.3,0,13.3-6,13.3-13.3C813.8,294.8,813.8,294.8,813.8,294.7z"/>
+		<path class="st1" d="M811.3,300.9c-3.3,4.3-10.3,2.9-14.8,3.1c0,0-0.8,0-1.6,0.1c0,0,0.3-0.1,0.7-0.2c3.1-1.1,4.7-1.3,6.6-2.3
+			c3.7-1.9,7.2-5.9,7.9-10.1c-1.3,4.1-5.6,7.6-9.3,8.9c-2.6,1-7.3,1.9-7.3,1.9l-0.2-0.1c-3.2-1.6-3.3-8.6,2.4-10.8
+			c2.6-1,5-0.4,7.8-1.1c3-0.8,6.3-2.9,7.8-5.8C812.8,289.3,814.6,296.5,811.3,300.9z"/>
+		<path class="st1" d="M792.5,305.3c0.6,0,1.1-0.5,1.1-1.1c0-0.6-0.5-1.1-1.1-1.1s-1.1,0.5-1.1,1.1
+			C791.4,304.8,791.9,305.3,792.5,305.3z"/>
+	</g>
+	<g>
+		<g>
+			
+				<linearGradient id="SVGID_00000006675867382795775240000004157247717200790714_" gradientUnits="userSpaceOnUse" x1="943.7053" y1="-44.4491" x2="943.7053" y2="-55.8923" gradientTransform="matrix(1 0 0 -1 0 300.1305)">
+				<stop  offset="0.22" style="stop-color:#50C8E9"/>
+				<stop  offset="0.47" style="stop-color:#4AC7E9"/>
+				<stop  offset="0.63" style="stop-color:#3BC4E7"/>
+				<stop  offset="0.77" style="stop-color:#2ABADE"/>
+				<stop  offset="0.89" style="stop-color:#21A5CB"/>
+				<stop  offset="1" style="stop-color:#1B8AB3"/>
+				<stop  offset="1" style="stop-color:#1B8AB3"/>
+			</linearGradient>
+			<path style="fill:url(#SVGID_00000006675867382795775240000004157247717200790714_);" d="M949.4,354c0.7,0,1.2-0.5,1.2-1.2v-0.2
+				c-0.5-3.9-2.7-7-6.9-7c-4.2,0-6.5,2.7-6.9,7c-0.1,0.7,0.4,1.3,1.1,1.4L949.4,354L949.4,354z"/>
+			<path class="st98" d="M943.7,346.5c-0.7,0-1.5-0.2-2.1-0.6l2.1,5.4l2.1-5.4C945.1,346.3,944.4,346.5,943.7,346.5z"/>
+			
+				<linearGradient id="SVGID_00000025422270488327481180000016227936426957840825_" gradientUnits="userSpaceOnUse" x1="943.3797" y1="-38.3233" x2="944.2177" y2="-48.7091" gradientTransform="matrix(1 0 0 -1 0 300.1305)">
+				<stop  offset="0.22" style="stop-color:#50C8E9"/>
+				<stop  offset="0.47" style="stop-color:#4AC7E9"/>
+				<stop  offset="0.63" style="stop-color:#3BC4E7"/>
+				<stop  offset="0.77" style="stop-color:#2ABADE"/>
+				<stop  offset="0.89" style="stop-color:#21A5CB"/>
+				<stop  offset="1" style="stop-color:#1B8AB3"/>
+				<stop  offset="1" style="stop-color:#1B8AB3"/>
+			</linearGradient>
+			<circle style="fill:url(#SVGID_00000025422270488327481180000016227936426957840825_);" cx="943.7" cy="342.7" r="3.9"/>
+			<path class="st42" d="M939.2,342.7v-4.9c0-0.1-0.1-0.2-0.1-0.2c0,0,0,0,0,0h-1.3c-0.1,0-0.2,0.1-0.2,0.2c0,0,0,0,0,0v4.7
+				c0,0.1-0.1,0.2-0.2,0.2h-1.1c-0.1,0-0.1-0.1-0.1-0.1v-1.3c0-0.1,0-0.1-0.1-0.1c0,0-0.1,0-0.1,0l-2.2,2.2c-0.1,0.1-0.1,0.2,0,0.2
+				c0,0,0,0,0,0l2.2,2.2c0,0.1,0.1,0.1,0.1,0.1s0.1-0.1,0.1-0.1l0,0v-1.3c0-0.1,0-0.1,0.1-0.1h2.7c0.1,0,0.2-0.1,0.2-0.2V342.7z"/>
+		</g>
+		<g>
+			<path class="st15" d="M948.8,323.7c0,4.4-5.3,7.9-6.4,8.6c-0.1,0.1-0.3,0.1-0.4,0c-1.2-0.7-6.4-4.2-6.4-8.6v-5.3
+				c0-0.2,0.2-0.4,0.4-0.4c4.1-0.1,3.2-1.9,6.3-1.9c3.1,0,2.1,1.8,6.3,1.9c0.2,0,0.4,0.2,0.4,0.4V323.7z"/>
+			<path class="st16" d="M948.3,323.8c0,4-4.9,7.2-5.9,7.9c-0.1,0.1-0.3,0.1-0.4,0c-1.1-0.7-5.9-3.9-5.9-7.9V319
+				c0-0.2,0.2-0.4,0.4-0.4c3.8-0.1,2.9-1.8,5.7-1.8c2.8,0,2,1.7,5.7,1.8c0.2,0,0.4,0.2,0.4,0.4V323.8z"/>
+			
+				<linearGradient id="SVGID_00000126285695663720995090000002904472438829819298_" gradientUnits="userSpaceOnUse" x1="942.1671" y1="-16.6851" x2="942.1671" y2="-31.631" gradientTransform="matrix(1 0 0 -1 0 300.1305)">
+				<stop  offset="0" style="stop-color:#5EA0EF"/>
+				<stop  offset="0.18" style="stop-color:#559CEC"/>
+				<stop  offset="0.47" style="stop-color:#3C91E5"/>
+				<stop  offset="0.84" style="stop-color:#1380DA"/>
+				<stop  offset="1" style="stop-color:#0078D4"/>
+			</linearGradient>
+			<path style="fill:url(#SVGID_00000126285695663720995090000002904472438829819298_);" d="M942.2,324.3v-7.5c2.8,0,2,1.7,5.7,1.8
+				c0.2,0,0.4,0.2,0.4,0.4v4.8c0,0.2,0,0.3,0,0.5H942.2z M942.2,324.3h-6.1c0.4,3.8,4.9,6.8,5.9,7.4c0,0,0.1,0,0.2,0.1h0V324.3z"/>
+			<path class="st18" d="M936.4,318.6c3.8-0.1,2.9-1.8,5.7-1.8v7.5h-6.1c0-0.2,0-0.3,0-0.5V319C936.1,318.8,936.2,318.6,936.4,318.6
+				z"/>
+			<path class="st18" d="M948.2,324.3h-6.1v7.5l0,0c0.1,0,0.1,0,0.2-0.1C943.4,331.1,947.9,328.1,948.2,324.3z"/>
+		</g>
+	</g>
+	<g>
+		<g>
+			
+				<linearGradient id="SVGID_00000161618725787701638590000010727584604338345902_" gradientUnits="userSpaceOnUse" x1="943.7053" y1="110.3554" x2="943.7053" y2="98.9122" gradientTransform="matrix(1 0 0 -1 0 300.1305)">
+				<stop  offset="0.22" style="stop-color:#50C8E9"/>
+				<stop  offset="0.47" style="stop-color:#4AC7E9"/>
+				<stop  offset="0.63" style="stop-color:#3BC4E7"/>
+				<stop  offset="0.77" style="stop-color:#2ABADE"/>
+				<stop  offset="0.89" style="stop-color:#21A5CB"/>
+				<stop  offset="1" style="stop-color:#1B8AB3"/>
+				<stop  offset="1" style="stop-color:#1B8AB3"/>
+			</linearGradient>
+			<path style="fill:url(#SVGID_00000161618725787701638590000010727584604338345902_);" d="M949.4,199.2c0.7,0,1.2-0.5,1.2-1.2
+				v-0.2c-0.5-3.9-2.7-7-6.9-7c-4.2,0-6.5,2.7-6.9,7c-0.1,0.7,0.4,1.3,1.1,1.4L949.4,199.2L949.4,199.2z"/>
+			<path class="st98" d="M943.7,191.7c-0.7,0-1.5-0.2-2.1-0.6l2.1,5.4l2.1-5.4C945.1,191.5,944.4,191.7,943.7,191.7z"/>
+			
+				<linearGradient id="SVGID_00000043446153553586494730000014500178954399049602_" gradientUnits="userSpaceOnUse" x1="943.3797" y1="116.4812" x2="944.2177" y2="106.0954" gradientTransform="matrix(1 0 0 -1 0 300.1305)">
+				<stop  offset="0.22" style="stop-color:#50C8E9"/>
+				<stop  offset="0.47" style="stop-color:#4AC7E9"/>
+				<stop  offset="0.63" style="stop-color:#3BC4E7"/>
+				<stop  offset="0.77" style="stop-color:#2ABADE"/>
+				<stop  offset="0.89" style="stop-color:#21A5CB"/>
+				<stop  offset="1" style="stop-color:#1B8AB3"/>
+				<stop  offset="1" style="stop-color:#1B8AB3"/>
+			</linearGradient>
+			<circle style="fill:url(#SVGID_00000043446153553586494730000014500178954399049602_);" cx="943.7" cy="187.8" r="3.9"/>
+			<path class="st42" d="M939.2,187.9V183c0-0.1-0.1-0.2-0.1-0.2c0,0,0,0,0,0h-1.3c-0.1,0-0.2,0.1-0.2,0.2c0,0,0,0,0,0v4.7
+				c0,0.1-0.1,0.2-0.2,0.2h-1.1c-0.1,0-0.1-0.1-0.1-0.1v-1.3c0-0.1,0-0.1-0.1-0.1c0,0-0.1,0-0.1,0l-2.2,2.2c-0.1,0.1-0.1,0.2,0,0.2
+				c0,0,0,0,0,0l2.2,2.2c0,0.1,0.1,0.1,0.1,0.1s0.1-0.1,0.1-0.1l0,0v-1.3c0-0.1,0-0.1,0.1-0.1h2.7c0.1,0,0.2-0.1,0.2-0.2V187.9z"/>
+		</g>
+		<g>
+			<path class="st15" d="M948.8,168.9c0,4.4-5.3,7.9-6.4,8.6c-0.1,0.1-0.3,0.1-0.4,0c-1.2-0.7-6.4-4.2-6.4-8.6v-5.3
+				c0-0.2,0.2-0.4,0.4-0.4c4.1-0.1,3.2-1.9,6.3-1.9c3.1,0,2.1,1.8,6.3,1.9c0.2,0,0.4,0.2,0.4,0.4V168.9z"/>
+			<path class="st16" d="M948.3,169c0,4-4.9,7.2-5.9,7.9c-0.1,0.1-0.3,0.1-0.4,0c-1.1-0.7-5.9-3.9-5.9-7.9v-4.8
+				c0-0.2,0.2-0.4,0.4-0.4c3.8-0.1,2.9-1.8,5.7-1.8c2.8,0,2,1.7,5.7,1.8c0.2,0,0.4,0.2,0.4,0.4V169z"/>
+			
+				<linearGradient id="SVGID_00000090982485442614818950000007020008429385259924_" gradientUnits="userSpaceOnUse" x1="942.1671" y1="138.1194" x2="942.1671" y2="123.1735" gradientTransform="matrix(1 0 0 -1 0 300.1305)">
+				<stop  offset="0" style="stop-color:#5EA0EF"/>
+				<stop  offset="0.18" style="stop-color:#559CEC"/>
+				<stop  offset="0.47" style="stop-color:#3C91E5"/>
+				<stop  offset="0.84" style="stop-color:#1380DA"/>
+				<stop  offset="1" style="stop-color:#0078D4"/>
+			</linearGradient>
+			<path style="fill:url(#SVGID_00000090982485442614818950000007020008429385259924_);" d="M942.2,169.5V162c2.8,0,2,1.7,5.7,1.8
+				c0.2,0,0.4,0.2,0.4,0.4v4.8c0,0.2,0,0.3,0,0.5H942.2z M942.2,169.5h-6.1c0.4,3.8,4.9,6.8,5.9,7.4c0,0,0.1,0,0.2,0.1h0V169.5z"/>
+			<path class="st18" d="M936.4,163.8c3.8-0.1,2.9-1.8,5.7-1.8v7.5h-6.1c0-0.2,0-0.3,0-0.5v-4.8C936.1,164,936.2,163.8,936.4,163.8z
+				"/>
+			<path class="st18" d="M948.2,169.5h-6.1v7.5l0,0c0.1,0,0.1,0,0.2-0.1C943.4,176.3,947.9,173.3,948.2,169.5z"/>
+		</g>
+	</g>
+	<g>
+		<g>
+			<path class="st104" d="M660.4,350.3l-6.4,6.4c-0.1,0.1-0.3,0.2-0.4,0.1c0,0,0,0-0.1-0.1l-6.4-6.4c-0.1-0.1-0.1-0.4,0-0.5
+				c0.1-0.1,0.1-0.1,0.2-0.1h3.7c0.2,0,0.3-0.1,0.3-0.3c0,0,0-0.1,0-0.1v-8.2c0-0.2,0.2-0.3,0.3-0.3c0,0,0,0,0,0h3.9
+				c0.2,0,0.3,0.1,0.3,0.3v8.2c0,0.2,0.1,0.3,0.3,0.3c0,0,0,0,0,0h3.7c0.2-0.1,0.4,0,0.4,0.2C660.6,350,660.5,350.2,660.4,350.3
+				L660.4,350.3z"/>
+			<path class="st104" d="M668.7,376.5l-6-10.4c-0.5-0.9-1.8-1.6-2.8-1.6h-12c-1,0-2.3,0.7-2.8,1.6l-6,10.4c-0.5,0.9-0.5,2.4,0,3.3
+				l6,10.4c0.5,0.9,1.8,1.6,2.8,1.6h12c1,0,2.3-0.7,2.8-1.6l6-10.4C669.2,378.9,669.2,377.4,668.7,376.5z M652.5,370.2
+				c0-0.7,0.6-1.2,1.2-1.2c0.7,0,1.2,0.6,1.2,1.2v7.4c0,0.7-0.6,1.2-1.2,1.2c-0.7,0-1.2-0.6-1.2-1.2V370.2z M653.8,386
+				c-4.6,0-8.4-3.8-8.4-8.4c0-2.6,1.3-5.2,3.4-6.7c0.5-0.4,1.2-0.3,1.5,0.2c0.4,0.5,0.3,1.2-0.2,1.5c-1.6,1.2-2.5,3-2.5,5
+				c0,3.4,2.8,6.2,6.2,6.2c3.4,0,6.2-2.8,6.2-6.2c0-2-0.9-3.8-2.5-5c-0.5-0.4-0.6-1-0.2-1.5c0.4-0.5,1-0.6,1.5-0.2
+				c2.1,1.6,3.4,4.1,3.4,6.7C662.2,382.3,658.4,386,653.8,386z"/>
+		</g>
+		<g>
+			<circle cx="793.8" cy="377.3" r="2.5"/>
+			<circle cx="801.3" cy="377.3" r="2.5"/>
+			<circle cx="808.9" cy="377.3" r="2.5"/>
+		</g>
+		<g>
+			<path class="st104" d="M734.1,350.3l-6.4,6.4c-0.1,0.1-0.3,0.2-0.4,0.1c0,0,0,0-0.1-0.1l-6.4-6.4c-0.1-0.1-0.1-0.4,0-0.5
+				c0.1-0.1,0.1-0.1,0.2-0.1h3.7c0.2,0,0.3-0.1,0.3-0.3c0,0,0-0.1,0-0.1v-8.2c0-0.2,0.2-0.3,0.3-0.3c0,0,0,0,0,0h3.9
+				c0.2,0,0.3,0.1,0.3,0.3v8.2c0,0.2,0.1,0.3,0.3,0.3c0,0,0,0,0,0h3.7c0.2-0.1,0.4,0,0.4,0.2C734.4,350,734.3,350.2,734.1,350.3
+				L734.1,350.3z"/>
+			<path class="st104" d="M742.4,376.5l-6-10.4c-0.5-0.9-1.8-1.6-2.8-1.6h-12c-1,0-2.3,0.7-2.8,1.6l-6,10.4c-0.5,0.9-0.5,2.4,0,3.3
+				l6,10.4c0.5,0.9,1.8,1.6,2.8,1.6h12c1,0,2.3-0.7,2.8-1.6l6-10.4C742.9,378.9,742.9,377.4,742.4,376.5z M726.3,370.2
+				c0-0.7,0.6-1.2,1.2-1.2c0.7,0,1.2,0.6,1.2,1.2v7.4c0,0.7-0.6,1.2-1.2,1.2c-0.7,0-1.2-0.6-1.2-1.2V370.2z M727.5,386
+				c-4.6,0-8.4-3.8-8.4-8.4c0-2.6,1.3-5.2,3.4-6.7c0.5-0.4,1.2-0.3,1.5,0.2c0.4,0.5,0.3,1.2-0.2,1.5c-1.6,1.2-2.5,3-2.5,5
+				c0,3.4,2.8,6.2,6.2,6.2c3.4,0,6.2-2.8,6.2-6.2c0-2-0.9-3.8-2.5-5c-0.5-0.4-0.6-1-0.2-1.5c0.4-0.5,1-0.6,1.5-0.2
+				c2.1,1.6,3.4,4.1,3.4,6.7C735.9,382.3,732.2,386,727.5,386z"/>
+		</g>
+		<path class="st104" d="M889.9,376.5l-6-10.4c-0.5-0.9-1.8-1.6-2.8-1.6h-12c-1,0-2.3,0.7-2.8,1.6l-6,10.4c-0.5,0.9-0.5,2.4,0,3.3
+			l6,10.4c0.5,0.9,1.8,1.6,2.8,1.6h12c1,0,2.3-0.7,2.8-1.6l6-10.4C890.4,378.9,890.4,377.4,889.9,376.5z M873.8,370.2
+			c0-0.7,0.6-1.2,1.2-1.2c0.7,0,1.2,0.6,1.2,1.2v7.4c0,0.7-0.6,1.2-1.2,1.2c-0.7,0-1.2-0.6-1.2-1.2V370.2z M875,386
+			c-4.6,0-8.4-3.8-8.4-8.4c0-2.6,1.3-5.2,3.4-6.7c0.5-0.4,1.2-0.3,1.5,0.2c0.4,0.5,0.3,1.2-0.2,1.5c-1.6,1.2-2.5,3-2.5,5
+			c0,3.4,2.8,6.2,6.2,6.2c3.4,0,6.2-2.8,6.2-6.2c0-2-0.9-3.8-2.5-5c-0.5-0.4-0.6-1-0.2-1.5c0.4-0.5,1-0.6,1.5-0.2
+			c2.1,1.6,3.4,4.1,3.4,6.7C883.4,382.3,879.7,386,875,386z"/>
+	</g>
+	<g>
+		<text transform="matrix(1 0 0 1 732.3201 418.1927)" class="st105 st106 st107">Private FQDN</text>
+	</g>
+	<text transform="matrix(1 0 0 1 578.6876 171.589)" class="st105 st106 st108">Service Runtime subnet</text>
+	<text transform="matrix(1 0 0 1 583.6872 327.6888)" class="st105 st106 st108">Apps subnet</text>
+	<rect x="606.6" y="289" class="st84" width="153.2" height="19.8"/>
+	<text transform="matrix(1 0 0 1 628.5444 300.0872)" class="st105 st109 st110">Azure Spring Apps </text>
+	<g>
+		<rect x="982.1" y="151.2" class="st1" width="125" height="279.5"/>
+		<rect x="982.1" y="151.2" class="st14" width="125" height="279.5"/>
+	</g>
+	<g>
+		
+			<linearGradient id="SVGID_00000083799809176688289080000011429276884150516360_" gradientUnits="userSpaceOnUse" x1="1034.4265" y1="78.8615" x2="1052.6083" y2="78.8615" gradientTransform="matrix(1 0 0 -1 0 300.1305)">
+			<stop  offset="0" style="stop-color:#005CA1"/>
+			<stop  offset="7.000000e-02" style="stop-color:#0161AA"/>
+			<stop  offset="0.36" style="stop-color:#2571B8"/>
+			<stop  offset="0.52" style="stop-color:#2E76BC"/>
+			<stop  offset="0.64" style="stop-color:#2973BA"/>
+			<stop  offset="0.82" style="stop-color:#166BB5"/>
+			<stop  offset="1" style="stop-color:#005CA1"/>
+		</linearGradient>
+		<path style="fill:url(#SVGID_00000083799809176688289080000011429276884150516360_);" d="M1043.6,214.1c-5,0-9.1-1.5-9.1-3.3v17.5
+			c0,1.8,4,3.3,9,3.3h0.2c5,0,9.1-1.5,9.1-3.3v-17.5C1052.6,212.7,1048.6,214.1,1043.6,214.1z"/>
+		<path class="st80" d="M1052.6,210.9c0,1.8-4.1,3.3-9.1,3.3s-9.1-1.5-9.1-3.3c0-1.8,4.2-3.3,9.1-3.3
+			C1048.6,207.6,1052.7,209,1052.6,210.9"/>
+		<path class="st39" d="M1050.5,210.6c0,1.1-3.1,2.1-7,2.1s-7-0.9-7-2.1c0-1.1,3.1-2.1,7-2.1
+			C1047.5,208.5,1050.5,209.4,1050.5,210.6"/>
+		<path class="st81" d="M1043.6,211.1c-1.9,0-3.7,0.2-5.5,0.8c1.8,0.6,3.6,0.9,5.5,0.8c1.9,0,3.7-0.2,5.5-0.8
+			C1047.3,211.3,1045.4,211,1043.6,211.1z"/>
+	</g>
+	<g>
+		<g>
+			<path class="st112" d="M1084.5,385.3c-0.1,0-0.2,0.2-0.2,0.3c0,0.7,0,2.5,0,3.7c0,0,0.1,0.1,0.1,0.1c0.3,0,0.9,0,1.4,0
+				c0.7,0,1.2-0.1,1.4-0.2c0.6-0.3,0.9-1,0.9-1.7c0-1.7-1.2-2.3-2.9-2.3C1085.1,385.2,1084.8,385.2,1084.5,385.3L1084.5,385.3
+				L1084.5,385.3z M1088.9,392.9c0-1.7-1.2-2.6-3.5-2.6c-0.1,0-0.8,0-1,0c-0.1,0-0.1,0.1-0.1,0.1c0,1.2,0,3.1,0,3.9
+				c0,0.3,0.3,0.8,0.6,0.9c0.3,0.2,1,0.2,1.5,0.2C1087.7,395.4,1088.9,394.7,1088.9,392.9L1088.9,392.9L1088.9,392.9z M1081,384.3
+				c0.2,0,0.7,0.1,2,0.1c1.2,0,2.2,0,3.5,0c1.5,0,3.5,0.5,3.5,2.8c0,1.1-0.8,2-1.8,2.4c-0.1,0-0.1,0.1,0,0.1
+				c1.4,0.4,2.7,1.2,2.7,2.9c0,1.6-1,2.7-2.5,3.3c-0.9,0.4-2,0.5-3.2,0.5c-0.9,0-3.2-0.1-4.5-0.1c-0.1-0.1,0.1-0.7,0.2-0.8
+				c0.3,0,0.5,0,0.9-0.1c0.5-0.1,0.5-0.3,0.6-1c0-0.6,0-2.7,0-4.2c0-2.1,0-3.5,0-4.2c0-0.5-0.2-0.7-0.6-0.8
+				c-0.3-0.1-0.8-0.1-1.2-0.2C1080.6,385,1080.9,384.4,1081,384.3L1081,384.3L1081,384.3z M1071.1,395c0.4,0.3,1.2,0.5,1.9,0.5
+				c0.9,0,1.8-0.2,2.7-1c0.9-0.8,1.5-2.1,1.5-4.1c0-1.9-0.7-3.5-2.2-4.4c-0.9-0.5-1.9-0.8-3.2-0.8c-0.4,0-0.7,0-1,0.1
+				c-0.1,0-0.2,0.2-0.2,0.3c0,0.3,0,3,0,4.5c0,1.6,0,3.8,0,4.1C1070.8,394.4,1070.9,394.8,1071.1,395L1071.1,395L1071.1,395z
+				 M1067.3,384.3c0.3,0,1.6,0.1,2.2,0.1c1.1,0,1.8-0.1,3.9-0.1c1.7,0,3.1,0.5,4.2,1.3c1.2,1.1,1.9,2.6,1.9,4.4
+				c0,2.6-1.2,4.1-2.4,4.9c-1.2,0.9-2.7,1.4-4.9,1.4c-1.2,0-3.2,0-4.8-0.1h0c-0.1-0.2,0.1-0.8,0.3-0.8c0.4-0.1,0.6-0.1,0.8-0.2
+				c0.4-0.1,0.4-0.3,0.5-1c0.1-1.2,0-2.6,0-4.2c0-1.1,0-3.4,0-4.1c-0.1-0.6-0.3-0.8-0.8-0.9c-0.3-0.1-0.6-0.1-1.1-0.2
+				C1066.9,385,1067.2,384.4,1067.3,384.3L1067.3,384.3L1067.3,384.3z"/>
+			<path class="st113" d="M1046.6,395.6c-0.4-0.1-0.7-0.1-1.1-0.3c-0.1,0-0.1-0.2-0.1-0.3c0-0.6,0-2.3,0-3.5c0-0.9-0.2-1.7-0.5-2.3
+				c-0.5-0.6-1.1-1-2-1c-0.8,0-1.8,0.5-2.6,1.2c0,0-0.2,0.1-0.1-0.1c0-0.2,0-0.6,0.1-0.8c0-0.2-0.1-0.4-0.1-0.4
+				c-0.5,0.3-2.1,0.6-2.7,0.7c-0.4,0.1-0.5,0.5-0.1,0.6h0c0.5,0.1,0.8,0.3,1,0.4c0.2,0.1,0.2,0.3,0.2,0.5c0,1.3,0,3.2,0,4.3
+				c0,0.4-0.1,0.6-0.4,0.6l0,0c-0.2,0.1-0.4,0.1-0.7,0.1c-0.1,0.1-0.1,0.6,0,0.8c0.2,0,1.2-0.1,2-0.1c1.1,0,1.7,0.1,2,0.1
+				c0.1-0.1,0.2-0.6,0.1-0.8c-0.3,0-0.6-0.1-0.8-0.1c-0.3-0.1-0.4-0.2-0.4-0.6c0-0.9,0-2.8,0-4.1c0-0.4,0.1-0.5,0.2-0.6
+				c0.4-0.3,1-0.6,1.6-0.6c0.5,0,0.9,0.2,1.2,0.4c0.4,0.3,0.5,0.8,0.5,1.1c0.1,0.7,0.1,2.2,0.1,3.5c0,0.7-0.1,0.9-0.3,0.9
+				c-0.1,0.1-0.4,0.1-0.8,0.2c-0.1,0.1-0.1,0.6,0,0.8c0.5,0,1.1-0.1,1.9-0.1c1.1,0,1.7,0.1,2,0.1
+				C1046.6,396.3,1046.6,395.8,1046.6,395.6L1046.6,395.6L1046.6,395.6z M1051.3,389.1c-0.9,0-1.5,0.7-1.5,1.8
+				c0,1.1,0.5,2.4,1.9,2.4c0.2,0,0.7-0.1,0.9-0.3c0.3-0.3,0.5-0.9,0.5-1.6C1053.2,390,1052.5,389.1,1051.3,389.1L1051.3,389.1
+				L1051.3,389.1z M1051.2,396.7c-0.3,0-0.6,0.1-0.7,0.2c-0.7,0.5-1,0.9-1,1.4c0,0.5,0.2,0.9,0.6,1.2c0.5,0.4,1.2,0.6,2.1,0.6
+				c1.7,0,2.5-0.9,2.5-1.9c0-0.6-0.3-1.1-1-1.3C1053.1,396.8,1052.2,396.7,1051.2,396.7L1051.2,396.7L1051.2,396.7z M1051.3,401.1
+				c-1,0-1.8-0.2-2.4-0.7c-0.6-0.5-0.9-1.2-0.9-1.7c0-0.1,0-0.5,0.3-0.9c0.2-0.2,0.6-0.6,1.6-1.3c0,0,0.1,0,0.1-0.1s0-0.1-0.1-0.1
+				c-0.8-0.3-1-0.8-1.1-1.1v0c0-0.1-0.1-0.2,0.1-0.3c0.1-0.1,0.3-0.2,0.5-0.3c0.3-0.2,0.6-0.4,0.8-0.5c0,0,0-0.1,0-0.1
+				s0-0.1-0.1-0.1c-1.2-0.4-1.8-1.3-1.8-2.6c0-0.9,0.4-1.7,1.1-2.2c0.5-0.4,1.7-0.8,2.5-0.8h0.1c0.8,0,1.2,0.2,1.9,0.4
+				c0.3,0.1,0.7,0.2,1.1,0.2c0.7,0,1-0.2,1.2-0.4c0,0,0.1,0.1,0.1,0.3c0,0.2-0.1,0.5-0.2,0.8c-0.1,0.2-0.4,0.3-0.8,0.3h-0.1
+				c-0.3,0-0.4-0.1-0.4-0.1l-0.1,0c0,0,0,0.1,0,0.1l0,0c0,0.2,0.1,0.6,0.1,0.7c0,1.4-0.6,2-1.2,2.5c-0.6,0.4-1.2,0.7-2,0.8
+				c0,0-0.1,0-0.2,0c-0.1,0-0.2,0-0.2,0h0c-0.1,0-0.5,0.2-0.5,0.5c0,0.3,0.2,0.6,0.9,0.6c0.2,0,0.3,0,0.5,0c1,0.1,2.2,0.2,2.8,0.3
+				c0.8,0.3,1.3,1,1.3,1.8c0,1.3-0.9,2.4-2.4,3.2C1052.9,400.9,1052.1,401.1,1051.3,401.1L1051.3,401.1L1051.3,401.1z M1061.1,389.2
+				c-0.4,0-0.7,0.1-0.9,0.3c-0.7,0.4-1,1.2-1,2.4c0,2.2,1.1,3.8,2.7,3.8c0.5,0,0.9-0.1,1.2-0.4c0.5-0.4,0.8-1.2,0.8-2.4
+				C1063.8,390.7,1062.7,389.2,1061.1,389.2L1061.1,389.2L1061.1,389.2z M1061.4,396.5c-2.9,0-4-2.1-4-4.1c0-1.4,0.6-2.5,1.7-3.2
+				c0.8-0.5,1.8-0.8,2.6-0.8c2.2,0,3.8,1.6,3.8,3.9c0,1.6-0.6,2.8-1.8,3.5C1063.1,396.2,1062.2,396.5,1061.4,396.5L1061.4,396.5
+				L1061.4,396.5z M1030.9,389.2c-0.4,0-0.7,0.1-0.9,0.3c-0.7,0.4-1,1.2-1,2.4c0,2.2,1.1,3.8,2.7,3.8c0.5,0,0.9-0.1,1.2-0.4
+				c0.5-0.4,0.8-1.2,0.8-2.4C1033.6,390.7,1032.5,389.2,1030.9,389.2L1030.9,389.2L1030.9,389.2z M1031.2,396.5c-2.9,0-4-2.1-4-4.1
+				c0-1.4,0.6-2.5,1.7-3.2c0.8-0.5,1.8-0.8,2.6-0.8c2.2,0,3.8,1.6,3.8,3.9c0,1.6-0.6,2.8-1.8,3.5
+				C1033,396.2,1032,396.5,1031.2,396.5L1031.2,396.5L1031.2,396.5z M1011.7,396.3c0-0.1-0.1-0.2-0.1-0.4c0-0.1,0-0.2,0.1-0.3
+				c0.4-0.1,0.5-0.1,0.8-0.2c0.3-0.1,0.5-0.3,0.5-0.7c0.1-1,0.1-3,0-4.3v0c0-0.2,0-0.3-0.2-0.5c-0.3-0.2-0.6-0.3-1-0.4
+				c-0.2-0.1-0.3-0.1-0.2-0.2c0-0.1,0.1-0.2,0.3-0.3c0.6-0.1,2-0.4,2.6-0.7c0,0,0.1,0.1,0.1,0.3l0,0.2c0,0.2,0,0.4,0,0.6
+				c0,0.1,0.1,0.1,0.1,0.1c0,0,0.1,0,0.1,0c1.1-0.9,2.1-1.2,2.6-1.2c0.8,0,1.5,0.4,2,1.2c0,0.1,0.1,0.1,0.1,0.1c0,0,0.1,0,0.1-0.1
+				c1-0.8,2-1.2,2.7-1.2c1.6,0,2.5,1.2,2.5,3.2c0,0.6,0,1.3,0,2c0,0.6,0,1.1,0,1.5c0,0.1,0.1,0.4,0.3,0.4c0.2,0.1,0.6,0.2,1,0.2h0
+				c0,0.1,0,0.6-0.1,0.6c-0.1,0-0.3,0-0.4,0c-0.3,0-0.8,0-1.3,0c-1.1,0-1.6,0-2.1,0.1c0-0.1-0.1-0.5,0-0.6c0.3-0.1,0.5-0.1,0.6-0.2
+				c0.3-0.1,0.4-0.3,0.4-0.7c0-0.3,0.1-3.1,0-3.8c-0.1-0.7-0.6-1.5-1.7-1.5c-0.4,0-1.1,0.2-1.7,0.7c0,0-0.1,0.1-0.1,0.2v0
+				c0.1,0.4,0.1,0.8,0.1,1.4v1.1c0,0.8,0,1.5,0,2c0,0.4,0.2,0.5,0.4,0.5c0.1,0,0.2,0,0.3,0.1c0.2,0,0.3,0.1,0.5,0.1
+				c0,0.1,0,0.3,0,0.5c0,0.1-0.1,0.2-0.1,0.2c-0.6,0-1.2,0-2.1,0c-0.3,0-0.7,0-1.1,0c-0.3,0-0.6,0-0.8,0c0,0-0.1-0.2-0.1-0.3
+				c0-0.2,0-0.3,0.1-0.3c0.1,0,0.2,0,0.2,0c0.2,0,0.4-0.1,0.5-0.1c0.3-0.1,0.4-0.2,0.4-0.6c0.1-0.9,0.1-3.3,0-3.9
+				c-0.2-1-0.8-1.5-1.7-1.5c-0.5,0-1.2,0.3-1.7,0.7c-0.1,0.1-0.2,0.2-0.2,0.4v1c0,1.2,0,2.8,0,3.4c0,0.2,0.1,0.4,0.5,0.5
+				c0.1,0,0.2,0.1,0.4,0.1l0.3,0.1c0,0.1,0,0.5-0.1,0.6c-0.2,0-0.4,0-0.6,0c-0.4,0-0.8,0-1.3,0c-0.6,0-1,0-1.4,0
+				C1012.1,396.3,1011.9,396.3,1011.7,396.3L1011.7,396.3L1011.7,396.3z"/>
+			<g>
+				<path class="st114" d="M1002.7,400.5l-0.7-0.2c0,0,0.1-3.6-1.2-3.8c-0.9-1,0.1-42.1,3.2-0.1c0,0-1.1,0.5-1.2,1.4
+					C1002.5,398.6,1002.7,400.5,1002.7,400.5L1002.7,400.5L1002.7,400.5z"/>
+				<path class="st115" d="M1002.7,400.5l-0.7-0.2c0,0,0.1-3.6-1.2-3.8c-0.9-1,0.1-42.1,3.2-0.1c0,0-1.1,0.5-1.2,1.4
+					C1002.5,398.6,1002.7,400.5,1002.7,400.5L1002.7,400.5L1002.7,400.5z"/>
+				<path class="st114" d="M1003,397c0,0,6.1-4,4.7-12.4c-1.4-6.1-4.7-8.1-5-8.9c-0.4-0.5-0.8-1.5-0.8-1.5l0.3,17
+					C1002.2,391.2,1001.7,396.4,1003,397"/>
+				<path class="st116" d="M1003,397c0,0,6.1-4,4.7-12.4c-1.4-6.1-4.7-8.1-5-8.9c-0.4-0.5-0.8-1.5-0.8-1.5l0.3,17
+					C1002.2,391.2,1001.7,396.4,1003,397"/>
+				<path class="st114" d="M1001.6,397.2c0,0-5.8-3.9-5.4-10.9c0.3-6.9,4.4-10.3,5.2-10.9c0.5-0.5,0.5-0.8,0.6-1.3
+					c0.4,0.8,0.3,11.5,0.3,12.8C1002.4,391.8,1002,396.3,1001.6,397.2L1001.6,397.2L1001.6,397.2z"/>
+				<path class="st117" d="M1001.6,397.2c0,0-5.8-3.9-5.4-10.9c0.3-6.9,4.4-10.3,5.2-10.9c0.5-0.5,0.5-0.8,0.6-1.3
+					c0.4,0.8,0.3,11.5,0.3,12.8C1002.4,391.8,1002,396.3,1001.6,397.2L1001.6,397.2L1001.6,397.2z"/>
+			</g>
+		</g>
+	</g>
+	<g>
+		<rect x="990.7" y="159.7" class="st84" width="109.4" height="35.4"/>
+		<text transform="matrix(1 0 0 1 990.7248 171.5887)"><tspan x="0" y="0" class="st105 st106 st108">Data Services </tspan><tspan x="0" y="16.8" class="st105 st106 st108">subnet</tspan></text>
+	</g>
+	<g>
+		<rect x="1015.5" y="237.5" class="st84" width="56" height="34.9"/>
+		<text transform="matrix(1 0 0 1 1032.3986 246.814)"><tspan x="0" y="0" class="st105 st106 st107">Data </tspan><tspan x="-7.3" y="13.2" class="st105 st106 st107">services</tspan></text>
+	</g>
+	<rect x="1008.3" y="324.1" class="st84" width="70.5" height="34.9"/>
+	<text transform="matrix(1 0 0 1 1009.4583 333.4669)"><tspan x="0" y="0" class="st105 st106 st107">Azure Cosmos </tspan><tspan x="27.1" y="13.2" class="st105 st106 st107">DB</tspan></text>
+	<g>
+		<g>
+			<line class="st118" x1="974.6" y1="371.2" x2="957.9" y2="371.2"/>
+			<g>
+				<polygon class="st8" points="973.5,367.4 979.9,371.2 973.5,374.9 				"/>
+			</g>
+		</g>
+	</g>
+	<g>
+		<path class="st39" d="M1032.9,297.6c-0.2,0-0.3-0.1-0.3-0.3l0,0c0-2-1.6-3.5-3.5-3.5c-0.2,0-0.3-0.1-0.3-0.3l0,0
+			c0-0.2,0.1-0.3,0.3-0.3l0,0c2,0,3.5-1.6,3.5-3.5c0-0.2,0.1-0.3,0.3-0.4c0,0,0,0,0,0l0,0c0.2,0,0.3,0.1,0.3,0.3l0,0l0,0
+			c0,2,1.6,3.5,3.5,3.5l0,0c0.2,0,0.3,0.1,0.3,0.3l0,0c0,0.2-0.1,0.3-0.3,0.3l0,0c-2,0-3.5,1.6-3.5,3.5
+			C1033.3,297.4,1033.1,297.5,1032.9,297.6C1032.9,297.6,1032.9,297.6,1032.9,297.6z"/>
+		<path class="st39" d="M1055.3,319.2c-0.1,0-0.2-0.1-0.2-0.2l0,0c0-1.6-1.3-2.9-2.9-2.9c-0.1,0-0.2-0.1-0.2-0.2l0,0l0,0
+			c0-0.1,0.1-0.2,0.2-0.2l0,0l0,0c1.6,0,2.9-1.3,2.9-2.9c0-0.1,0.1-0.2,0.2-0.2l0,0l0,0c0.1,0,0.2,0.1,0.2,0.2l0,0l0,0
+			c0,1.6,1.3,2.9,2.9,2.9l0,0c0.1,0,0.2,0.1,0.2,0.2c0,0.1-0.1,0.2-0.2,0.2l0,0c-1.6,0-2.9,1.3-2.9,2.9l0,0
+			C1055.5,319.1,1055.4,319.2,1055.3,319.2L1055.3,319.2z"/>
+		
+			<radialGradient id="SVGID_00000112594917079690843310000015735284063964210579_" cx="886.6058" cy="31.1833" r="10.5496" gradientTransform="matrix(1.04 0 0 -1.03 120.6462 336.1524)" gradientUnits="userSpaceOnUse">
+			<stop  offset="0.18" style="stop-color:#699CD3"/>
+			<stop  offset="1" style="stop-color:#2E76BC"/>
+		</radialGradient>
+		<path style="fill:url(#SVGID_00000112594917079690843310000015735284063964210579_);" d="M1054.2,301.6c1.4,5.8-2.2,11.7-8,13.1
+			c-5.8,1.4-11.7-2.2-13.1-8c-1.4-5.8,2.2-11.7,8-13.1C1046.9,292.1,1052.7,295.7,1054.2,301.6
+			C1054.2,301.5,1054.2,301.6,1054.2,301.6z"/>
+		<g>
+			<defs>
+				<path id="SVGID_00000168797246056403961510000002534136216572777659_" d="M1054.2,301.6c1.4,5.8-2.2,11.7-8,13.1
+					c-5.8,1.4-11.7-2.2-13.1-8c-1.4-5.8,2.2-11.7,8-13.1C1046.9,292.1,1052.7,295.7,1054.2,301.6
+					C1054.2,301.5,1054.2,301.6,1054.2,301.6z"/>
+			</defs>
+			<clipPath id="SVGID_00000039108823972008670590000011506019052138478220_">
+				<use xlink:href="#SVGID_00000168797246056403961510000002534136216572777659_"  style="overflow:visible;"/>
+			</clipPath>
+			<g style="clip-path:url(#SVGID_00000039108823972008670590000011506019052138478220_);">
+				<path class="st121" d="M1037.7,311.5c1.6,0,2.9-1.3,2.9-2.9c0-1.6-1.3-2.9-2.9-2.9c0,0,0,0,0,0c0-0.1,0-0.2,0-0.2
+					c0-1.6-1.3-2.9-2.9-2.9h-2.2c-0.1,1.4,0,2.7,0.3,4c0.4,1.8,1.3,3.5,2.6,4.9H1037.7z"/>
+				<path class="st121" d="M1054.2,302.1L1054.2,302.1c-0.4-1.9-1.2-3.7-2.5-5.1c-0.2-0.1-0.3-0.1-0.5-0.2c-1.7-0.5-3.5,0.5-4,2.2
+					c-0.1,0.2-0.1,0.5-0.1,0.7h-0.4c-1.7,0-3,1.4-3,3.1c0,1.3,0.8,2.5,2,2.9c0.3,0.1,0.6,0.2,1,0.2h3.5
+					C1051.7,304.7,1053,303.5,1054.2,302.1z"/>
+			</g>
+		</g>
+		<path class="st39" d="M1058.1,295c-1.1-1.9-3.7-2.6-7.4-2c-1.2,0.2-2.4,0.5-3.6,0.8c1,0.3,1.9,0.8,2.7,1.4l1.3-0.3
+			c0.6-0.1,1.3-0.2,2-0.2c1.8,0,3,0.4,3.5,1.3l0,0c0.7,1.1,0.1,3.1-1.6,5.3c-2.3,2.9-5.2,5.3-8.4,7.2c-3.2,2-6.8,3.3-10.5,4
+			c-2.8,0.4-4.8,0-5.4-1.1c-0.7-1.1-0.1-3.1,1.6-5.3c0.2-0.3,0.3-0.4,0.5-0.7c-0.1-1-0.1-2,0.1-3c-0.8,0.8-1.5,1.6-2.1,2.5
+			c-2.2,2.9-2.8,5.6-1.7,7.4c1.2,1.6,3.2,2.4,5.1,2.2c0.8,0,1.5-0.1,2.3-0.2c3.9-0.7,7.7-2.2,11-4.3c3.4-2,6.4-4.6,8.9-7.7
+			C1058.6,299.5,1059.2,296.9,1058.1,295z"/>
+	</g>
+	<g>
+		
+			<linearGradient id="SVGID_00000119833097681445850800000015821384875949326258_" gradientUnits="userSpaceOnUse" x1="579.4418" y1="-166.3035" x2="581.8105" y2="-168.6723" gradientTransform="matrix(1 -1.396263e-03 -1.396263e-03 -1 2.7925 299.629)">
+			<stop  offset="0" style="stop-color:#86D633"/>
+			<stop  offset="0.24" style="stop-color:#83D232"/>
+			<stop  offset="0.5" style="stop-color:#7CC52F"/>
+			<stop  offset="0.76" style="stop-color:#6FB02A"/>
+			<stop  offset="1" style="stop-color:#5E9624"/>
+		</linearGradient>
+		<circle style="fill:url(#SVGID_00000119833097681445850800000015821384875949326258_);" cx="583.6" cy="466.3" r="1.7"/>
+		
+			<linearGradient id="SVGID_00000008863192993857430380000004190067238178545552_" gradientUnits="userSpaceOnUse" x1="574.0992" y1="-166.3034" x2="576.4529" y2="-168.6715" gradientTransform="matrix(1 -1.396263e-03 -1.396263e-03 -1 2.7925 299.629)">
+			<stop  offset="0" style="stop-color:#86D633"/>
+			<stop  offset="0.24" style="stop-color:#83D232"/>
+			<stop  offset="0.5" style="stop-color:#7CC52F"/>
+			<stop  offset="0.76" style="stop-color:#6FB02A"/>
+			<stop  offset="1" style="stop-color:#5E9624"/>
+		</linearGradient>
+		<circle style="fill:url(#SVGID_00000008863192993857430380000004190067238178545552_);" cx="578.3" cy="466.3" r="1.7"/>
+		
+			<linearGradient id="SVGID_00000084492258134679502750000003960620314959506835_" gradientUnits="userSpaceOnUse" x1="568.7603" y1="-166.2997" x2="571.114" y2="-168.6678" gradientTransform="matrix(1 -1.396263e-03 -1.396263e-03 -1 2.7925 299.629)">
+			<stop  offset="0" style="stop-color:#86D633"/>
+			<stop  offset="0.24" style="stop-color:#83D232"/>
+			<stop  offset="0.5" style="stop-color:#7CC52F"/>
+			<stop  offset="0.76" style="stop-color:#6FB02A"/>
+			<stop  offset="1" style="stop-color:#5E9624"/>
+		</linearGradient>
+		<circle style="fill:url(#SVGID_00000084492258134679502750000003960620314959506835_);" cx="573" cy="466.3" r="1.7"/>
+		<path class="st18" d="M574.2,473l-1,1c-0.2,0.2-0.4,0.2-0.6,0l0,0l-7.1-7.1c-0.3-0.3-0.3-0.9,0-1.2l0,0l1-1l0,0l7.7,7.7
+			C574.3,472.6,574.3,472.8,574.2,473L574.2,473z"/>
+		<path class="st22" d="M573.1,458.7l1,1c0.2,0.2,0.2,0.4,0,0.6l-7.6,7.6l0,0l-1-1c-0.3-0.3-0.3-0.9,0-1.2l0,0l7-7
+			C572.6,458.5,572.9,458.5,573.1,458.7z"/>
+		<path class="st18" d="M590,464.7l1,1c0.3,0.3,0.3,0.9,0,1.2l0,0l-7.1,7.1c-0.2,0.2-0.4,0.2-0.6,0l0,0l-1-1c-0.2-0.2-0.2-0.4,0-0.6
+			l0,0L590,464.7L590,464.7z"/>
+		<path class="st22" d="M591,466.9l-1,1l0,0l-7.6-7.6c-0.2-0.2-0.2-0.4,0-0.6l0,0l1-1c0.2-0.2,0.4-0.2,0.6,0l0,0l7,7
+			C591.3,466,591.3,466.5,591,466.9L591,466.9L591,466.9z"/>
+	</g>
+	<g>
+		
+			<linearGradient id="SVGID_00000014634157408814489930000008218126733339281318_" gradientUnits="userSpaceOnUse" x1="608.3003" y1="78.1875" x2="608.3003" y2="112.9649" gradientTransform="matrix(1 0 0 -1 0 300.1305)">
+			<stop  offset="0" style="stop-color:#5E9741"/>
+			<stop  offset="2.000000e-02" style="stop-color:#5F9841"/>
+			<stop  offset="1" style="stop-color:#76BC43"/>
+		</linearGradient>
+		<path style="fill:url(#SVGID_00000014634157408814489930000008218126733339281318_);" d="M593.6,203.1l14-14c0.4-0.4,1-0.4,1.4,0
+			c0,0,0,0,0,0l14,14c0.4,0.4,0.4,1,0,1.4c0,0,0,0,0,0l-14,14c-0.4,0.4-1,0.4-1.4,0l-14-14C593.2,204.2,593.2,203.6,593.6,203.1
+			C593.6,203.2,593.6,203.2,593.6,203.1z"/>
+		<path class="st126" d="M612,195.5l-3.5-3.5c-0.1-0.1-0.2-0.1-0.3,0l-3.5,3.5c-0.1,0.1-0.1,0.2,0,0.2c0,0.1,0.1,0.1,0.2,0.1h2.1
+			c0.1,0,0.2,0.1,0.2,0.2v3.3c0,0.1,0.1,0.2,0.2,0.2h2.2c0.1,0,0.2-0.1,0.2-0.2V196c0-0.1,0.1-0.2,0.2-0.2h2.1c0.1,0,0.2,0,0.2-0.1
+			C612.1,195.6,612,195.6,612,195.5z"/>
+		<path class="st126" d="M600,199.9l-3.5,3.5c-0.1,0.1-0.1,0.2,0,0.2l3.5,3.5c0.1,0.1,0.2,0.1,0.3,0c0,0,0.1-0.1,0.1-0.1v-2
+			c0-0.1,0.1-0.2,0.2-0.2h3.3c0.1,0,0.2-0.1,0.2-0.2c0,0,0,0,0,0v-2.2c0-0.1,0-0.2-0.1-0.2c0,0,0,0-0.1,0h-3.3
+			c-0.1,0-0.2-0.1-0.2-0.1c0,0,0,0,0,0v-2c0-0.1,0-0.2-0.1-0.2C600.1,199.7,600,199.8,600,199.9z"/>
+		<path class="st126" d="M616.8,207.2l3.5-3.5c0.1-0.1,0.1-0.2,0-0.2l-3.5-3.5c-0.1-0.1-0.2-0.1-0.3,0c0,0,0,0.1,0,0.1v2.1
+			c0,0.1-0.1,0.2-0.2,0.2c0,0,0,0,0,0h-3.3c-0.1,0-0.2,0.1-0.2,0.2c0,0,0,0,0,0v2.2c0,0.1,0.1,0.2,0.1,0.2c0,0,0,0,0,0h3.3
+			c0.1,0,0.2,0.1,0.2,0.2v2.1C616.5,207.2,616.6,207.3,616.8,207.2C616.7,207.2,616.7,207.2,616.8,207.2z"/>
+		<path class="st1" d="M612.9,203.9c0-2.6-2.1-4.7-4.6-4.7c-2.6,0-4.7,2.1-4.7,4.6c0,2.1,1.4,3.9,3.4,4.5v1.6
+			c-1.4,0.7-1.9,2.4-1.2,3.8c0.7,1.4,2.4,1.9,3.8,1.2c1.4-0.7,1.9-2.4,1.2-3.8c-0.3-0.5-0.7-1-1.2-1.2v-1.7
+			C611.6,207.6,612.9,205.9,612.9,203.9z"/>
+		<circle id="e99c3387-15c3-4f28-bd4b-cb209b430e06_1_" class="st28" cx="608.3" cy="203.8" r="2.7"/>
+	</g>
+	<g>
+		<path class="st104" d="M839.5,197.8c-0.3-2.3-1-4.8-2-7.7c-0.4,0.9-0.8,1.6-1.3,2.3c-2.2-2.3-5.3-3.7-8.8-3.7
+			c-4.5,0-8.4,2.4-10.5,6c1.9,0.1,3.6,0.9,5,2.1c-1.5-1-3.1-1.4-4.7-1.4c-4.8,0-8.7,3.9-8.7,8.7s3.9,8.7,8.7,8.7h20
+			c4.2,0,7.6-3.4,7.6-7.6C844.8,201.7,842.6,198.8,839.5,197.8z M820.8,210.1c-0.4,0.4-1,0.5-1.5,0.2c-0.4-0.4-0.5-1-0.2-1.5
+			c0.4-0.4,1-0.5,1.5-0.2C821.1,209,821.2,209.6,820.8,210.1z M837.5,206.4c-3,4-9.5,2.7-13.6,2.9c0,0-0.7,0-1.5,0.2
+			c0,0,0.3-0.1,0.6-0.2c2.9-1,4.3-1.2,6-2.1c3.3-1.7,6.6-5.4,7.3-9.3c-1.3,3.7-5.1,6.9-8.6,8.2c-2.4,0.9-6.7,1.7-6.7,1.7
+			c0,0-0.2-0.1-0.2-0.1c-2.9-1.4-3-7.8,2.3-9.9c2.3-0.9,4.6-0.4,7.1-1c2.7-0.6,5.8-2.7,7.1-5.3C838.8,195.7,840.5,202.3,837.5,206.4
+			z"/>
+	</g>
+	<g>
+		<path class="st104" d="M912.3,197.8c-0.3-2.3-1-4.8-2-7.7c-0.4,0.9-0.8,1.6-1.3,2.3c-2.2-2.3-5.3-3.7-8.8-3.7
+			c-4.5,0-8.4,2.4-10.5,6c1.9,0.1,3.6,0.9,5,2.1c-1.5-1-3.1-1.4-4.7-1.4c-4.8,0-8.7,3.9-8.7,8.7s3.9,8.7,8.7,8.7h20
+			c4.2,0,7.6-3.4,7.6-7.6C917.6,201.7,915.4,198.8,912.3,197.8z M893.6,210.1c-0.4,0.4-1,0.5-1.5,0.2c-0.4-0.4-0.5-1-0.2-1.5
+			c0.4-0.4,1-0.5,1.5-0.2C893.9,209,894,209.6,893.6,210.1z M910.2,206.4c-3,4-9.5,2.7-13.6,2.9c0,0-0.7,0-1.5,0.2
+			c0,0,0.3-0.1,0.6-0.2c2.9-1,4.3-1.2,6-2.1c3.3-1.7,6.6-5.4,7.3-9.3c-1.3,3.7-5.1,6.9-8.6,8.2c-2.4,0.9-6.7,1.7-6.7,1.7
+			c0,0-0.2-0.1-0.2-0.1c-2.9-1.4-3-7.8,2.3-9.9c2.3-0.9,4.6-0.4,7.1-1c2.7-0.6,5.8-2.7,7.1-5.3C911.6,195.7,913.3,202.3,910.2,206.4
+			z"/>
+	</g>
+	
+		<image style="overflow:visible;" width="208" height="208" xlink:href="AD59AD98.png"  transform="matrix(0.1408 0 0 0.1408 739.2327 186.0836)">
+	</image>
+	<g>
+		<circle cx="673.6" cy="200" r="2.5"/>
+		<circle cx="681.1" cy="200" r="2.5"/>
+		<circle cx="688.6" cy="200" r="2.5"/>
+	</g>
+	<g>
+		<text transform="matrix(1 0 0 1 594.5848 234.1507)"><tspan x="0" y="0" class="st105 st106 st107">Azure</tspan><tspan x="0.6" y="13.2" class="st105 st106 st107">Load  </tspan><tspan x="-6.4" y="26.4" class="st105 st106 st107">Balancer</tspan></text>
+	</g>
+	<g>
+		<text transform="matrix(1 0 0 1 810.9133 231.0197)"><tspan x="0" y="0" class="st105 st106 st107">Config</tspan><tspan x="1.5" y="13.2" class="st105 st106 st107">server</tspan></text>
+	</g>
+	<g>
+		<text transform="matrix(1 0 0 1 881.6721 231.0197)"><tspan x="0" y="0" class="st105 st106 st107">Service</tspan><tspan x="-2.4" y="13.2" class="st105 st106 st107">Registry</tspan></text>
+	</g>
+	<g>
+		<text transform="matrix(1 0 0 1 740.0609 231.0197)" class="st105 st106 st107">kpack</text>
+	</g>
+	<g>
+		
+			<rect x="437.6" y="94.4" transform="matrix(4.311885e-03 -1 1 4.311885e-03 226.862 648.4962)" class="st50" width="3" height="231.9"/>
+		<g>
+			<polygon class="st50" points="313.6,209.8 327,204.4 323.8,209.8 327,215.3 			"/>
+		</g>
+		<path class="st51" d="M555,211.5l-2.2,0l0-1.5l2.2,0L555,211.5z M550.9,211.5l-4,0l0-1.5l4,0L550.9,211.5z M544.9,211.5l-4,0
+			l0-1.5l4,0L544.9,211.5z M538.9,211.4l-4,0l0-1.5l4,0L538.9,211.4z M532.9,211.4l-4,0l0-1.5l4,0L532.9,211.4z M526.9,211.4l-4,0
+			l0-1.5l4,0L526.9,211.4z M520.9,211.4l-4,0l0-1.5l4,0L520.9,211.4z M514.9,211.3l-4,0l0-1.5l4,0L514.9,211.3z M508.9,211.3l-4,0
+			l0-1.5l4,0L508.9,211.3z M502.9,211.3l-4,0l0-1.5l4,0L502.9,211.3z M496.9,211.3l-4,0l0-1.5l4,0L496.9,211.3z M490.9,211.2l-4,0
+			l0-1.5l4,0L490.9,211.2z M484.9,211.2l-4,0l0-1.5l4,0L484.9,211.2z M478.9,211.2l-4,0l0-1.5l4,0L478.9,211.2z M472.9,211.2l-4,0
+			l0-1.5l4,0L472.9,211.2z M466.9,211.1l-4,0l0-1.5l4,0L466.9,211.1z M460.9,211.1l-4,0l0-1.5l4,0L460.9,211.1z M454.9,211.1l-4,0
+			l0-1.5l4,0L454.9,211.1z M448.9,211.1l-4,0l0-1.5l4,0L448.9,211.1z M442.9,211.1l-4,0l0-1.5l4,0L442.9,211.1z M436.9,211l-4,0
+			l0-1.5l4,0L436.9,211z M430.9,211l-4,0l0-1.5l4,0L430.9,211z M424.9,211l-4,0l0-1.5l4,0L424.9,211z M418.9,211l-4,0l0-1.5l4,0
+			L418.9,211z M412.9,210.9l-4,0l0-1.5l4,0L412.9,210.9z M406.9,210.9l-4,0l0-1.5l4,0L406.9,210.9z M400.9,210.9l-4,0l0-1.5l4,0
+			L400.9,210.9z M394.9,210.9l-4,0l0-1.5l4,0L394.9,210.9z M388.9,210.8l-4,0l0-1.5l4,0L388.9,210.8z M382.9,210.8l-4,0l0-1.5l4,0
+			L382.9,210.8z M376.9,210.8l-4,0l0-1.5l4,0L376.9,210.8z M370.9,210.8l-4,0l0-1.5l4,0L370.9,210.8z M364.9,210.7l-4,0l0-1.5l4,0
+			L364.9,210.7z M358.9,210.7l-4,0l0-1.5l4,0L358.9,210.7z M352.9,210.7l-4,0l0-1.5l4,0L352.9,210.7z M346.9,210.7l-4,0l0-1.5l4,0
+			L346.9,210.7z M340.9,210.6l-4,0l0-1.5l4,0L340.9,210.6z M334.9,210.6l-4,0l0-1.5l4,0L334.9,210.6z M328.9,210.6l-4,0l0-1.5l4,0
+			L328.9,210.6z"/>
+	</g>
+	<g>
+		<rect x="311.9" y="226.8" class="st52" width="234.2" height="3"/>
+		<g>
+			<polygon class="st52" points="544.7,222.3 555,228.3 544.7,234.3 			"/>
+		</g>
+		<g>
+			<path class="st53" d="M544.5,229.3h-1v-2h1L544.5,229.3z M541.5,229.3h-1v-2h1L541.5,229.3z M538.5,229.3h-1v-2h1L538.5,229.3z
+				 M535.5,229.3h-1v-2h1L535.5,229.3z M532.5,229.3h-1v-2h1L532.5,229.3z M529.4,229.3h-1v-2h1L529.4,229.3z M526.4,229.3h-1v-2h1
+				L526.4,229.3z M523.4,229.3h-1v-2h1L523.4,229.3z M520.4,229.3h-1v-2h1L520.4,229.3z M517.4,229.3h-1v-2h1L517.4,229.3z
+				 M514.4,229.3h-1v-2h1L514.4,229.3z M511.4,229.3h-1v-2h1L511.4,229.3z M508.4,229.3h-1v-2h1L508.4,229.3z M505.3,229.3h-1v-2h1
+				L505.3,229.3z M502.3,229.3h-1v-2h1L502.3,229.3z M499.3,229.3h-1v-2h1L499.3,229.3z M496.3,229.3h-1v-2h1L496.3,229.3z
+				 M493.3,229.3h-1v-2h1L493.3,229.3z M490.3,229.3h-1v-2h1L490.3,229.3z M487.3,229.3h-1v-2h1L487.3,229.3z M484.2,229.3h-1v-2h1
+				L484.2,229.3z M481.2,229.3h-1v-2h1L481.2,229.3z M478.2,229.3h-1v-2h1L478.2,229.3z M475.2,229.3h-1v-2h1L475.2,229.3z
+				 M472.2,229.3h-1v-2h1L472.2,229.3z M469.2,229.3h-1v-2h1L469.2,229.3z M466.2,229.3h-1v-2h1L466.2,229.3z M463.1,229.3h-1v-2h1
+				L463.1,229.3z M460.1,229.3h-1v-2h1L460.1,229.3z M457.1,229.3h-1v-2h1L457.1,229.3z M454.1,229.3h-1v-2h1L454.1,229.3z
+				 M451.1,229.3h-1v-2h1L451.1,229.3z M448.1,229.3h-1v-2h1L448.1,229.3z M445.1,229.3h-1v-2h1L445.1,229.3z M442,229.3h-1v-2h1
+				L442,229.3z M439,229.3h-1v-2h1L439,229.3z M436,229.3h-1v-2h1L436,229.3z M433,229.3h-1v-2h1L433,229.3z M430,229.3h-1v-2h1
+				L430,229.3z M427,229.3h-1v-2h1L427,229.3z M424,229.3h-1v-2h1L424,229.3z M420.9,229.3h-1v-2h1L420.9,229.3z M417.9,229.3h-1v-2
+				h1L417.9,229.3z M414.9,229.3h-1v-2h1L414.9,229.3z M411.9,229.3h-1v-2h1L411.9,229.3z M408.9,229.3h-1v-2h1L408.9,229.3z
+				 M405.9,229.3h-1v-2h1L405.9,229.3z M402.9,229.3h-1v-2h1L402.9,229.3z M399.8,229.3h-1v-2h1L399.8,229.3z M396.8,229.3h-1v-2h1
+				L396.8,229.3z M393.8,229.3h-1v-2h1L393.8,229.3z M390.8,229.3h-1v-2h1L390.8,229.3z M387.8,229.3h-1v-2h1L387.8,229.3z
+				 M384.8,229.3h-1v-2h1L384.8,229.3z M381.8,229.3h-1v-2h1L381.8,229.3z M378.8,229.3h-1v-2h1L378.8,229.3z M375.7,229.3h-1v-2h1
+				L375.7,229.3z M372.7,229.3h-1v-2h1L372.7,229.3z M369.7,229.3h-1v-2h1L369.7,229.3z M366.7,229.3h-1v-2h1L366.7,229.3z
+				 M363.7,229.3h-1v-2h1L363.7,229.3z M360.7,229.3h-1v-2h1L360.7,229.3z M357.7,229.3h-1v-2h1L357.7,229.3z M354.6,229.3h-1v-2h1
+				L354.6,229.3z M351.6,229.3h-1v-2h1L351.6,229.3z M348.6,229.3h-1v-2h1L348.6,229.3z M345.6,229.3h-1v-2h1L345.6,229.3z
+				 M342.6,229.3h-1v-2h1L342.6,229.3z M339.6,229.3h-1v-2h1L339.6,229.3z M336.6,229.3h-1v-2h1L336.6,229.3z M333.5,229.3h-1v-2h1
+				L333.5,229.3z M330.5,229.3h-1v-2h1L330.5,229.3z M327.5,229.3h-1v-2h1L327.5,229.3z M324.5,229.3h-1v-2h1L324.5,229.3z
+				 M321.5,229.3h-1v-2h1L321.5,229.3z M318.5,229.3h-1v-2h1L318.5,229.3z M315.5,229.3h-1v-2h1L315.5,229.3z M312.4,229.3
+				L312.4,229.3l0-2L312.4,229.3z"/>
+			<rect x="311.9" y="227.3" class="st53" width="0.5" height="2"/>
+		</g>
+	</g>
+	<g class="st127">
+		<rect x="336" y="153.9" class="st1" width="117.5" height="124.1"/>
+		<rect x="336" y="153.9" class="st128" width="117.5" height="124.1"/>
+	</g>
+	<g>
+		
+			<linearGradient id="SVGID_00000175324169324139057870000000139677757915888768_" gradientUnits="userSpaceOnUse" x1="394.8193" y1="66.5866" x2="394.8193" y2="94.78" gradientTransform="matrix(1 0 0 -1 -3.547359e-03 300.129)">
+			<stop  offset="0" style="stop-color:#258378"/>
+			<stop  offset="0.42" style="stop-color:#49A498"/>
+			<stop  offset="0.78" style="stop-color:#60BBAD"/>
+			<stop  offset="1" style="stop-color:#68C2B5"/>
+		</linearGradient>
+		<path style="fill:url(#SVGID_00000175324169324139057870000000139677757915888768_);" d="M380.1,217.3l14-14c0.4-0.4,1-0.4,1.4,0
+			l14,14c0.4,0.4,0.4,1,0,1.4l-14,14c-0.4,0.4-1,0.4-1.4,0l-14-14C379.7,218.3,379.7,217.7,380.1,217.3z"/>
+		<path class="st1" d="M391.4,210.4l3.3-3.3c0.1-0.1,0.2-0.1,0.2,0l3.4,3.3c0.1,0.1,0.1,0.2,0,0.2c0,0-0.1,0.1-0.2,0.1h-2
+			c-0.1,0-0.2,0.1-0.2,0.2l0,0v4.3c0,0.1-0.1,0.2-0.2,0.2l0,0h-2.1c-0.1,0-0.2-0.1-0.2-0.1c0,0,0,0,0,0v-4.3c0-0.1-0.1-0.2-0.2-0.2
+			h-2C391.4,210.7,391.3,210.6,391.4,210.4C391.4,210.5,391.4,210.4,391.4,210.4z M398.4,225.7L395,229c-0.1,0.1-0.2,0.1-0.2,0
+			l-3.3-3.3c-0.1-0.1,0-0.2,0-0.2c0,0,0.1,0,0.1,0h2c0.1,0,0.2-0.1,0.2-0.2v-4.3c0-0.1,0.1-0.2,0.2-0.2c0,0,0,0,0,0h2.1
+			c0.1,0,0.2,0.1,0.2,0.2l0,0v4.3c0,0.1,0.1,0.2,0.2,0.2l0,0h1.9c0.1-0.1,0.2,0,0.2,0C398.5,225.5,398.4,225.6,398.4,225.7z
+			 M388.4,221.3v-1.9c0-0.1-0.1-0.2-0.2-0.2h-4.3c-0.1,0-0.2-0.1-0.2-0.2v-2.1c0-0.1,0.1-0.2,0.2-0.2h4.3c0.1,0,0.2-0.1,0.2-0.2v-2
+			c0-0.1,0-0.2,0.1-0.2c0.1,0,0.1,0,0.2,0.1l3.3,3.4c0.1,0.1,0.1,0.2,0,0.2c0,0,0,0,0,0l-3.3,3.3c-0.1,0.1-0.2,0.1-0.2,0
+			C388.4,221.4,388.4,221.3,388.4,221.3z M401.3,214.6v2c0,0.1,0.1,0.2,0.2,0.2h4.3c0.1,0,0.2,0.1,0.2,0.2v2.1
+			c0,0.1-0.1,0.2-0.2,0.2h-4.3c-0.1,0-0.2,0.1-0.2,0.2v1.9c0,0.1,0,0.2-0.1,0.2c-0.1,0-0.1,0-0.2-0.1l-3.3-3.4
+			c-0.1-0.1-0.1-0.2,0-0.2c0,0,0,0,0,0l3.3-3.3c0-0.1,0.1-0.1,0.2,0C401.3,214.5,401.3,214.6,401.3,214.6z"/>
+	</g>
+</g>
+<g id="Text">
+	<rect x="184.9" y="479.5" class="st84" width="145.2" height="13.2"/>
+	<text transform="matrix(1 0 0 1 184.8866 489.8904)" class="st105 st106 st108">hub-virtual-network</text>
+	<rect x="565.2" y="479.5" class="st84" width="145.2" height="13.2"/>
+	<text transform="matrix(1 0 0 1 565.2439 489.8904)" class="st105 st106 st108">spoke-virtual-network</text>
+	<rect x="411.5" y="101.1" class="st84" width="44" height="30.8"/>
+	<text transform="matrix(1 0 0 1 424.2541 111.4908)"><tspan x="0" y="0" class="st105 st106 st108">VNet </tspan><tspan x="9.6" y="16.8" class="st105 st106 st108">link</tspan></text>
+	<rect x="517.1" y="101.1" class="st84" width="44" height="30.8"/>
+	<text transform="matrix(1 0 0 1 529.854 111.4908)"><tspan x="0" y="0" class="st105 st106 st108">VNet </tspan><tspan x="9.6" y="16.8" class="st105 st106 st108">link</tspan></text>
+	<text transform="matrix(1 0 0 1 97.5004 114.3273)"><tspan x="0" y="0" class="st105 st106 st108">ExpressRoute</tspan><tspan x="22.6" y="16.8" class="st105 st106 st108">circuit</tspan></text>
+	<rect x="484.1" y="424" class="st84" width="61.6" height="53.5"/>
+	<text transform="matrix(1 0 0 1 494.7974 435.8995)"><tspan x="0" y="0" class="st105 st106 st108">Virtual </tspan><tspan x="-6.3" y="16.8" class="st105 st106 st108">Network</tspan><tspan x="-3.6" y="33.6" class="st105 st106 st108">peering</tspan></text>
+	<text transform="matrix(1 0 0 1 211.2325 176.8271)"><tspan x="0" y="0" class="st105 st106 st108">Azure Firewall</tspan><tspan x="21.8" y="16.8" class="st105 st106 st108">subnet</tspan></text>
+	<text transform="matrix(1 0 0 1 213.9846 260.427)" class="st105 st106 st108">Corp Firewall</text>
+	<text transform="matrix(1 0 0 1 353.7489 176.8271)"><tspan x="0" y="0" class="st105 st106 st108">App Gateway</tspan><tspan x="18.1" y="16.8" class="st105 st106 st108"> subnet</tspan></text>
+	<text transform="matrix(1 0 0 1 343.8056 250.389)"><tspan x="0" y="0" class="st105 st106 st108">Corp application</tspan><tspan x="24.6" y="16.8" class="st105 st106 st108">Gateway</tspan></text>
+	<text transform="matrix(1 0 0 1 654.1141 23.0319)"><tspan x="0" y="0" class="st105 st106 st108">Monitoring</tspan><tspan x="-7.1" y="16.8" class="st105 st106 st108">infrastructure</tspan></text>
+	<text transform="matrix(1 0 0 1 814.2615 23.0318)"><tspan x="0" y="0" class="st105 st106 st108">Security</tspan><tspan x="-17.6" y="16.8" class="st105 st106 st108">infrastructure</tspan></text>
+	<text transform="matrix(1 0 0 1 970.6858 28.3318)" class="st105 st106 st108">CI/CD Pipelines</text>
+	<text transform="matrix(1 0 0 1 212.1945 382.7889)"><tspan x="0" y="0" class="st105 st106 st108">ExpressRoute</tspan><tspan x="14.8" y="16.8" class="st105 st106 st108">Gateway</tspan></text>
+	<text transform="matrix(1 0 0 1 204.0183 313.2886)" class="st105 st106 st108">Gateway subnet</text>
+	<rect x="340.4" y="301.4" class="st84" width="108.8" height="38.9"/>
+	<text transform="matrix(1 0 0 1 360.1537 313.2886)"><tspan x="0" y="0" class="st105 st106 st108">Centralized </tspan><tspan x="-12.3" y="16.8" class="st105 st106 st108">services subnet</tspan></text>
+	<text transform="matrix(1 0 0 1 355.0578 396.8885)" class="st105 st106 st108">DNS services</text>
+	<rect x="454.8" y="17.1" class="st84" width="123.2" height="35.2"/>
+	<text transform="matrix(1 0 0 1 459.0429 27.4947)"><tspan x="0" y="0" class="st105 st106 st108">Azure Spring Apps </tspan><tspan x="3.6" y="16.8" class="st105 st106 st108">private DNS zone</tspan></text>
+	<text transform="matrix(1 0 0 1 63.8869 28.3316)"><tspan x="0" y="0" class="st105 st106 st108">Ingress</tspan><tspan x="0" y="19" class="st105 st106 st108">Egress</tspan></text>
+	<g>
+		<rect x="269.1" y="43.4" class="st84" width="70.4" height="35.2"/>
+		<text transform="matrix(1 0 0 1 269.1436 53.7395)"><tspan x="0" y="0" class="st105 st106 st108">Egress to </tspan><tspan x="0" y="16.8" class="st105 st106 st108">Internet</tspan></text>
+	</g>
+	<g>
+		<rect x="155.5" y="43.4" class="st84" width="83.6" height="35.2"/>
+		<text transform="matrix(1 0 0 1 178.3137 53.7397)"><tspan x="0" y="0" class="st105 st106 st108">Ingress to </tspan><tspan x="-21.4" y="16.8" class="st105 st106 st108">App Gateway</tspan></text>
+	</g>
+	<rect x="790.2" y="89.9" class="st84" width="32.1" height="32.2"/>
+	<text transform="matrix(1 0 0 1 797.5444 99.2828)"><tspan x="0" y="0" class="st105 st106 st107">Key </tspan><tspan x="-6.1" y="13" class="st105 st106 st107">Vaults</tspan></text>
+	<rect x="843" y="89.9" class="st84" width="52.8" height="28.8"/>
+	<text transform="matrix(1 0 0 1 850.2234 99.2828)"><tspan x="0" y="0" class="st105 st106 st107">Security</tspan><tspan x="3.2" y="13" class="st105 st106 st107">Center</tspan></text>
+	<rect x="628.7" y="89.9" class="st84" width="60.2" height="32.2"/>
+	<text transform="matrix(1 0 0 1 631.2186 99.2823)"><tspan x="0" y="0" class="st105 st106 st107">Application </tspan><tspan x="8.8" y="13" class="st105 st106 st107">Insights</tspan></text>
+	<rect x="698.3" y="89.4" class="st84" width="52.8" height="28.8"/>
+	<text transform="matrix(1 0 0 1 710.7407 98.7828)"><tspan x="0" y="0" class="st105 st106 st107">Azure </tspan><tspan x="-5.7" y="13" class="st105 st106 st107">Monitor</tspan></text>
+	<g>
+		<rect x="933.2" y="89.9" class="st84" width="49.6" height="27.1"/>
+		<text transform="matrix(1 0 0 1 944.1033 99.2828)"><tspan x="0" y="0" class="st105 st106 st107">Azure </tspan><tspan x="-5.1" y="13" class="st105 st106 st107">DevOps</tspan></text>
+	</g>
+	<g>
+		<rect x="1053.2" y="89.9" class="st84" width="49.6" height="27.1"/>
+		<text transform="matrix(1 0 0 1 1060.8293 99.2828)"><tspan x="0" y="0" class="st105 st106 st107">GitHub </tspan><tspan x="-0.7" y="13" class="st105 st106 st107">Actions</tspan></text>
+	</g>
+	<g>
+		<text transform="matrix(1 0 0 1 1002.7797 103.1317)" class="st105 st106 st107">Jenkins</text>
+	</g>
+	<rect x="2.9" y="479.5" class="st84" width="163" height="12.8"/>
+	<text transform="matrix(1 0 0 1 2.8981 489.8904)" class="st105 st106 st108">On-premises network</text>
+	<text transform="matrix(1 0 0 1 26.4203 254.9852)" class="st105 st106 st108">Gateway</text>
+</g>
+<g id="Layer_1">
+</g>
 </svg>


### PR DESCRIPTION
Based on the request of the documentation team, I updated the diagrams in this repository to the matching set from the Azure public reference architecture documentation.